### PR TITLE
Implementar schemas Pydantic v2 en code/shared/schemas

### DIFF
--- a/bitacora/2026-04-17_schemas-pydantic-v2_xilema.md
+++ b/bitacora/2026-04-17_schemas-pydantic-v2_xilema.md
@@ -1,0 +1,66 @@
+# Schemas Pydantic v2 implementados para contratos v1.0
+
+**Fecha:** 2026-04-17
+**Autor:** Xilema
+**Area:** Rhizome
+**Tipo:** Avance
+
+## Contexto
+
+Cambium fijo `docs/20_data_contracts.md` como contrato cerrado v1.0 y pidio que mi siguiente foco fuera el issue `#1`: implementar los 6 schemas en `code/shared/schemas/` con `pydantic` v2, validadores y tests. El objetivo era desbloquear a Floema y dejar una fuente de verdad ejecutable para los contratos entre nodos.
+
+## Que hicimos / decidimos
+
+- Hice `git pull` en `main`, relei `docs/20_data_contracts.md`, `docs/30_safety_rules.md` y `CONTRIBUTING.md` §10 antes de tocar codigo.
+- Me asigne `#1` y `#5` en GitHub. `#5` queda preparado como spike para cuando el Jetson este disponible; el foco de hoy fue `#1`.
+- Cree la rama `feat/rhizome-schemas-pydantic`.
+- Implemente en `code/shared/schemas/`:
+  - `BaseSchema` con `schema_version`, `created_at`, `origin_node_id`, `signature`
+  - enums compartidos
+  - `RhizomeSnapshot`
+  - `PolicyPacket`
+  - `PolicyDelta`
+  - `WeatherPacket`
+  - `ContradictionAlert`
+  - `DecisionReceipt`
+- Añadi validadores para reglas duras relevantes del contrato:
+  - timestamps UTC con sufijo `Z`
+  - rangos de porcentajes y temperatura
+  - `valid_until > created_at`
+  - `base_policy_id` no vacio
+  - `WeatherPacket.provenance` como enum estricto
+  - evidencia obligatoria por `contradiction_type`
+  - `rationale_short <= 180`
+  - coherencia `executed` / `execution_details` / `blocked_reason`
+  - `action_params` minimos segun `action`
+- Anadi:
+  - `code/shared/pyproject.toml`
+  - `code/shared/Makefile`
+  - tests de roundtrip y validacion negativa
+  - ejemplos canonicos en memoria para tests
+- Corri la bateria real:
+  - `python -m pytest schemas/tests`
+  - resultado: **25 tests, 25 passed**
+
+## Por que
+
+He priorizado que el contrato quede ejecutable y legible antes de generar JSONs canonicos en fichero. Eso permite dos cosas:
+
+1. Floema ya puede empezar a mapear el contrato real desde una implementacion viva.
+2. El siguiente issue (`#2`) podra generar los JSONs canonicos **desde el propio codigo**, no a mano, evitando divergencias.
+
+Tambien he actualizado `code/shared/README.md` porque la version previa seguia hablando de JSON Schema como fuente de verdad, y eso ya no era cierto tras el cierre de `20_data_contracts.md`.
+
+## Que queda pendiente
+
+- [ ] Revisar el diff final y abrir PR pequeno contra `main` con `Closes #1`
+- [ ] Abordar `#2` para serializar ejemplos canonicos a fichero desde los modelos ya implementados
+- [ ] Arrancar `#5` en cuanto haya Jetson fisico en mesa
+- [ ] Mantener alineacion con Floema cuando empiece la replica Kotlin
+
+## Enlaces
+
+- [Contrato de datos v1.0](../docs/20_data_contracts.md)
+- [Safety rules v1.0](../docs/30_safety_rules.md)
+- [Respuesta de Cambium con invariantes](../bitacora/2026-04-15_respuesta-xilema-6-decisiones_cambium.md)
+- Issue `#1` Implementar schemas Pydantic v2

--- a/code/shared/Makefile
+++ b/code/shared/Makefile
@@ -1,0 +1,6 @@
+PYTHON ?= python
+
+.PHONY: test-schemas
+
+test-schemas:
+	$(PYTHON) -m pytest schemas/tests

--- a/code/shared/README.md
+++ b/code/shared/README.md
@@ -2,54 +2,56 @@
 
 Schemas JSON y protocolos compartidos entre Rhizome, Pollen y Meristem.
 
-Si un contrato de datos cruza de un nodo a otro, vive aqui. Unica fuente de verdad.
+Si un contrato de datos cruza de un nodo a otro, vive aqui. La **fuente de verdad** es la implementacion en Python con `pydantic` v2; Kotlin la replica para Pollen.
 
 ## Estructura
 
 ```
 shared/
 ├── README.md
+├── Makefile
 └── schemas/
-    ├── weather_packet.json
-    ├── policy_delta.json
-    ├── policy_packet.json
-    ├── contradiction_alert.json
-    ├── rhizome_snapshot.json
-    ├── decision_receipt.json
-    └── README.md
+    ├── __init__.py
+    ├── base.py
+    ├── enums.py
+    ├── rhizome_snapshot.py
+    ├── policy_packet.py
+    ├── policy_delta.py
+    ├── weather_packet.py
+    ├── contradiction_alert.py
+    ├── decision_receipt.py
+    └── tests/
 ```
 
 ## Convencion
 
-- Cada schema en JSON Schema Draft 2020-12
-- Cada schema tiene un `$id` estable: `https://sprout.network/schemas/v1/<nombre>.json`
-- Versiones via subcarpeta (`v1/`, `v2/`) cuando haya cambios breaking
-- Ejemplos minimos en `examples/` dentro de cada schema
+- Version actual del contrato: `docs/20_data_contracts.md` v1.0
+- `pydantic` es la implementacion canonica
+- Los parsers ignoran campos desconocidos para forward compatibility
+- Todos los timestamps viajan como ISO-8601 UTC con sufijo `Z`
+- Los ejemplos canonicos y round-trips viven en `schemas/tests/`
 
 ## Validacion
 
 ### Python (Rhizome, Meristem)
-```python
-from pydantic import BaseModel
-from pathlib import Path
-import json
-
-schema = json.loads(Path("shared/schemas/weather_packet.json").read_text())
-# generar modelo con datamodel-code-generator o escribir pydantic model a mano
+```bash
+cd code/shared
+make test-schemas
+# o, si no hay make disponible:
+python -m pytest schemas/tests
 ```
 
 ### Kotlin (Pollen)
 ```kotlin
 // usar kotlinx.serialization con data classes que mapean 1:1
-@Serializable data class WeatherPacket(
-    val type: String,
-    val id: String,
-    // ...
-)
+// respecto a los modelos Pydantic
 ```
 
 ## Cambios
 
-Si cambias un schema, actualizar **los tres nodos en el mismo commit**. Nunca commits que dejen los schemas inconsistentes.
+Si cambias un schema, sigue primero el proceso del contrato de datos:
 
-Si el cambio es breaking, bumpear version de carpeta y mantener la anterior para retrocompatibilidad temporal.
+1. entrada en `bitacora/`
+2. actualizacion de `docs/20_data_contracts.md`
+3. cambio en `code/shared/schemas/`
+4. sincronizacion posterior con Kotlin

--- a/code/shared/pyproject.toml
+++ b/code/shared/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "sprout-shared-schemas"
+version = "0.1.0"
+description = "Schemas compartidos de Sprout implementados con Pydantic v2."
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic>=2.12,<3",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0,<9",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["schemas/tests"]

--- a/code/shared/schemas/__init__.py
+++ b/code/shared/schemas/__init__.py
@@ -1,0 +1,19 @@
+"""Schemas compartidos de Sprout."""
+
+from .base import BaseSchema
+from .contradiction_alert import ContradictionAlert
+from .decision_receipt import DecisionReceipt
+from .policy_delta import PolicyDelta
+from .policy_packet import PolicyPacket
+from .rhizome_snapshot import RhizomeSnapshot
+from .weather_packet import WeatherPacket
+
+__all__ = [
+    "BaseSchema",
+    "ContradictionAlert",
+    "DecisionReceipt",
+    "PolicyDelta",
+    "PolicyPacket",
+    "RhizomeSnapshot",
+    "WeatherPacket",
+]

--- a/code/shared/schemas/base.py
+++ b/code/shared/schemas/base.py
@@ -1,0 +1,65 @@
+"""Tipos y validaciones comunes para los contratos de datos."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+UTC_ZULU_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+SIGNATURE_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def parse_utc_zulu(value: Any) -> datetime:
+    """Parsea un timestamp ISO-8601 UTC con sufijo Z."""
+
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() != timezone.utc.utcoffset(value):
+            raise ValueError("el timestamp debe ser UTC explicito")
+        return value.astimezone(timezone.utc)
+
+    if not isinstance(value, str) or not UTC_ZULU_RE.fullmatch(value):
+        raise ValueError("el timestamp debe seguir el formato ISO-8601 UTC con sufijo Z")
+
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+class BaseSchema(BaseModel):
+    """Base comun para todos los mensajes que viajan entre nodos."""
+
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    schema_version: str = Field(default="1.0")
+    created_at: datetime
+    origin_node_id: str = Field(min_length=1)
+    signature: str | None = None
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: str) -> str:
+        if value != "1.0":
+            raise ValueError("schema_version debe ser '1.0'")
+        return value
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def validate_created_at(cls, value: Any) -> datetime:
+        return parse_utc_zulu(value)
+
+    @field_validator("origin_node_id")
+    @classmethod
+    def validate_origin_node_id(cls, value: str) -> str:
+        if not value:
+            raise ValueError("origin_node_id no puede estar vacio")
+        return value
+
+    @field_validator("signature")
+    @classmethod
+    def validate_signature(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not SIGNATURE_RE.fullmatch(value):
+            raise ValueError("signature debe ser un HMAC-SHA256 hex de 64 chars")
+        return value

--- a/code/shared/schemas/contradiction_alert.py
+++ b/code/shared/schemas/contradiction_alert.py
@@ -1,0 +1,50 @@
+"""Schema ContradictionAlert."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import Field, field_validator, model_validator
+
+from .base import BaseSchema, parse_utc_zulu
+from .enums import ContradictionType, Severity
+
+CRITICAL_ACTIONS = {"block_watering", "request_policy_review"}
+EVIDENCE_REQUIRED_KEYS = {
+    ContradictionType.SENSOR_VS_VISION: {"sensor_reading", "vision_reading"},
+    ContradictionType.POLICY_EXPIRED: {"policy_id", "expired_at"},
+    ContradictionType.DEPOSIT_INCONSISTENT: {"tank_level_pct", "flow_history_summary"},
+    ContradictionType.FLOW_VS_PUMP: {"pump_active_from", "flow_rate_observed"},
+    ContradictionType.WEATHER_CONFLICT: {"active_policy_id", "conflicting_weather_packet_id"},
+    ContradictionType.TANK_UNDERFLOW: {"tank_level_pct", "minimum_threshold_pct"},
+}
+
+
+class ContradictionAlert(BaseSchema):
+    alert_id: str = Field(min_length=1)
+    target_node_id: str = Field(min_length=1)
+    contradiction_type: ContradictionType
+    severity: Severity
+    observed_at: datetime
+    evidence: dict[str, Any]
+    recommended_action: str | None = None
+    expires_at: datetime
+    rationale: str | None = None
+
+    @field_validator("observed_at", "expires_at", mode="before")
+    @classmethod
+    def validate_datetimes(cls, value: Any) -> datetime:
+        return parse_utc_zulu(value)
+
+    @model_validator(mode="after")
+    def validate_alert(self) -> "ContradictionAlert":
+        required_keys = EVIDENCE_REQUIRED_KEYS[self.contradiction_type]
+        missing = required_keys - self.evidence.keys()
+        if missing:
+            raise ValueError(f"evidence incompleta para {self.contradiction_type.value}: faltan {sorted(missing)}")
+        if self.expires_at <= self.created_at:
+            raise ValueError("expires_at debe ser posterior a created_at")
+        if self.severity == Severity.CRITICAL and self.recommended_action not in CRITICAL_ACTIONS:
+            raise ValueError("severity critical exige recommended_action de bloqueo o revision")
+        return self

--- a/code/shared/schemas/decision_receipt.py
+++ b/code/shared/schemas/decision_receipt.py
@@ -1,0 +1,97 @@
+"""Schema DecisionReceipt."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from .base import BaseSchema, parse_utc_zulu
+from .enums import ActionType
+
+WATER_ACTIONS = {ActionType.WATER_A, ActionType.WATER_B, ActionType.WATER_BOTH}
+
+
+class ExecutionDetails(BaseModel):
+    sent_to_esp32_at: datetime
+    esp32_ack_at: datetime
+    esp32_ack_status: str = Field(min_length=1)
+    actual_duration_s: float = Field(ge=0)
+    flow_observed_lpm: float = Field(ge=0)
+    estimated_liters_actual: float = Field(ge=0)
+
+    @field_validator("sent_to_esp32_at", "esp32_ack_at", mode="before")
+    @classmethod
+    def validate_datetimes(cls, value: Any) -> datetime:
+        return parse_utc_zulu(value)
+
+    @model_validator(mode="after")
+    def validate_order(self) -> "ExecutionDetails":
+        if self.esp32_ack_at < self.sent_to_esp32_at:
+            raise ValueError("esp32_ack_at no puede ser anterior a sent_to_esp32_at")
+        return self
+
+
+class DecisionReceipt(BaseSchema):
+    decision_id: str = Field(min_length=1)
+    snapshot_id: str = Field(min_length=1)
+    active_policy_id: str = Field(min_length=1)
+    action: ActionType
+    action_params: dict[str, Any]
+    rationale_short: str
+    rationale_full: str
+    policy_refs: list[str] = Field(min_length=1)
+    contradictions: list[str] = Field(default_factory=list)
+    confidence: float = Field(ge=0, le=1)
+    executed: bool
+    execution_details: ExecutionDetails | None = None
+    blocked_reason: str | None = None
+
+    @field_validator("rationale_short")
+    @classmethod
+    def validate_rationale_short(cls, value: str) -> str:
+        if len(value) > 180:
+            raise ValueError("rationale_short no puede superar 180 caracteres")
+        return value
+
+    @field_validator("rationale_full")
+    @classmethod
+    def validate_rationale_full(cls, value: str) -> str:
+        if len(value) > 2000:
+            raise ValueError("rationale_full no puede superar 2000 caracteres")
+        return value
+
+    @model_validator(mode="after")
+    def validate_execution_contract(self) -> "DecisionReceipt":
+        if self.executed:
+            if self.execution_details is None:
+                raise ValueError("executed=true exige execution_details")
+            if self.blocked_reason is not None:
+                raise ValueError("executed=true exige blocked_reason=null")
+        else:
+            if not self.blocked_reason:
+                raise ValueError("executed=false exige blocked_reason no vacio")
+            if self.execution_details is not None:
+                raise ValueError("executed=false exige execution_details=null")
+
+        required_action_params = {
+            ActionType.WATER_A: {"duration_s", "expected_liters"},
+            ActionType.WATER_B: {"duration_s", "expected_liters"},
+            ActionType.WATER_BOTH: {"duration_s", "expected_liters"},
+            ActionType.SKIP: {"next_check_in_s"},
+            ActionType.DEFER: {"defer_until", "reason"},
+            ActionType.ALERT: {"alert_id"},
+            ActionType.BLOCK: {"blocked_action", "reason"},
+            ActionType.SHUTDOWN: {"reason", "recoverable"},
+        }[self.action]
+        missing = required_action_params - self.action_params.keys()
+        if missing:
+            raise ValueError(f"action_params incompleto para {self.action.value}: faltan {sorted(missing)}")
+
+        if self.action in WATER_ACTIONS and self.executed:
+            duration = self.action_params.get("duration_s")
+            if not isinstance(duration, int) or duration <= 0:
+                raise ValueError("las acciones WATER_* requieren duration_s entero positivo")
+
+        return self

--- a/code/shared/schemas/enums.py
+++ b/code/shared/schemas/enums.py
@@ -1,0 +1,56 @@
+"""Enums compartidos entre nodos."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Mode(str, Enum):
+    NORMAL = "normal"
+    CONSERVATIVE = "conservative"
+    ALERT = "alert"
+
+
+class ActionType(str, Enum):
+    WATER_A = "WATER_A"
+    WATER_B = "WATER_B"
+    WATER_BOTH = "WATER_BOTH"
+    SKIP = "SKIP"
+    DEFER = "DEFER"
+    ALERT = "ALERT"
+    BLOCK = "BLOCK"
+    SHUTDOWN = "SHUTDOWN"
+
+
+class ContradictionType(str, Enum):
+    SENSOR_VS_VISION = "sensor_vs_vision"
+    POLICY_EXPIRED = "policy_expired"
+    DEPOSIT_INCONSISTENT = "deposit_inconsistent"
+    FLOW_VS_PUMP = "flow_vs_pump"
+    WEATHER_CONFLICT = "weather_conflict"
+    TANK_UNDERFLOW = "tank_underflow"
+
+
+class Severity(str, Enum):
+    INFO = "info"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+class WeatherProvenance(str, Enum):
+    LOCAL_STATION = "local_station"
+    FERRIED = "ferried"
+    FORECAST_API = "forecast_api"
+
+
+class PatchOperation(str, Enum):
+    REPLACE = "replace"
+    ADD = "add"
+    REMOVE = "remove"
+
+
+class DeltaPriority(str, Enum):
+    LOW = "low"
+    NORMAL = "normal"
+    HIGH = "high"
+    CRITICAL = "critical"

--- a/code/shared/schemas/policy_delta.py
+++ b/code/shared/schemas/policy_delta.py
@@ -1,0 +1,66 @@
+"""Schema PolicyDelta."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from .base import BaseSchema
+from .enums import DeltaPriority, PatchOperation
+
+ALLOWED_POLICY_PATHS = {
+    "valid_until",
+    "mode_default",
+    "rules.watering_window.start_hour_local",
+    "rules.watering_window.end_hour_local",
+    "rules.soil_moisture_thresholds.parcel_a.min_pct",
+    "rules.soil_moisture_thresholds.parcel_a.target_pct",
+    "rules.soil_moisture_thresholds.parcel_b.min_pct",
+    "rules.soil_moisture_thresholds.parcel_b.target_pct",
+    "rules.max_watering_duration_s",
+    "rules.daily_water_budget_liters",
+    "rules.tank_minimum_pct",
+    "rules.require_vision_confirmation",
+    "rules.conservative_triggers",
+    "rationale",
+    "notes",
+}
+
+
+class PolicyPatch(BaseModel):
+    op: PatchOperation
+    path: str = Field(min_length=1)
+    value: Any | None = None
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        if value not in ALLOWED_POLICY_PATHS:
+            raise ValueError("patch path no soportado por el schema v1.0")
+        return value
+
+    @model_validator(mode="after")
+    def validate_value_presence(self) -> "PolicyPatch":
+        if self.op == PatchOperation.REMOVE and self.value is not None:
+            raise ValueError("remove no admite value")
+        if self.op in {PatchOperation.REPLACE, PatchOperation.ADD} and self.value is None:
+            raise ValueError("replace/add requieren value")
+        return self
+
+
+class PolicyDelta(BaseSchema):
+    delta_id: str = Field(min_length=1)
+    target_node_id: str = Field(min_length=1)
+    base_policy_id: str = Field(min_length=1)
+    patches: list[PolicyPatch] = Field(min_length=1)
+    rationale: str | None = None
+    ttl_seconds: int = Field(ge=60, le=604800)
+    priority: DeltaPriority
+
+    @field_validator("base_policy_id")
+    @classmethod
+    def validate_base_policy_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("base_policy_id no puede estar vacio")
+        return value

--- a/code/shared/schemas/policy_packet.py
+++ b/code/shared/schemas/policy_packet.py
@@ -1,0 +1,77 @@
+"""Schema PolicyPacket."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator, field_validator
+
+from .base import BaseSchema, parse_utc_zulu
+from .enums import Mode
+
+
+class WateringWindow(BaseModel):
+    start_hour_local: int = Field(ge=0, le=23)
+    end_hour_local: int = Field(ge=0, le=23)
+
+    @model_validator(mode="after")
+    def validate_window(self) -> "WateringWindow":
+        if self.end_hour_local <= self.start_hour_local:
+            raise ValueError("la ventana de riego no puede cruzar medianoche en v1.0")
+        return self
+
+
+class MoistureThreshold(BaseModel):
+    min_pct: float = Field(ge=0, le=100)
+    target_pct: float = Field(ge=0, le=100)
+
+    @model_validator(mode="after")
+    def validate_thresholds(self) -> "MoistureThreshold":
+        if self.target_pct < self.min_pct:
+            raise ValueError("target_pct no puede ser menor que min_pct")
+        return self
+
+
+class SoilMoistureThresholds(BaseModel):
+    parcel_a: MoistureThreshold
+    parcel_b: MoistureThreshold
+
+
+class PolicyRules(BaseModel):
+    watering_window: WateringWindow
+    soil_moisture_thresholds: SoilMoistureThresholds
+    max_watering_duration_s: int = Field(gt=0, le=120)
+    daily_water_budget_liters: float = Field(gt=0)
+    tank_minimum_pct: float = Field(ge=0, le=100)
+    require_vision_confirmation: bool
+    conservative_triggers: list[str] = Field(default_factory=list)
+
+    @field_validator("tank_minimum_pct")
+    @classmethod
+    def validate_tank_minimum_pct(cls, value: float) -> float:
+        if value < 10.0:
+            raise ValueError("tank_minimum_pct no puede bajar del 10%")
+        return value
+
+
+class PolicyPacket(BaseSchema):
+    policy_id: str = Field(min_length=1)
+    target_node_id: str = Field(min_length=1)
+    valid_until: datetime
+    version_chain: list[str] = Field(min_length=1)
+    mode_default: Mode
+    rules: PolicyRules
+    rationale: str | None = None
+    notes: str | None = None
+
+    @field_validator("valid_until", mode="before")
+    @classmethod
+    def validate_valid_until(cls, value: Any) -> datetime:
+        return parse_utc_zulu(value)
+
+    @model_validator(mode="after")
+    def validate_policy(self) -> "PolicyPacket":
+        if self.valid_until <= self.created_at:
+            raise ValueError("valid_until debe ser posterior a created_at")
+        return self

--- a/code/shared/schemas/rhizome_snapshot.py
+++ b/code/shared/schemas/rhizome_snapshot.py
@@ -1,0 +1,78 @@
+"""Schema RhizomeSnapshot."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from .base import BaseSchema, parse_utc_zulu
+from .enums import Mode
+
+
+class SnapshotSensors(BaseModel):
+    soil_moisture_a_pct: float = Field(ge=0, le=100)
+    soil_moisture_b_pct: float = Field(ge=0, le=100)
+    tank_level_pct: float = Field(ge=0, le=100)
+    flow_rate_lpm: float = Field(ge=0)
+    last_reading_at: datetime
+
+    @field_validator("last_reading_at", mode="before")
+    @classmethod
+    def validate_last_reading_at(cls, value: Any) -> datetime:
+        return parse_utc_zulu(value)
+
+
+class SnapshotVision(BaseModel):
+    last_capture_at: datetime | None = None
+    parcel_a_status: str | None = None
+    parcel_b_status: str | None = None
+    visual_notes: str | None = Field(default=None, max_length=500)
+
+    @field_validator("last_capture_at", mode="before")
+    @classmethod
+    def validate_last_capture_at(cls, value: Any) -> datetime | None:
+        if value is None:
+            return None
+        return parse_utc_zulu(value)
+
+
+class SnapshotHealth(BaseModel):
+    cpu_temp_c: float
+    cpu_load_pct: float = Field(ge=0, le=100)
+    ram_used_gb: float = Field(ge=0)
+    ram_total_gb: float = Field(gt=0)
+    esp32_heartbeat_ok: bool
+    last_esp32_ack_at: datetime | None = None
+
+    @field_validator("cpu_temp_c")
+    @classmethod
+    def validate_cpu_temp_c(cls, value: float) -> float:
+        if not -20 <= value <= 120:
+            raise ValueError("cpu_temp_c fuera de rango razonable")
+        return value
+
+    @field_validator("last_esp32_ack_at", mode="before")
+    @classmethod
+    def validate_last_esp32_ack_at(cls, value: Any) -> datetime | None:
+        if value is None:
+            return None
+        return parse_utc_zulu(value)
+
+
+class RhizomeSnapshot(BaseSchema):
+    snapshot_id: str = Field(min_length=1)
+    mode: Mode
+    active_policy_id: str = Field(min_length=1)
+    active_policy_expires_at: datetime
+    sensors: SnapshotSensors
+    vision: SnapshotVision
+    health: SnapshotHealth
+    last_decision_id: str | None = None
+    pending_contradictions: list[str] = Field(default_factory=list)
+
+    @field_validator("active_policy_expires_at", mode="before")
+    @classmethod
+    def validate_active_policy_expires_at(cls, value: Any) -> datetime:
+        return parse_utc_zulu(value)

--- a/code/shared/schemas/tests/__init__.py
+++ b/code/shared/schemas/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests de los schemas compartidos."""

--- a/code/shared/schemas/tests/factories.py
+++ b/code/shared/schemas/tests/factories.py
@@ -1,0 +1,213 @@
+"""Ejemplos canonicos en memoria para los tests de schemas."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+def rhizome_snapshot_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T14:32:05Z",
+        "origin_node_id": "rhizome_01",
+        "signature": None,
+        "snapshot_id": "snap_rhizome_01_20260416T143205_a3f2",
+        "mode": "normal",
+        "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "active_policy_expires_at": "2026-04-17T08:30:15Z",
+        "sensors": {
+            "soil_moisture_a_pct": 38.2,
+            "soil_moisture_b_pct": 41.7,
+            "tank_level_pct": 72.0,
+            "flow_rate_lpm": 0.0,
+            "last_reading_at": "2026-04-16T14:31:58Z",
+        },
+        "vision": {
+            "last_capture_at": "2026-04-16T14:25:00Z",
+            "parcel_a_status": "healthy",
+            "parcel_b_status": "healthy",
+            "visual_notes": "hojas firmes, color normal en ambas parcelas",
+        },
+        "health": {
+            "cpu_temp_c": 58.4,
+            "cpu_load_pct": 41.0,
+            "ram_used_gb": 4.8,
+            "ram_total_gb": 7.4,
+            "esp32_heartbeat_ok": True,
+            "last_esp32_ack_at": "2026-04-16T14:32:00Z",
+        },
+        "last_decision_id": "rec_rhizome_01_20260416T143000_91ba",
+        "pending_contradictions": [],
+    }
+
+
+def policy_packet_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T08:30:15Z",
+        "origin_node_id": "meristem_01",
+        "signature": None,
+        "policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "target_node_id": "rhizome_01",
+        "valid_until": "2026-04-17T08:30:15Z",
+        "version_chain": [
+            "pkt_rhizome_01_20260415T083015_1234",
+            "pkt_rhizome_01_20260416T083015_d5e7",
+        ],
+        "mode_default": "normal",
+        "rules": {
+            "watering_window": {"start_hour_local": 6, "end_hour_local": 9},
+            "soil_moisture_thresholds": {
+                "parcel_a": {"min_pct": 35.0, "target_pct": 55.0},
+                "parcel_b": {"min_pct": 30.0, "target_pct": 50.0},
+            },
+            "max_watering_duration_s": 45,
+            "daily_water_budget_liters": 8.0,
+            "tank_minimum_pct": 15.0,
+            "require_vision_confirmation": False,
+            "conservative_triggers": [
+                "tank_level_below_30",
+                "no_pollen_visit_48h",
+                "policy_expires_within_3h",
+            ],
+        },
+        "rationale": "Post-lluvia del 15 abril. Humedad general alta. Subir umbrales parcela B que suele retener mas.",
+        "notes": "Primera iteracion tras validacion semanal.",
+    }
+
+
+def policy_delta_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T15:00:00Z",
+        "origin_node_id": "meristem_01",
+        "signature": None,
+        "delta_id": "delta_meristem_01_20260416T150000_c92d",
+        "target_node_id": "rhizome_01",
+        "base_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "patches": [
+            {
+                "op": "replace",
+                "path": "rules.soil_moisture_thresholds.parcel_b.min_pct",
+                "value": 32.0,
+            },
+            {
+                "op": "replace",
+                "path": "rules.daily_water_budget_liters",
+                "value": 10.0,
+            },
+            {
+                "op": "add",
+                "path": "rules.conservative_triggers",
+                "value": "humidity_below_25_forecast",
+            },
+        ],
+        "rationale": "Forecast Pollen trae humedad baja esperada en 24h. Subir budget y anadir trigger.",
+        "ttl_seconds": 86400,
+        "priority": "normal",
+    }
+
+
+def weather_packet_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T12:15:00Z",
+        "origin_node_id": "pollen_01",
+        "signature": None,
+        "packet_id": "pkt_weather_pollen_01_20260416T121500_e7a2",
+        "observed_at": "2026-04-16T11:45:00Z",
+        "observed_by_node_id": "rhizome_02",
+        "provenance": "ferried",
+        "valid_until": "2026-04-16T17:45:00Z",
+        "location": {
+            "lat": 42.1828,
+            "lon": 1.9931,
+            "altitude_m": 1100,
+            "label": "Castellar de n'Hug, parcela A",
+        },
+        "measurements": {
+            "temperature_c": 18.4,
+            "humidity_rel_pct": 62.0,
+            "pressure_hpa": 1013.5,
+            "rain_last_1h_mm": 0.0,
+            "rain_last_24h_mm": 2.4,
+            "wind_speed_kmh": 8.2,
+            "wind_direction_deg": 220,
+            "solar_radiation_wm2": 485,
+            "uv_index": 4.8,
+        },
+        "confidence": 0.85,
+        "notes": "Estacion WS90 en rhizome_02. Ultima calibracion hace 3 semanas.",
+    }
+
+
+def contradiction_alert_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T13:22:30Z",
+        "origin_node_id": "pollen_01",
+        "signature": None,
+        "alert_id": "alert_pollen_01_20260416T132230_f108",
+        "target_node_id": "rhizome_01",
+        "contradiction_type": "sensor_vs_vision",
+        "severity": "warning",
+        "observed_at": "2026-04-16T13:20:00Z",
+        "evidence": {
+            "sensor_reading": {
+                "source": "snap_rhizome_01_20260416T131800_4c5e",
+                "soil_moisture_a_pct": 42.0,
+            },
+            "vision_reading": {
+                "source": "pollen_capture_20260416T132015",
+                "assessment": "severe_stress",
+                "notes": "Hojas claramente caidas en parcela A, decoloracion en los bordes.",
+            },
+        },
+        "recommended_action": "defer_and_review",
+        "expires_at": "2026-04-16T19:22:30Z",
+        "rationale": "Humedad 42% es razonable en estacion seca, pero el estado visual indica estres claro. Puede haber sensor mal calibrado o problema de raiz.",
+    }
+
+
+def decision_receipt_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T14:30:10Z",
+        "origin_node_id": "rhizome_01",
+        "signature": None,
+        "decision_id": "rec_rhizome_01_20260416T143010_91ba",
+        "snapshot_id": "snap_rhizome_01_20260416T143005_a3f2",
+        "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "action": "WATER_A",
+        "action_params": {"duration_s": 30, "expected_liters": 1.5},
+        "rationale_short": "Humedad A en 38%, por debajo del umbral 45%. Dentro de ventana de riego. Deposito al 72%.",
+        "rationale_full": "El snapshot reciente muestra humedad parcela A al 38.2%, umbral minimo 45% segun politica vigente. Hora local dentro de ventana 06-09. Deposito al 72%. Vision confirma planta sana.",
+        "policy_refs": [
+            "rules.soil_moisture_thresholds.parcel_a.min_pct",
+            "rules.watering_window",
+            "rules.tank_minimum_pct",
+        ],
+        "contradictions": [],
+        "confidence": 0.87,
+        "executed": True,
+        "execution_details": {
+            "sent_to_esp32_at": "2026-04-16T14:30:10Z",
+            "esp32_ack_at": "2026-04-16T14:30:11Z",
+            "esp32_ack_status": "OK",
+            "actual_duration_s": 30.2,
+            "flow_observed_lpm": 3.1,
+            "estimated_liters_actual": 1.56,
+        },
+        "blocked_reason": None,
+    }
+
+
+def canonical_examples() -> dict[str, dict]:
+    return {
+        "rhizome_snapshot": deepcopy(rhizome_snapshot_example()),
+        "policy_packet": deepcopy(policy_packet_example()),
+        "policy_delta": deepcopy(policy_delta_example()),
+        "weather_packet": deepcopy(weather_packet_example()),
+        "contradiction_alert": deepcopy(contradiction_alert_example()),
+        "decision_receipt": deepcopy(decision_receipt_example()),
+    }

--- a/code/shared/schemas/tests/test_roundtrip.py
+++ b/code/shared/schemas/tests/test_roundtrip.py
@@ -1,0 +1,36 @@
+"""Tests de round-trip para los schemas compartidos."""
+
+from __future__ import annotations
+
+import pytest
+
+from schemas import (
+    ContradictionAlert,
+    DecisionReceipt,
+    PolicyDelta,
+    PolicyPacket,
+    RhizomeSnapshot,
+    WeatherPacket,
+)
+from schemas.tests.factories import canonical_examples
+
+MODEL_BY_NAME = {
+    "rhizome_snapshot": RhizomeSnapshot,
+    "policy_packet": PolicyPacket,
+    "policy_delta": PolicyDelta,
+    "weather_packet": WeatherPacket,
+    "contradiction_alert": ContradictionAlert,
+    "decision_receipt": DecisionReceipt,
+}
+
+
+@pytest.mark.parametrize("name", sorted(MODEL_BY_NAME))
+def test_canonical_examples_roundtrip(name: str) -> None:
+    model_cls = MODEL_BY_NAME[name]
+    payload = canonical_examples()[name]
+
+    parsed = model_cls.model_validate(payload)
+    dumped = parsed.model_dump(mode="json")
+    reparsed = model_cls.model_validate(dumped)
+
+    assert reparsed.model_dump(mode="json") == dumped

--- a/code/shared/schemas/tests/test_validation.py
+++ b/code/shared/schemas/tests/test_validation.py
@@ -1,0 +1,175 @@
+"""Tests negativos de validacion para reglas duras de los schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from schemas import ContradictionAlert, DecisionReceipt, PolicyDelta, PolicyPacket, RhizomeSnapshot, WeatherPacket
+from schemas.tests.factories import (
+    contradiction_alert_example,
+    decision_receipt_example,
+    policy_delta_example,
+    policy_packet_example,
+    rhizome_snapshot_example,
+    weather_packet_example,
+)
+
+
+def test_rhizome_snapshot_rejects_percent_out_of_range() -> None:
+    payload = rhizome_snapshot_example()
+    payload["sensors"]["soil_moisture_a_pct"] = 120.0
+
+    with pytest.raises(ValidationError):
+        RhizomeSnapshot.model_validate(payload)
+
+
+def test_rhizome_snapshot_rejects_cpu_temp_out_of_range() -> None:
+    payload = rhizome_snapshot_example()
+    payload["health"]["cpu_temp_c"] = 140.0
+
+    with pytest.raises(ValidationError):
+        RhizomeSnapshot.model_validate(payload)
+
+
+def test_policy_packet_rejects_invalid_window() -> None:
+    payload = policy_packet_example()
+    payload["rules"]["watering_window"]["end_hour_local"] = 5
+
+    with pytest.raises(ValidationError):
+        PolicyPacket.model_validate(payload)
+
+
+def test_policy_packet_rejects_expired_policy() -> None:
+    payload = policy_packet_example()
+    payload["valid_until"] = "2026-04-16T08:00:00Z"
+
+    with pytest.raises(ValidationError):
+        PolicyPacket.model_validate(payload)
+
+
+def test_policy_packet_rejects_tank_minimum_below_hard_floor() -> None:
+    payload = policy_packet_example()
+    payload["rules"]["tank_minimum_pct"] = 5.0
+
+    with pytest.raises(ValidationError):
+        PolicyPacket.model_validate(payload)
+
+
+def test_policy_delta_requires_base_policy_id() -> None:
+    payload = policy_delta_example()
+    payload["base_policy_id"] = "   "
+
+    with pytest.raises(ValidationError):
+        PolicyDelta.model_validate(payload)
+
+
+def test_policy_delta_rejects_unknown_path() -> None:
+    payload = policy_delta_example()
+    payload["patches"][0]["path"] = "rules.unknown_field"
+
+    with pytest.raises(ValidationError):
+        PolicyDelta.model_validate(payload)
+
+
+def test_policy_delta_rejects_remove_with_value() -> None:
+    payload = policy_delta_example()
+    payload["patches"][0] = {"op": "remove", "path": "notes", "value": "sobrante"}
+
+    with pytest.raises(ValidationError):
+        PolicyDelta.model_validate(payload)
+
+
+def test_weather_packet_provenance_is_strict_enum() -> None:
+    payload = weather_packet_example()
+    payload["provenance"] = "voice_note"
+
+    with pytest.raises(ValidationError):
+        WeatherPacket.model_validate(payload)
+
+
+def test_weather_packet_requires_observed_not_future() -> None:
+    payload = weather_packet_example()
+    payload["observed_at"] = "2026-04-16T12:16:00Z"
+
+    with pytest.raises(ValidationError):
+        WeatherPacket.model_validate(payload)
+
+
+def test_weather_packet_local_station_requires_matching_origin() -> None:
+    payload = weather_packet_example()
+    payload["provenance"] = "local_station"
+
+    with pytest.raises(ValidationError):
+        WeatherPacket.model_validate(payload)
+
+
+def test_contradiction_alert_requires_evidence_shape() -> None:
+    payload = contradiction_alert_example()
+    del payload["evidence"]["vision_reading"]
+
+    with pytest.raises(ValidationError):
+        ContradictionAlert.model_validate(payload)
+
+
+def test_contradiction_alert_critical_requires_blocking_action() -> None:
+    payload = contradiction_alert_example()
+    payload["severity"] = "critical"
+    payload["recommended_action"] = "continue_with_caution"
+
+    with pytest.raises(ValidationError):
+        ContradictionAlert.model_validate(payload)
+
+
+def test_contradiction_alert_requires_future_expiry() -> None:
+    payload = contradiction_alert_example()
+    payload["expires_at"] = "2026-04-16T13:00:00Z"
+
+    with pytest.raises(ValidationError):
+        ContradictionAlert.model_validate(payload)
+
+
+def test_decision_receipt_rejects_long_rationale_short() -> None:
+    payload = decision_receipt_example()
+    payload["rationale_short"] = "x" * 181
+
+    with pytest.raises(ValidationError):
+        DecisionReceipt.model_validate(payload)
+
+
+def test_decision_receipt_requires_execution_details_when_executed() -> None:
+    payload = decision_receipt_example()
+    payload["execution_details"] = None
+
+    with pytest.raises(ValidationError):
+        DecisionReceipt.model_validate(payload)
+
+
+def test_decision_receipt_rejects_blocked_reason_when_executed() -> None:
+    payload = decision_receipt_example()
+    payload["blocked_reason"] = "no deberia existir"
+
+    with pytest.raises(ValidationError):
+        DecisionReceipt.model_validate(payload)
+
+
+def test_decision_receipt_requires_blocked_reason_when_not_executed() -> None:
+    payload = decision_receipt_example()
+    payload["executed"] = False
+    payload["execution_details"] = None
+    payload["blocked_reason"] = ""
+
+    with pytest.raises(ValidationError):
+        DecisionReceipt.model_validate(payload)
+
+
+def test_decision_receipt_requires_action_params_per_action() -> None:
+    payload = decision_receipt_example()
+    payload["action"] = "DEFER"
+    payload["action_params"] = {"reason": "viento"}
+    payload["executed"] = False
+    payload["execution_details"] = None
+    payload["blocked_reason"] = "deferred"
+
+    with pytest.raises(ValidationError):
+        DecisionReceipt.model_validate(payload)

--- a/code/shared/schemas/weather_packet.py
+++ b/code/shared/schemas/weather_packet.py
@@ -1,0 +1,63 @@
+"""Schema WeatherPacket."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator, field_validator
+
+from .base import BaseSchema, parse_utc_zulu
+from .enums import WeatherProvenance
+
+
+class WeatherLocation(BaseModel):
+    lat: float = Field(ge=-90, le=90)
+    lon: float = Field(ge=-180, le=180)
+    altitude_m: float | None = None
+    label: str | None = None
+
+
+class WeatherMeasurements(BaseModel):
+    temperature_c: float | None = None
+    humidity_rel_pct: float | None = Field(default=None, ge=0, le=100)
+    pressure_hpa: float | None = None
+    rain_last_1h_mm: float | None = Field(default=None, ge=0)
+    rain_last_24h_mm: float | None = Field(default=None, ge=0)
+    wind_speed_kmh: float | None = Field(default=None, ge=0)
+    wind_direction_deg: float | None = Field(default=None, ge=0, le=360)
+    solar_radiation_wm2: float | None = Field(default=None, ge=0)
+    uv_index: float | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def validate_at_least_one_measurement(self) -> "WeatherMeasurements":
+        if not any(value is not None for value in self.model_dump().values()):
+            raise ValueError("measurements debe incluir al menos una medida")
+        return self
+
+
+class WeatherPacket(BaseSchema):
+    packet_id: str = Field(min_length=1)
+    observed_at: datetime
+    observed_by_node_id: str = Field(min_length=1)
+    provenance: WeatherProvenance
+    valid_until: datetime
+    location: WeatherLocation
+    measurements: WeatherMeasurements
+    confidence: float = Field(ge=0, le=1)
+    notes: str | None = None
+
+    @field_validator("observed_at", "valid_until", mode="before")
+    @classmethod
+    def validate_datetimes(cls, value: Any) -> datetime:
+        return parse_utc_zulu(value)
+
+    @model_validator(mode="after")
+    def validate_packet(self) -> "WeatherPacket":
+        if self.observed_at > self.created_at:
+            raise ValueError("observed_at no puede estar en el futuro respecto a created_at")
+        if self.valid_until <= self.created_at:
+            raise ValueError("valid_until debe ser posterior a created_at")
+        if self.provenance == WeatherProvenance.LOCAL_STATION and self.observed_by_node_id != self.origin_node_id:
+            raise ValueError("local_station exige observed_by_node_id == origin_node_id")
+        return self


### PR DESCRIPTION
Closes #1

## Resumen
- implementa los 6 contratos v1.0 en `code/shared/schemas/` con `pydantic` v2
- añade `BaseSchema`, enums compartidos y validadores para reglas duras clave
- agrega tests de roundtrip y validacion negativa
- actualiza `code/shared/README.md` para reflejar que Pydantic es la fuente de verdad
- deja bitacora de avance para este bloque

## Como probar
1. `cd code/shared`
2. `python -m pytest schemas/tests`

## Notas
- `#5` queda asignado y preparado como spike separado para cuando el Jetson este disponible.
- El archivo `bitacora/2026-04-15_confirmacion-y-arranque-rhizome_xilema.md` sigue local y no forma parte de este PR.