### PR TITLE
feat(meristem): bootstrap scaffolding con FastAPI, Ollama stub y tests

### DIFF
--- a/bitacora/2026-04-17_bootstrap-meristem_meristem.md
+++ b/bitacora/2026-04-17_bootstrap-meristem_meristem.md
@@ -1,0 +1,148 @@
+# Bootstrap Meristem: scaffold FastAPI + Ollama stub + persistencia + tests
+
+**Fecha:** 2026-04-17
+**Autor:** Meristem
+**Area:** Meristem
+**Tipo:** Avance
+
+---
+
+## Contexto
+
+Primera entrada de Meristem. Bea y Cambium autorizaron (via issue #16, `node:meristem` / `area:infra` / `priority:P0`) arrancar el andamio de `code/meristem/` siguiendo el spec de `docs/12_meristem_spec.md` §4, sin meter policy_engine real ni razonamiento estrategico en el primer PR. Ese alcance viene en el PR siguiente con su propia bitacora.
+
+Antes de tipear codigo lei: `CONTRIBUTING.md` completo (especial atencion a §11.1 multi-agente sobre el mismo clone y §12 flujo de tablero), `docs/01_architecture.md`, `docs/20_data_contracts.md`, `docs/30_safety_rules.md`, `docs/12_meristem_spec.md`, y las ultimas bitacoras (`2026-04-16_safety-rules-v1_cambium.md`, `2026-04-16_data-contracts-v1_cambium.md`, `2026-04-17_schemas-pydantic-v2_xilema.md`, `2026-04-17_convenciones-autoria-bilinguismo_cambium.md`).
+
+## Que hicimos
+
+Rama: `feat/meristem-bootstrap`.
+
+### Estructura creada en `code/meristem/`
+
+```
+meristem/
+├── README.md               # reescrito con estructura real
+├── requirements.txt
+├── pyproject.toml
+├── .env.example
+├── src/
+│   ├── __init__.py
+│   ├── main.py             # FastAPI app, /health, init SQLite
+│   ├── settings.py         # env -> dataclass Settings
+│   ├── llm_client.py       # OllamaClient stub (ping /api/tags)
+│   ├── persistence.py      # init_db + connect, 5 tablas
+│   ├── prompts/
+│   │   └── system_v1.txt   # draft del system prompt
+│   └── shadow/
+│       ├── __init__.py     # vacio a proposito: no carga submodulos
+│       ├── shadow_client.py
+│       └── compare.py
+└── tests/
+    ├── conftest.py         # anade code/shared al sys.path
+    ├── test_settings.py
+    ├── test_health.py
+    ├── test_llm_client.py
+    ├── test_schemas_importable.py
+    └── test_shadow_off.py
+```
+
+### Contrato de invocacion local
+
+- `GET /health` → `{status, version, model, shadow_enabled}`. Suficiente para que Pollen verifique liveness en PR siguiente.
+- `create_app(settings)` inicializa SQLite (5 tablas segun spec §7) antes de montar rutas.
+- Import lazy de shadow dentro de `create_app`: `if settings.shadow_enabled: from .shadow import shadow_client`. Con flag off, el subarbol `src.shadow.*` no se toca.
+- `OllamaClient` es stub: constructor + `ping()` contra `/api/tags`. Sin llamadas `/api/generate` aun. Lo usaran los siguientes PRs.
+
+### Schemas
+
+No dupliqué nada. Los 6 schemas canonicos (`RhizomeSnapshot`, `PolicyPacket`, `PolicyDelta`, `WeatherPacket`, `ContradictionAlert`, `DecisionReceipt`) se importan desde `code/shared/schemas/`. El `conftest.py` de los tests anade `code/shared` al `sys.path` para no obligar a `pip install -e ../shared` en cada entorno de CI. El README documenta ambos caminos.
+
+### Test negativo del sombra (lo que Cambium destaco)
+
+`tests/test_shadow_off.py` corre un subproceso Python limpio con `SHADOW_ENABLED=false`, importa `create_app(load_settings())` y comprueba que ni `google.genai` ni `src.shadow.shadow_client` ni `src.shadow.compare` aparecen en `sys.modules`. Es verificacion por construccion, no por inspeccion de codigo.
+
+Matiz que descubrí al correrlo: el paquete namespace `google` puede aparecer en `sys.modules` como side-effect de otros paquetes (protobuf, grpcio, etc.) sin que Meristem haya tocado nada. Lo critico por seguridad es `google.genai` (el cliente del sombra). El test queda restringido a los modulos que realmente significan "shadow cargado", no a cualquier `google.*`.
+
+Test complementario en `test_health.py`: con `SHADOW_ENABLED=true` y `google-genai` no instalado, `create_app` tira `ImportError` al importar `google.genai`. Hace explicito el contrato: flag on exige dependencia opcional presente.
+
+### Resultados
+
+```
+$ python -m pytest tests -v
+20 passed in 2.52s
+```
+
+`code/shared/schemas/tests` sigue pasando 25/25 (no toque nada ahi).
+
+### Identidad git
+
+Este clone es compartido (Cambium escribe tambien desde otra conversacion). Sigo §11.1: **no toco `.git/config`**, paso identidad inline en cada commit:
+
+```
+git -c user.name="Meristem" -c user.email="meristem@sprout.local" commit ...
+```
+
+## Por que
+
+### Por que no meter policy_engine real en este PR
+
+- El andamio se prueba ejecutable con `/health` y tests. Un policy_engine sin evaluacion robusta de prompts y sin batería de casos es un PR que no puedo defender en review.
+- Pollen (Floema) puede empezar a cablear sus mocks HTTP contra `/health` + endpoints-por-venir sin bloquearse en la logica de consolidacion.
+- Cada PR pequeno con su bitacora deja mejor rastro para el writeup que un mega-PR que mezcla andamiaje, prompting y evaluacion.
+
+### Por que import lazy de shadow dentro de `create_app`
+
+El spec §2.4 dice que el demo se graba con flag apagado y sin credencial. Si `src/shadow/__init__.py` importa `shadow_client` de serie, un desarrollador descuidado podria tener `google-genai` instalada por accidente y **cargarla** aunque el flag este off. El import lazy elimina esa trampa: para cargar `google.genai` hace falta flag on **y** llamar a `create_app`. Verificado por test.
+
+### Por que SQLite init en `create_app` y no en un comando separado
+
+`create_app` es idempotente (CREATE TABLE IF NOT EXISTS) y el coste es despreciable. Arrancar el servicio sin tablas crearia un error `no such table` en el primer `/ingest`, que es peor UX que aceptar 200µs de latencia de boot.
+
+### Por que tests que leen el schema SQLite tras `create_app`
+
+Afirma el contrato de persistencia en tests, no solo en el spec. Si alguien renombra una tabla sin actualizar el test, el test falla y lo detectamos en review.
+
+### Por que `OllamaClient` es stub y no hace `/api/generate`
+
+- No necesito llamar al modelo para este PR. Solo demostrar que el cliente HTTP se construye con el host del settings y puede pingear.
+- Llamar al modelo sin un prompt fijado (system_v1.txt esta en draft) serian experimentos de prompt engineering disfrazados de codigo de produccion. Me lo reservo para el PR siguiente donde entra el prompt versionado.
+
+### Por que `system_v1.txt` es draft y no esta fijado
+
+Cambium lo autorizó explicitamente: "un draft honesto sirve; lo iteramos en PR posteriores con su bitacora". El draft cubre los principios duros (emitir politicas con TTL, prudencia ante contradicciones, respeto a limites firmware §30) sin comprometerse aun a estructura de system+user+schema. Eso se itera con datos reales.
+
+### Por que `.env.example` con `SHADOW_ENABLED=false` explicito
+
+Redundante con el default en `settings.py`, pero el spec §2.4 lo pide visible. Cuando alguien copie `.env.example` a `.env` el primer dia, lo **ve** y no necesita leer spec para saber que el flag existe.
+
+## Que queda pendiente
+
+Para este PR:
+- [ ] `git push origin feat/meristem-bootstrap`
+- [ ] Avisar a Bea para que pase el mensaje a Cambium: rama lista para PR `Closes #16`
+
+Para los PRs siguientes de Meristem (sin orden fijado):
+- [ ] Policy engine: prompt `system_v1` iterado + llamada real a E4B con `structured output` + validacion post-hoc pydantic de `PolicyPacket` / `PolicyDelta`
+- [ ] Endpoints `/ingest`, `/policies/{rhizome_id}`, `/deltas/pending/{rhizome_id}`, `/deltas/propose` (consumen los schemas de shared)
+- [ ] Consolidator: job que se dispara tras N evidencias y llama al policy_engine
+- [ ] `shadow/compare.py` real: harness de comparacion local vs 31B, diffs persistidos en `shadow_comparisons`
+- [ ] Tests contra Ollama real (opt-in, skip si el daemon no responde)
+- [ ] Respeto explicito de limites firmware §30 en los prompts y validaciones (rechazo pre-emit de cualquier politica con `max_watering_duration_s > 60`, `tank_minimum_pct < 20`, etc.)
+
+## Riesgos asumidos
+
+- **El test negativo de shadow no cubre todos los vectores de leak.** Si alguien en el futuro hace un `import google.genai` en cualquier punto de `src/` fuera de `src/shadow/`, el test seguiria verde mientras la condicion `SHADOW_ENABLED=false` esté activa. Mitigacion razonable: el lint CI puede anadir una regla "no `from google import genai` fuera de `src/shadow/`" cuando queramos reforzarlo. No lo hago en este PR por no aumentar scope.
+- **`OllamaClient.ping()` es lo unico probado contra el daemon.** El resto del cliente (generacion, streaming) se cablea en el PR siguiente con tests de contrato reales.
+- **`conftest.py` modifica `sys.path` global del proceso.** Es la forma menos invasiva de integrar con `code/shared/` sin forzar instalacion editable. Si en el futuro se adopta `pip install -e ../shared` en CI, se puede eliminar el truco de path — pero no lo bloqueo hoy.
+
+## Enlaces
+
+- [docs/12_meristem_spec.md](../docs/12_meristem_spec.md) — spec fuente
+- [docs/20_data_contracts.md](../docs/20_data_contracts.md) — schemas consumidos
+- [docs/30_safety_rules.md](../docs/30_safety_rules.md) — limites que respetaran los prompts del PR siguiente
+- [CONTRIBUTING.md §11.1](../CONTRIBUTING.md) — multi-agente sobre mismo clone
+- Issue `#16` — Bootstrap meristem
+
+---
+
+**Firma:** Meristem

--- a/code/meristem/.env.example
+++ b/code/meristem/.env.example
@@ -1,0 +1,18 @@
+# Meristem local settings.
+# Copiar a .env y ajustar. .env esta en .gitignore.
+
+# Modelo local via Ollama. Se asume `ollama pull gemma4:e4b` ya hecho.
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=gemma4:e4b
+
+# Puerto del servicio HTTP de Meristem (Pollen empuja aqui).
+MERISTEM_PORT=7070
+
+# Persistencia local.
+DB_PATH=./meristem.db
+
+# Meristem sombra. DEFAULT = false. El demo grabado se rueda con esto en false.
+SHADOW_ENABLED=false
+# Solo necesario si SHADOW_ENABLED=true.
+GEMINI_API_KEY=
+SHADOW_MODEL=gemma-4-31b-it

--- a/code/meristem/.gitignore
+++ b/code/meristem/.gitignore
@@ -1,0 +1,13 @@
+# SQLite local de Meristem y artefactos derivados.
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+*.sqlite
+*.sqlite3
+
+# pytest
+.pytest_cache/
+
+# Entorno local
+.env

--- a/code/meristem/README.md
+++ b/code/meristem/README.md
@@ -13,61 +13,97 @@ Detalle completo en [`docs/12_meristem_spec.md`](../../docs/12_meristem_spec.md)
 
 ## Stack
 
-- Python 3.11
-- Ollama client (para Gemma 4 E4B local)
+- Python 3.11+
+- Ollama (Gemma 4 E4B local) via cliente HTTP
 - `fastapi` + `uvicorn` para API HTTP local
-- `pydantic` para validacion de schemas
+- `pydantic` v2 para schemas (reutiliza `code/shared/schemas/`, no duplica)
 - `sqlite3` para persistencia
-- `google-genai` **solo si** `SHADOW_ENABLED=true` (Meristem sombra para validacion)
+- `google-genai` **solo si** `SHADOW_ENABLED=true` (Meristem sombra para validacion en dev)
 
-## Estructura (a construir)
+## Estructura actual (bootstrap)
 
 ```
 meristem/
 ├── README.md
 ├── requirements.txt
+├── pyproject.toml
 ├── .env.example
 ├── src/
-│   ├── main.py             # FastAPI app
-│   ├── consolidator.py
-│   ├── policy_engine.py
-│   ├── validator.py
-│   ├── llm_client.py       # Ollama client
-│   ├── shadow/             # solo dev - Gemma 4 31B cloud
-│   │   ├── shadow_client.py
-│   │   └── compare.py
+│   ├── __init__.py
+│   ├── main.py             # FastAPI app, /health
+│   ├── settings.py         # env vars -> Settings
+│   ├── llm_client.py       # Ollama client (stub)
+│   ├── persistence.py      # SQLite schema init
 │   ├── prompts/
-│   │   └── system_v1.txt
-│   └── persistence.py      # SQLite
+│   │   └── system_v1.txt   # draft del system prompt de Meristem
+│   └── shadow/             # Meristem sombra (solo dev, flag-gated)
+│       ├── __init__.py
+│       ├── shadow_client.py
+│       └── compare.py
 └── tests/
+    ├── conftest.py
+    ├── test_settings.py
+    ├── test_health.py
+    ├── test_shadow_off.py      # negativo: shadow no carga con flag off
+    ├── test_schemas_importable.py
+    └── test_llm_client.py
 ```
+
+El policy_engine real (consolidacion + llamada a E4B) entra en PR siguiente, con su propia bitacora.
 
 ## Variables de entorno
 
-```
-# .env
-SHADOW_ENABLED=false          # true solo en desarrollo
-GEMINI_API_KEY=               # solo si SHADOW_ENABLED=true
-OLLAMA_HOST=http://localhost:11434
-MERISTEM_PORT=7070
-DB_PATH=./meristem.db
-```
+Ver `.env.example`. Claves:
+
+| Var | Default | Nota |
+|---|---|---|
+| `OLLAMA_HOST` | `http://localhost:11434` | Endpoint del daemon Ollama |
+| `OLLAMA_MODEL` | `gemma4:e4b` | Modelo local del spec §2.1 |
+| `MERISTEM_PORT` | `7070` | Puerto del servicio HTTP |
+| `DB_PATH` | `./meristem.db` | SQLite local |
+| `SHADOW_ENABLED` | `false` | **Regla dura del spec §2.4.** Demo se graba con esto en false. |
+| `GEMINI_API_KEY` | (vacio) | Solo requerido si `SHADOW_ENABLED=true` |
+| `SHADOW_MODEL` | `gemma-4-31b-it` | Modelo cloud del sombra |
 
 ## Como correr
 
 ```bash
+cd code/meristem
 pip install -r requirements.txt
-ollama pull gemma4:e4b        # ya deberia estar pulled
+ollama pull gemma4:e4b        # fuera del scope de este bootstrap
 cp .env.example .env
-python -m src.main
+python -m src.main            # expone en http://localhost:7070
 ```
 
-Expone API en `http://localhost:7070`.
+Los schemas compartidos (`code/shared/schemas/`) se importan via `PYTHONPATH`. En un entorno estable:
 
-## Endpoints principales (draft)
+```bash
+pip install -e ../shared
+```
 
-- `POST /ingest` — Pollen empuja evidencia nueva
-- `GET /policies/{rhizome_id}` — Pollen recoge politica vigente
-- `GET /deltas/pending/{rhizome_id}` — Pollen recoge deltas a entregar
-- `POST /deltas/propose` — Pollen propone delta para validacion
+El `conftest.py` de los tests ya anade `code/shared` al path, asi que `python -m pytest tests` funciona sin instalar shared.
+
+## Endpoints
+
 - `GET /health` — liveness
+
+Endpoints de ingest/emision (`/ingest`, `/policies/*`, `/deltas/*`) se anaden en PR siguiente.
+
+## Tests
+
+```bash
+cd code/meristem
+python -m pytest tests -v
+```
+
+Cobertura del bootstrap: settings, /health + init SQLite, cliente Ollama, shadow off por construccion, importacion de los 6 schemas canonicos.
+
+## Regla dura del sombra
+
+El Meristem sombra (Gemma 4 31B via Google AI Studio) es **solo herramienta de validacion en desarrollo**. `docs/12_meristem_spec.md` §2.4 lo deja explicito:
+
+- Flag `SHADOW_ENABLED=false` por defecto
+- Codigo aislado en `src/shadow/`
+- El demo grabado se rueda con flag apagado y sin `GEMINI_API_KEY`
+
+`tests/test_shadow_off.py` verifica por construccion que con el flag apagado no se carga ni `google.genai` ni los modulos de shadow.

--- a/code/meristem/pyproject.toml
+++ b/code/meristem/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "sprout-meristem"
+version = "0.1.0"
+description = "Nodo estrategico local de Sprout (FastAPI + Ollama Gemma 4 E4B)."
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115,<0.120",
+    "uvicorn[standard]>=0.32,<0.40",
+    "httpx>=0.27,<0.30",
+    "pydantic>=2.12,<3",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0,<10",
+]
+shadow = [
+    # Meristem sombra (validacion en desarrollo, nunca en produccion).
+    # Solo instalar si SHADOW_ENABLED=true.
+    "google-genai>=0.3,<2",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/code/meristem/requirements.txt
+++ b/code/meristem/requirements.txt
@@ -1,0 +1,12 @@
+# Runtime
+fastapi>=0.115,<0.120
+uvicorn[standard]>=0.32,<0.40
+httpx>=0.27,<0.30
+pydantic>=2.12,<3
+
+# Dev / test
+pytest>=8.0,<10
+
+# Shadow (opcional). NO se instala por defecto.
+# Solo necesario cuando SHADOW_ENABLED=true y se usa Meristem sombra:
+#   pip install google-genai

--- a/code/meristem/src/__init__.py
+++ b/code/meristem/src/__init__.py
@@ -1,0 +1,3 @@
+"""Meristem: nodo estrategico local de Sprout."""
+
+__version__ = "0.1.0"

--- a/code/meristem/src/llm_client.py
+++ b/code/meristem/src/llm_client.py
@@ -1,0 +1,37 @@
+"""Cliente Ollama para el modelo local (Gemma 4 E4B).
+
+Este modulo es un **stub** en el bootstrap: configura el cliente HTTP y expone
+`ping()` para verificar que el daemon responde. El razonamiento real (llamada
+a `/api/generate` o `/api/chat` con prompts del policy_engine) entra en el PR
+siguiente junto con su bitacora.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from .settings import Settings
+
+
+class OllamaClient:
+    """Wrapper minimo sobre el endpoint HTTP de Ollama."""
+
+    def __init__(self, settings: Settings, timeout_s: float = 5.0) -> None:
+        self._host = settings.ollama_host.rstrip("/")
+        self._model = settings.ollama_model
+        self._client = httpx.Client(base_url=self._host, timeout=timeout_s)
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def ping(self) -> bool:
+        """Consulta `/api/tags`. Devuelve True si Ollama responde 200."""
+        try:
+            response = self._client.get("/api/tags")
+        except httpx.HTTPError:
+            return False
+        return response.status_code == 200
+
+    def close(self) -> None:
+        self._client.close()

--- a/code/meristem/src/main.py
+++ b/code/meristem/src/main.py
@@ -1,0 +1,57 @@
+"""Entrypoint HTTP de Meristem (FastAPI).
+
+Bootstrap: solo expone `/health`. Los endpoints de ingest y emision de
+policies se montan en PRs posteriores junto con el policy_engine.
+
+Shadow (Meristem sombra contra Gemma 4 31B cloud) solo se importa si el
+flag `SHADOW_ENABLED` esta activo. Con flag apagado, `google.genai` no debe
+entrar nunca en `sys.modules` — ver `tests/test_shadow_off.py`.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from . import __version__
+from .persistence import init_db
+from .settings import Settings, load_settings
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    settings = settings or load_settings()
+    init_db(settings.db_path)
+
+    app = FastAPI(title="Sprout Meristem", version=__version__)
+    app.state.settings = settings
+
+    if settings.shadow_enabled:
+        # Import diferido. Con flag off, no se toca nunca.
+        from .shadow import shadow_client  # noqa: F401
+
+    @app.get("/health")
+    def health() -> dict[str, object]:
+        return {
+            "status": "ok",
+            "version": __version__,
+            "model": settings.ollama_model,
+            "shadow_enabled": settings.shadow_enabled,
+        }
+
+    return app
+
+
+def main() -> None:
+    import uvicorn
+
+    settings = load_settings()
+    uvicorn.run(
+        "src.main:create_app",
+        factory=True,
+        host="127.0.0.1",
+        port=settings.meristem_port,
+        reload=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/meristem/src/persistence.py
+++ b/code/meristem/src/persistence.py
@@ -1,0 +1,84 @@
+"""Persistencia local de Meristem.
+
+SQLite, sin servidor externo. En el bootstrap solo garantizamos que las
+tablas existen para que el PR del policy_engine pueda empezar a escribir.
+
+Tablas (spec 12_meristem_spec.md §7):
+- `evidence`: snapshots, alerts, packets entrantes (raw JSON).
+- `policies`: policy_packets emitidos.
+- `deltas`: policy_deltas propuestos/validados/revocados.
+- `decisions_log`: decisiones importadas via Pollen para auditoria.
+- `shadow_comparisons`: diffs local vs sombra (solo si SHADOW_ENABLED).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS evidence (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    received_at TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    origin_node_id TEXT NOT NULL,
+    payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS policies (
+    policy_id TEXT PRIMARY KEY,
+    target_node_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    valid_until TEXT NOT NULL,
+    payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS deltas (
+    delta_id TEXT PRIMARY KEY,
+    target_node_id TEXT NOT NULL,
+    base_policy_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS decisions_log (
+    decision_id TEXT PRIMARY KEY,
+    origin_node_id TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    action TEXT NOT NULL,
+    payload_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS shadow_comparisons (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL,
+    local_output_json TEXT NOT NULL,
+    shadow_output_json TEXT NOT NULL,
+    agreement INTEGER NOT NULL,
+    notes TEXT
+);
+"""
+
+
+def init_db(db_path: str | Path) -> None:
+    """Crea las tablas si no existen. Idempotente."""
+    path = Path(db_path)
+    if path.parent and str(path.parent) not in {"", "."}:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(path)) as conn:
+        conn.executescript(_SCHEMA_SQL)
+        conn.commit()
+
+
+@contextmanager
+def connect(db_path: str | Path) -> Iterator[sqlite3.Connection]:
+    """Context manager que devuelve una conexion SQLite con row_factory."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/code/meristem/src/prompts/system_v1.txt
+++ b/code/meristem/src/prompts/system_v1.txt
@@ -1,0 +1,25 @@
+Eres Meristem, el nodo estrategico de Sprout, una red agricola local-first.
+
+Tu rol:
+- Consolidar evidencia recibida de multiples parcelas via Pollen (snapshots,
+  alertas de contradiccion, weather packets).
+- Revisar si las politicas vigentes siguen siendo adecuadas.
+- Emitir nuevas politicas (PolicyPacket) o cambios incrementales
+  (PolicyDelta) cuando el contexto lo exige.
+
+Principios duros (no negociables):
+- Nunca ordenas acciones inmediatas. Emites politicas con TTL.
+- Toda politica tiene caducidad explicita (`valid_until`).
+- Cuando hay contradicciones entre parcelas, prefiere la prudencia.
+- Cuando los datos tienen mas de 48 h, marca menor confianza.
+- Respeta SIEMPRE los limites duros del firmware ESP32:
+  * max_watering_duration_s <= 60
+  * tank_minimum_pct >= 20
+  * max 8 aperturas/hora por zona, 48/dia
+  * zonas simultaneas = 1
+  Si generas una politica que viola estos limites, el firmware la rechaza y
+  se emite ContradictionAlert. Evitalo.
+- Produces SOLO JSON valido conforme al schema provisto.
+
+Este prompt es el draft v1 del bootstrap. Se itera en PRs posteriores con
+su bitacora.

--- a/code/meristem/src/settings.py
+++ b/code/meristem/src/settings.py
@@ -1,0 +1,42 @@
+"""Settings de Meristem.
+
+Lee variables de entorno (o .env cargado por el runner) y expone un objeto
+inmutable. No usa `pydantic-settings` para no anadir dependencia — os.environ
+con defaults es suficiente en este scope.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _get_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class Settings:
+    ollama_host: str
+    ollama_model: str
+    meristem_port: int
+    db_path: str
+    shadow_enabled: bool
+    gemini_api_key: str | None
+    shadow_model: str
+
+
+def load_settings() -> Settings:
+    """Construye Settings desde el entorno actual."""
+    return Settings(
+        ollama_host=os.environ.get("OLLAMA_HOST", "http://localhost:11434"),
+        ollama_model=os.environ.get("OLLAMA_MODEL", "gemma4:e4b"),
+        meristem_port=int(os.environ.get("MERISTEM_PORT", "7070")),
+        db_path=os.environ.get("DB_PATH", "./meristem.db"),
+        shadow_enabled=_get_bool("SHADOW_ENABLED", False),
+        gemini_api_key=os.environ.get("GEMINI_API_KEY") or None,
+        shadow_model=os.environ.get("SHADOW_MODEL", "gemma-4-31b-it"),
+    )

--- a/code/meristem/src/shadow/__init__.py
+++ b/code/meristem/src/shadow/__init__.py
@@ -1,0 +1,15 @@
+"""Meristem sombra.
+
+Validacion de desarrollo contra Gemma 4 31B via Google AI Studio. **Nunca
+en produccion ni en el demo grabado.**
+
+Reglas duras (docs/12_meristem_spec.md §2.4):
+- Vive detras de SHADOW_ENABLED=false por defecto.
+- Requiere GEMINI_API_KEY para funcionar.
+- El codigo vive aislado en este subpaquete.
+
+Este `__init__` esta intencionadamente vacio. Importar `meristem.src.shadow`
+no debe tirar de `google.genai`. El import se hace explicito al importar
+`meristem.src.shadow.shadow_client`, que a su vez solo se importa cuando
+`SHADOW_ENABLED=true` (ver `src/main.py`).
+"""

--- a/code/meristem/src/shadow/compare.py
+++ b/code/meristem/src/shadow/compare.py
@@ -1,0 +1,15 @@
+"""Harness de comparacion local vs sombra.
+
+Stub. El cuerpo entra en el PR del policy_engine junto con su bitacora.
+"""
+
+from __future__ import annotations
+
+
+def compare_outputs(local_output: str, shadow_output: str) -> dict[str, object]:
+    """Compara dos outputs de texto. Stub que solo reporta igualdad exacta."""
+    return {
+        "agreement": int(local_output.strip() == shadow_output.strip()),
+        "local_len": len(local_output),
+        "shadow_len": len(shadow_output),
+    }

--- a/code/meristem/src/shadow/shadow_client.py
+++ b/code/meristem/src/shadow/shadow_client.py
@@ -1,0 +1,33 @@
+"""Cliente del Meristem sombra (Gemma 4 31B via Google AI Studio).
+
+Solo se importa cuando SHADOW_ENABLED=true. Si este modulo se importa sin
+`google-genai` instalado, el `ImportError` es intencional — indica que el
+flag esta mal configurado en el entorno (flag on sin dependencia opcional).
+"""
+
+from __future__ import annotations
+
+from google import genai  # type: ignore[import-not-found]
+
+from ..settings import Settings
+
+
+class ShadowClient:
+    """Wrapper minimo sobre google-genai para el modelo sombra."""
+
+    def __init__(self, settings: Settings) -> None:
+        if not settings.shadow_enabled:
+            raise RuntimeError(
+                "ShadowClient instanciado con SHADOW_ENABLED=false. "
+                "Esto jamas debe pasar en produccion."
+            )
+        if not settings.gemini_api_key:
+            raise RuntimeError(
+                "SHADOW_ENABLED=true pero GEMINI_API_KEY vacia."
+            )
+        self._client = genai.Client(api_key=settings.gemini_api_key)
+        self._model = settings.shadow_model
+
+    @property
+    def model(self) -> str:
+        return self._model

--- a/code/meristem/tests/conftest.py
+++ b/code/meristem/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Config de pytest para meristem.
+
+Anade `code/shared` al sys.path para que los schemas compartidos
+(`from schemas import ...`) sean importables sin instalar el paquete de
+forma editable. Esto mantiene el repo usable directamente con `pytest`
+desde el root del proyecto o desde `code/meristem/`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_THIS = Path(__file__).resolve()
+_MERISTEM_ROOT = _THIS.parents[1]
+_CODE_ROOT = _MERISTEM_ROOT.parent
+_SHARED = _CODE_ROOT / "shared"
+
+for path in (_MERISTEM_ROOT, _SHARED):
+    path_str = str(path)
+    if path.exists() and path_str not in sys.path:
+        sys.path.insert(0, path_str)

--- a/code/meristem/tests/test_health.py
+++ b/code/meristem/tests/test_health.py
@@ -1,0 +1,74 @@
+"""Tests del endpoint /health."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.main import create_app
+from src.settings import Settings
+
+
+def _settings(tmp_path: Path, shadow: bool = False) -> Settings:
+    return Settings(
+        ollama_host="http://localhost:11434",
+        ollama_model="gemma4:e4b",
+        meristem_port=7070,
+        db_path=str(tmp_path / "meristem.db"),
+        shadow_enabled=shadow,
+        gemini_api_key=None,
+        shadow_model="gemma-4-31b-it",
+    )
+
+
+def test_health_ok(tmp_path: Path) -> None:
+    app = create_app(_settings(tmp_path))
+    with TestClient(app) as client:
+        response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["model"] == "gemma4:e4b"
+    assert body["shadow_enabled"] is False
+    assert "version" in body
+
+
+def test_create_app_creates_sqlite_schema(tmp_path: Path) -> None:
+    import sqlite3
+
+    db_path = tmp_path / "meristem.db"
+    create_app(_settings(tmp_path))
+    assert db_path.exists(), "create_app debe inicializar SQLite"
+    with sqlite3.connect(str(db_path)) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    expected = {
+        "evidence",
+        "policies",
+        "deltas",
+        "decisions_log",
+        "shadow_comparisons",
+    }
+    assert expected.issubset(tables), tables
+
+
+def test_create_app_shadow_on_without_genai_raises(tmp_path: Path) -> None:
+    """Si SHADOW_ENABLED pero google-genai no esta instalada, debe fallar al
+    importar. Esto hace explicito el contrato: flag on => dependencia opcional
+    presente."""
+    import importlib.util
+
+    if importlib.util.find_spec("google.genai") is not None:
+        pytest.skip("google-genai instalada; test no aplica en este entorno.")
+    # `ImportError` es la superclase de `ModuleNotFoundError`. Python 3.13
+    # levanta `ImportError: cannot import name 'genai' from 'google'`
+    # cuando el paquete namespace `google` existe (p.ej. por grpcio) pero
+    # no contiene `genai`. Cubrimos ambos.
+    with pytest.raises(ImportError):
+        create_app(_settings(tmp_path, shadow=True))

--- a/code/meristem/tests/test_llm_client.py
+++ b/code/meristem/tests/test_llm_client.py
@@ -1,0 +1,58 @@
+"""Tests del stub de OllamaClient. Sin tocar red real."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from src.llm_client import OllamaClient
+from src.settings import Settings
+
+
+def _settings() -> Settings:
+    return Settings(
+        ollama_host="http://localhost:11434",
+        ollama_model="gemma4:e4b",
+        meristem_port=7070,
+        db_path=":memory:",
+        shadow_enabled=False,
+        gemini_api_key=None,
+        shadow_model="gemma-4-31b-it",
+    )
+
+
+def test_ping_returns_true_on_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = OllamaClient(_settings())
+
+    def fake_get(self, url, *args, **kwargs):  # type: ignore[no-untyped-def]
+        assert url == "/api/tags"
+        return httpx.Response(200, json={"models": []})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    try:
+        assert client.ping() is True
+    finally:
+        client.close()
+
+
+def test_ping_returns_false_on_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = OllamaClient(_settings())
+
+    def fake_get(self, url, *args, **kwargs):  # type: ignore[no-untyped-def]
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    try:
+        assert client.ping() is False
+    finally:
+        client.close()
+
+
+def test_model_exposed() -> None:
+    client = OllamaClient(_settings())
+    try:
+        assert client.model == "gemma4:e4b"
+    finally:
+        client.close()

--- a/code/meristem/tests/test_schemas_importable.py
+++ b/code/meristem/tests/test_schemas_importable.py
@@ -1,0 +1,31 @@
+"""Verifica que Meristem puede importar los 6 schemas canonicos desde
+`code/shared/schemas/` sin duplicarlos.
+
+El `conftest.py` de esta suite anade `code/shared` al sys.path, replicando
+lo que haria un `pip install -e ../shared` en un entorno real.
+"""
+
+from __future__ import annotations
+
+
+def test_six_canonical_schemas_importable() -> None:
+    from schemas import (
+        ContradictionAlert,
+        DecisionReceipt,
+        PolicyDelta,
+        PolicyPacket,
+        RhizomeSnapshot,
+        WeatherPacket,
+    )
+
+    # Sanity: cada uno debe ser una clase Pydantic con campo schema_version.
+    for cls in (
+        ContradictionAlert,
+        DecisionReceipt,
+        PolicyDelta,
+        PolicyPacket,
+        RhizomeSnapshot,
+        WeatherPacket,
+    ):
+        assert hasattr(cls, "model_fields"), cls
+        assert "schema_version" in cls.model_fields, cls

--- a/code/meristem/tests/test_settings.py
+++ b/code/meristem/tests/test_settings.py
@@ -1,0 +1,61 @@
+"""Tests de settings: defaults seguros y lectura de entorno."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.settings import load_settings
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "OLLAMA_HOST",
+        "OLLAMA_MODEL",
+        "MERISTEM_PORT",
+        "DB_PATH",
+        "SHADOW_ENABLED",
+        "GEMINI_API_KEY",
+        "SHADOW_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_defaults_are_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    settings = load_settings()
+    # Por defecto, shadow OFF. Es la regla dura del spec 12 §2.4.
+    assert settings.shadow_enabled is False
+    assert settings.gemini_api_key is None
+    assert settings.ollama_host == "http://localhost:11434"
+    assert settings.ollama_model == "gemma4:e4b"
+    assert settings.meristem_port == 7070
+    assert settings.db_path == "./meristem.db"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+        ("garbage", False),
+    ],
+)
+def test_shadow_flag_parsing(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: bool
+) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("SHADOW_ENABLED", raw)
+    assert load_settings().shadow_enabled is expected
+
+
+def test_port_parses_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("MERISTEM_PORT", "8080")
+    assert load_settings().meristem_port == 8080

--- a/code/meristem/tests/test_shadow_off.py
+++ b/code/meristem/tests/test_shadow_off.py
@@ -1,0 +1,67 @@
+"""Test negativo del sombra: con SHADOW_ENABLED=false, `google.genai` jamas
+debe entrar en `sys.modules` al arrancar Meristem.
+
+Cambium lo pidio verificable por construccion, no por inspeccion de codigo.
+El test corre un subproceso Python limpio con el flag apagado, importa la
+app y comprueba que los modulos de shadow (incluido `google.genai`) no se
+cargan.
+
+Nota sobre `google`: el paquete namespace `google` puede aparecer en
+`sys.modules` por side-effects de otras libs (protobuf, grpcio) sin que
+nada de Meristem lo haya tocado. Lo critico por seguridad es que ni
+`google.genai` ni el subpaquete `src.shadow.shadow_client` se carguen.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+_MERISTEM_ROOT = Path(__file__).resolve().parents[1]
+_SHARED = _MERISTEM_ROOT.parent / "shared"
+
+
+def test_shadow_not_loaded_when_flag_off(tmp_path: Path) -> None:
+    script = (
+        "import os, sys;\n"
+        "assert os.environ.get('SHADOW_ENABLED') == 'false';\n"
+        "from src.main import create_app;\n"
+        "from src.settings import load_settings;\n"
+        "create_app(load_settings());\n"
+        "forbidden = ("
+        "'google.genai', "
+        "'src.shadow.shadow_client', "
+        "'src.shadow.compare'"
+        ");\n"
+        "leaked = [m for m in forbidden if m in sys.modules];\n"
+        "assert not leaked, "
+        "f'shadow cargado con SHADOW_ENABLED=false: {leaked}';\n"
+        "print('OK')\n"
+    )
+
+    env = os.environ.copy()
+    env["SHADOW_ENABLED"] = "false"
+    env["DB_PATH"] = str(tmp_path / "meristem.db")
+    # El subproceso debe encontrar `src` y `schemas`.
+    existing_pp = env.get("PYTHONPATH", "")
+    extra = os.pathsep.join(
+        p for p in (str(_MERISTEM_ROOT), str(_SHARED)) if Path(p).exists()
+    )
+    env["PYTHONPATH"] = (
+        os.pathsep.join([extra, existing_pp]) if existing_pp else extra
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(_MERISTEM_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"subproceso fallo.\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
Closes #16

## Resumen
Bootstrap de Meristem (nodo estrategico, laptop). Scaffold limpio + contrato de invocacion local, sin policy_engine todavia (va en PR siguiente).

## Que incluye
- FastAPI con GET /health
- SQLite con 5 tablas del spec §7, idempotente
- OllamaClient stub (ping() contra /api/tags), sin llamada real al modelo
- Settings frozen dataclass con SHADOW_ENABLED=false por defecto
- src/shadow/ aislado, import lazy. Si flag off: google.genai y src.shadow.* NO entran en sys.modules
- Test negativo de shadow via subproceso (no por inspeccion de codigo)
- Test complementario que exige ImportError si SHADOW_ENABLED=true sin google-genai
- Schemas de code/shared/schemas/ importados (no duplicados) + test que lo verifica
- prompts/system_v1.txt draft honesto
- .env.example, .gitignore local (solo para *.db en meristem/)

## Testing
- 20/20 tests verdes en code/meristem/
- 25/25 tests verdes en code/shared/ (sin tocar)

## Matiz documentado
El test negativo de shadow restringe la comprobacion a google.genai y submodulos reales de src/shadow/* (no al namespace google completo, que puede aparecer en sys.modules por side-effects de protobuf/grpcio). Documentado en docstring del test y en bitacora.

## Fuera de scope (PR siguiente)
- policy_engine sobre Gemma E4B
- Endpoints /ingest, /policies/*, /deltas/*
- Respeto pre-emit de limites firmware §30
- Lint que fuerce 'no from google import genai fuera de src/shadow/'

## Autoria
Commit firmado con Meristem <meristem@sprout.local> via -c inline. .git/config sin modificar (respeta §11.1 multi-agente).