### PR TITLE
feat(shared): ejemplos canonicos JSON para los 6 schemas + generador

### DIFF
--- a/bitacora/2026-04-17_ejemplos-canonicos-json_xilema.md
+++ b/bitacora/2026-04-17_ejemplos-canonicos-json_xilema.md
@@ -1,0 +1,49 @@
+# Xilema - issue #2 - ejemplos canonicos JSON
+
+Fecha: 2026-04-17
+Rama: `feat/rhizome-canonical-json-examples`
+Issue: `#2`
+
+## Objetivo
+
+Sacar los ejemplos canonicos de `schemas/tests/factories.py` a una ubicacion propia, generar los `.json` desde Pydantic y usarlos como fixtures reales para round-trip Python <-> JSON <-> Python.
+
+## Trabajo realizado
+
+- Creo `code/shared/schemas/examples/` como espacio canonico de ejemplos.
+- Muevo los builders de payload a `schemas/examples/builders.py`.
+- Añado `schemas/examples/generate_examples.py` para serializar los ejemplos a JSON desde los modelos Pydantic.
+- Genero 6 archivos core:
+  - `rhizome_snapshot.json`
+  - `policy_packet.json`
+  - `policy_delta.json`
+  - `weather_packet.json`
+  - `contradiction_alert.json`
+  - `decision_receipt.json`
+- Añado un fixture suplementario `decision_receipt_blocked.json` para cubrir el caso `executed=false` con `blocked_reason`, pedido en la issue.
+- Actualizo tests para validar los ficheros comprometidos y comprobar que el generador no se ha quedado desfasado.
+- Mantengo `schemas/tests/factories.py` como wrapper de compatibilidad para no romper imports existentes mientras el repo converge.
+
+## Validacion
+
+En `code/shared/`:
+
+```bash
+python -m schemas.examples.generate_examples --check
+python -m pytest schemas/tests
+```
+
+Resultado: `33 passed`.
+
+## Nota de drift
+
+He detectado un desacople menor entre issue y documento:
+
+- La issue `#2` pide los archivos como `code/shared/schemas/examples/<schema>.json`.
+- `docs/20_data_contracts.md` seccion 6 menciona nombres con sufijo `_01`.
+
+He seguido la nomenclatura de la issue para no bloquear a Floema ni a los fixtures cruzados. Si quereis, esto se puede alinear luego en docs con un cambio pequeno y explicito.
+
+## Contexto de rama
+
+`main` no traia todavia el merge de `#13` cuando he arrancado `#2`, asi que he apoyado esta rama sobre `feat/rhizome-schemas-pydantic` para no duplicar ni reimplementar la base de schemas.

--- a/code/shared/Makefile
+++ b/code/shared/Makefile
@@ -1,6 +1,12 @@
 PYTHON ?= python
 
-.PHONY: test-schemas
+.PHONY: check-examples generate-examples test-schemas
+
+check-examples:
+	$(PYTHON) schemas/examples/generate_examples.py --check
+
+generate-examples:
+	$(PYTHON) schemas/examples/generate_examples.py
 
 test-schemas:
 	$(PYTHON) -m pytest schemas/tests

--- a/code/shared/README.md
+++ b/code/shared/README.md
@@ -20,6 +20,10 @@ shared/
     ├── weather_packet.py
     ├── contradiction_alert.py
     ├── decision_receipt.py
+    ├── examples/
+    │   ├── builders.py
+    │   ├── generate_examples.py
+    │   └── *.json
     └── tests/
 ```
 
@@ -29,15 +33,19 @@ shared/
 - `pydantic` es la implementacion canonica
 - Los parsers ignoran campos desconocidos para forward compatibility
 - Todos los timestamps viajan como ISO-8601 UTC con sufijo `Z`
-- Los ejemplos canonicos y round-trips viven en `schemas/tests/`
+- Los payloads canonicos viven en `schemas/examples/`
+- Los JSON canonicos se generan con `python schemas/examples/generate_examples.py`
+- Los round-trips Python viven en `schemas/tests/`
 
 ## Validacion
 
 ### Python (Rhizome, Meristem)
 ```bash
 cd code/shared
+make generate-examples
 make test-schemas
 # o, si no hay make disponible:
+python -m schemas.examples.generate_examples
 python -m pytest schemas/tests
 ```
 
@@ -55,3 +63,5 @@ Si cambias un schema, sigue primero el proceso del contrato de datos:
 2. actualizacion de `docs/20_data_contracts.md`
 3. cambio en `code/shared/schemas/`
 4. sincronizacion posterior con Kotlin
+
+Si cambias un ejemplo canonico, no edites el JSON a mano: ajusta `schemas/examples/builders.py` y vuelve a generar los archivos.

--- a/code/shared/schemas/examples/__init__.py
+++ b/code/shared/schemas/examples/__init__.py
@@ -1,6 +1,6 @@
-"""Compatibility wrapper for canonical schema example builders."""
+"""Canonical schema examples for Sprout shared contracts."""
 
-from schemas.examples.builders import (
+from .builders import (
     canonical_examples,
     contradiction_alert_example,
     decision_receipt_blocked_example,

--- a/code/shared/schemas/examples/builders.py
+++ b/code/shared/schemas/examples/builders.py
@@ -1,0 +1,247 @@
+"""Canonical example payload builders for shared schemas."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+def rhizome_snapshot_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T14:32:05Z",
+        "origin_node_id": "rhizome_01",
+        "signature": None,
+        "snapshot_id": "snap_rhizome_01_20260416T143205_a3f2",
+        "mode": "normal",
+        "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "active_policy_expires_at": "2026-04-17T08:30:15Z",
+        "sensors": {
+            "soil_moisture_a_pct": 38.2,
+            "soil_moisture_b_pct": 41.7,
+            "tank_level_pct": 72.0,
+            "flow_rate_lpm": 0.0,
+            "last_reading_at": "2026-04-16T14:31:58Z",
+        },
+        "vision": {
+            "last_capture_at": "2026-04-16T14:25:00Z",
+            "parcel_a_status": "healthy",
+            "parcel_b_status": "healthy",
+            "visual_notes": "hojas firmes, color normal en ambas parcelas",
+        },
+        "health": {
+            "cpu_temp_c": 58.4,
+            "cpu_load_pct": 41.0,
+            "ram_used_gb": 4.8,
+            "ram_total_gb": 7.4,
+            "esp32_heartbeat_ok": True,
+            "last_esp32_ack_at": "2026-04-16T14:32:00Z",
+        },
+        "last_decision_id": "rec_rhizome_01_20260416T143000_91ba",
+        "pending_contradictions": [],
+    }
+
+
+def policy_packet_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T08:30:15Z",
+        "origin_node_id": "meristem_01",
+        "signature": None,
+        "policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "target_node_id": "rhizome_01",
+        "valid_until": "2026-04-17T08:30:15Z",
+        "version_chain": [
+            "pkt_rhizome_01_20260415T083015_1234",
+            "pkt_rhizome_01_20260416T083015_d5e7",
+        ],
+        "mode_default": "normal",
+        "rules": {
+            "watering_window": {"start_hour_local": 6, "end_hour_local": 9},
+            "soil_moisture_thresholds": {
+                "parcel_a": {"min_pct": 35.0, "target_pct": 55.0},
+                "parcel_b": {"min_pct": 30.0, "target_pct": 50.0},
+            },
+            "max_watering_duration_s": 45,
+            "daily_water_budget_liters": 8.0,
+            "tank_minimum_pct": 15.0,
+            "require_vision_confirmation": False,
+            "conservative_triggers": [
+                "tank_level_below_30",
+                "no_pollen_visit_48h",
+                "policy_expires_within_3h",
+            ],
+        },
+        "rationale": "Post-lluvia del 15 abril. Humedad general alta. Subir umbrales parcela B que suele retener mas.",
+        "notes": "Primera iteracion tras validacion semanal.",
+    }
+
+
+def policy_delta_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T15:00:00Z",
+        "origin_node_id": "meristem_01",
+        "signature": None,
+        "delta_id": "delta_meristem_01_20260416T150000_c92d",
+        "target_node_id": "rhizome_01",
+        "base_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "patches": [
+            {
+                "op": "replace",
+                "path": "rules.soil_moisture_thresholds.parcel_b.min_pct",
+                "value": 32.0,
+            },
+            {
+                "op": "replace",
+                "path": "rules.daily_water_budget_liters",
+                "value": 10.0,
+            },
+            {
+                "op": "add",
+                "path": "rules.conservative_triggers",
+                "value": "humidity_below_25_forecast",
+            },
+        ],
+        "rationale": "Forecast Pollen trae humedad baja esperada en 24h. Subir budget y anadir trigger.",
+        "ttl_seconds": 86400,
+        "priority": "normal",
+    }
+
+
+def weather_packet_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T12:15:00Z",
+        "origin_node_id": "pollen_01",
+        "signature": None,
+        "packet_id": "pkt_weather_pollen_01_20260416T121500_e7a2",
+        "observed_at": "2026-04-16T11:45:00Z",
+        "observed_by_node_id": "rhizome_02",
+        "provenance": "ferried",
+        "valid_until": "2026-04-16T17:45:00Z",
+        "location": {
+            "lat": 42.1828,
+            "lon": 1.9931,
+            "altitude_m": 1100,
+            "label": "Castellar de n'Hug, parcela A",
+        },
+        "measurements": {
+            "temperature_c": 18.4,
+            "humidity_rel_pct": 62.0,
+            "pressure_hpa": 1013.5,
+            "rain_last_1h_mm": 0.0,
+            "rain_last_24h_mm": 2.4,
+            "wind_speed_kmh": 8.2,
+            "wind_direction_deg": 220,
+            "solar_radiation_wm2": 485,
+            "uv_index": 4.8,
+        },
+        "confidence": 0.85,
+        "notes": "Estacion WS90 en rhizome_02. Ultima calibracion hace 3 semanas.",
+    }
+
+
+def contradiction_alert_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T13:22:30Z",
+        "origin_node_id": "pollen_01",
+        "signature": None,
+        "alert_id": "alert_pollen_01_20260416T132230_f108",
+        "target_node_id": "rhizome_01",
+        "contradiction_type": "sensor_vs_vision",
+        "severity": "warning",
+        "observed_at": "2026-04-16T13:20:00Z",
+        "evidence": {
+            "sensor_reading": {
+                "source": "snap_rhizome_01_20260416T131800_4c5e",
+                "soil_moisture_a_pct": 42.0,
+            },
+            "vision_reading": {
+                "source": "pollen_capture_20260416T132015",
+                "assessment": "severe_stress",
+                "notes": "Hojas claramente caidas en parcela A, decoloracion en los bordes.",
+            },
+        },
+        "recommended_action": "defer_and_review",
+        "expires_at": "2026-04-16T19:22:30Z",
+        "rationale": "Humedad 42% es razonable en estacion seca, pero el estado visual indica estres claro. Puede haber sensor mal calibrado o problema de raiz.",
+    }
+
+
+def decision_receipt_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T14:30:10Z",
+        "origin_node_id": "rhizome_01",
+        "signature": None,
+        "decision_id": "rec_rhizome_01_20260416T143010_91ba",
+        "snapshot_id": "snap_rhizome_01_20260416T143005_a3f2",
+        "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "action": "WATER_A",
+        "action_params": {"duration_s": 30, "expected_liters": 1.5},
+        "rationale_short": "Humedad A en 38%, por debajo del umbral 45%. Dentro de ventana de riego. Deposito al 72%.",
+        "rationale_full": "El snapshot reciente muestra humedad parcela A al 38.2%, umbral minimo 45% segun politica vigente. Hora local dentro de ventana 06-09. Deposito al 72%. Vision confirma planta sana.",
+        "policy_refs": [
+            "rules.soil_moisture_thresholds.parcel_a.min_pct",
+            "rules.watering_window",
+            "rules.tank_minimum_pct",
+        ],
+        "contradictions": [],
+        "confidence": 0.87,
+        "executed": True,
+        "execution_details": {
+            "sent_to_esp32_at": "2026-04-16T14:30:10Z",
+            "esp32_ack_at": "2026-04-16T14:30:11Z",
+            "esp32_ack_status": "OK",
+            "actual_duration_s": 30.2,
+            "flow_observed_lpm": 3.1,
+            "estimated_liters_actual": 1.56,
+        },
+        "blocked_reason": None,
+    }
+
+
+def decision_receipt_blocked_example() -> dict:
+    return {
+        "schema_version": "1.0",
+        "created_at": "2026-04-16T17:05:40Z",
+        "origin_node_id": "rhizome_01",
+        "signature": None,
+        "decision_id": "rec_rhizome_01_20260416T170540_6f4c",
+        "snapshot_id": "snap_rhizome_01_20260416T170500_77ae",
+        "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+        "action": "BLOCK",
+        "action_params": {
+            "blocked_action": "WATER_A",
+            "reason": "tank_minimum_pct reached",
+        },
+        "rationale_short": "Riego bloqueado: deposito al 11%, por debajo del minimo de seguridad.",
+        "rationale_full": "El snapshot reporta deposito al 11%, por debajo del 15% exigido por la politica activa. Aunque la parcela A esta seca, Rhizome no envia comando al ESP32 y eleva bloqueo preventivo.",
+        "policy_refs": [
+            "rules.soil_moisture_thresholds.parcel_a.min_pct",
+            "rules.tank_minimum_pct",
+        ],
+        "contradictions": ["alert_pollen_01_20260416T132230_f108"],
+        "confidence": 0.94,
+        "executed": False,
+        "execution_details": None,
+        "blocked_reason": "tank_below_minimum_pct",
+    }
+
+
+def canonical_examples() -> dict[str, dict]:
+    return {
+        "rhizome_snapshot": deepcopy(rhizome_snapshot_example()),
+        "policy_packet": deepcopy(policy_packet_example()),
+        "policy_delta": deepcopy(policy_delta_example()),
+        "weather_packet": deepcopy(weather_packet_example()),
+        "contradiction_alert": deepcopy(contradiction_alert_example()),
+        "decision_receipt": deepcopy(decision_receipt_example()),
+    }
+
+
+def supplemental_examples() -> dict[str, dict]:
+    return {
+        "decision_receipt_blocked": deepcopy(decision_receipt_blocked_example()),
+    }

--- a/code/shared/schemas/examples/contradiction_alert.json
+++ b/code/shared/schemas/examples/contradiction_alert.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T13:22:30Z",
+  "origin_node_id": "pollen_01",
+  "signature": null,
+  "alert_id": "alert_pollen_01_20260416T132230_f108",
+  "target_node_id": "rhizome_01",
+  "contradiction_type": "sensor_vs_vision",
+  "severity": "warning",
+  "observed_at": "2026-04-16T13:20:00Z",
+  "evidence": {
+    "sensor_reading": {
+      "source": "snap_rhizome_01_20260416T131800_4c5e",
+      "soil_moisture_a_pct": 42.0
+    },
+    "vision_reading": {
+      "source": "pollen_capture_20260416T132015",
+      "assessment": "severe_stress",
+      "notes": "Hojas claramente caidas en parcela A, decoloracion en los bordes."
+    }
+  },
+  "recommended_action": "defer_and_review",
+  "expires_at": "2026-04-16T19:22:30Z",
+  "rationale": "Humedad 42% es razonable en estacion seca, pero el estado visual indica estres claro. Puede haber sensor mal calibrado o problema de raiz."
+}

--- a/code/shared/schemas/examples/decision_receipt.json
+++ b/code/shared/schemas/examples/decision_receipt.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T14:30:10Z",
+  "origin_node_id": "rhizome_01",
+  "signature": null,
+  "decision_id": "rec_rhizome_01_20260416T143010_91ba",
+  "snapshot_id": "snap_rhizome_01_20260416T143005_a3f2",
+  "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+  "action": "WATER_A",
+  "action_params": {
+    "duration_s": 30,
+    "expected_liters": 1.5
+  },
+  "rationale_short": "Humedad A en 38%, por debajo del umbral 45%. Dentro de ventana de riego. Deposito al 72%.",
+  "rationale_full": "El snapshot reciente muestra humedad parcela A al 38.2%, umbral minimo 45% segun politica vigente. Hora local dentro de ventana 06-09. Deposito al 72%. Vision confirma planta sana.",
+  "policy_refs": [
+    "rules.soil_moisture_thresholds.parcel_a.min_pct",
+    "rules.watering_window",
+    "rules.tank_minimum_pct"
+  ],
+  "contradictions": [],
+  "confidence": 0.87,
+  "executed": true,
+  "execution_details": {
+    "sent_to_esp32_at": "2026-04-16T14:30:10Z",
+    "esp32_ack_at": "2026-04-16T14:30:11Z",
+    "esp32_ack_status": "OK",
+    "actual_duration_s": 30.2,
+    "flow_observed_lpm": 3.1,
+    "estimated_liters_actual": 1.56
+  },
+  "blocked_reason": null
+}

--- a/code/shared/schemas/examples/decision_receipt_blocked.json
+++ b/code/shared/schemas/examples/decision_receipt_blocked.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T17:05:40Z",
+  "origin_node_id": "rhizome_01",
+  "signature": null,
+  "decision_id": "rec_rhizome_01_20260416T170540_6f4c",
+  "snapshot_id": "snap_rhizome_01_20260416T170500_77ae",
+  "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+  "action": "BLOCK",
+  "action_params": {
+    "blocked_action": "WATER_A",
+    "reason": "tank_minimum_pct reached"
+  },
+  "rationale_short": "Riego bloqueado: deposito al 11%, por debajo del minimo de seguridad.",
+  "rationale_full": "El snapshot reporta deposito al 11%, por debajo del 15% exigido por la politica activa. Aunque la parcela A esta seca, Rhizome no envia comando al ESP32 y eleva bloqueo preventivo.",
+  "policy_refs": [
+    "rules.soil_moisture_thresholds.parcel_a.min_pct",
+    "rules.tank_minimum_pct"
+  ],
+  "contradictions": [
+    "alert_pollen_01_20260416T132230_f108"
+  ],
+  "confidence": 0.94,
+  "executed": false,
+  "execution_details": null,
+  "blocked_reason": "tank_below_minimum_pct"
+}

--- a/code/shared/schemas/examples/generate_examples.py
+++ b/code/shared/schemas/examples/generate_examples.py
@@ -1,0 +1,110 @@
+"""Generate canonical JSON examples from the Pydantic models."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from schemas import (
+    ContradictionAlert,
+    DecisionReceipt,
+    PolicyDelta,
+    PolicyPacket,
+    RhizomeSnapshot,
+    WeatherPacket,
+)
+from schemas.examples.builders import (
+    contradiction_alert_example,
+    decision_receipt_blocked_example,
+    decision_receipt_example,
+    policy_delta_example,
+    policy_packet_example,
+    rhizome_snapshot_example,
+    weather_packet_example,
+)
+
+EXAMPLES_DIR = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class ExampleSpec:
+    filename: str
+    model_cls: type
+    payload_factory: Callable[[], dict]
+
+
+CORE_EXAMPLE_SPECS = (
+    ExampleSpec("rhizome_snapshot.json", RhizomeSnapshot, rhizome_snapshot_example),
+    ExampleSpec("policy_packet.json", PolicyPacket, policy_packet_example),
+    ExampleSpec("policy_delta.json", PolicyDelta, policy_delta_example),
+    ExampleSpec("weather_packet.json", WeatherPacket, weather_packet_example),
+    ExampleSpec("contradiction_alert.json", ContradictionAlert, contradiction_alert_example),
+    ExampleSpec("decision_receipt.json", DecisionReceipt, decision_receipt_example),
+)
+
+SUPPLEMENTAL_EXAMPLE_SPECS = (
+    ExampleSpec("decision_receipt_blocked.json", DecisionReceipt, decision_receipt_blocked_example),
+)
+
+ALL_EXAMPLE_SPECS = CORE_EXAMPLE_SPECS + SUPPLEMENTAL_EXAMPLE_SPECS
+
+
+def render_example(spec: ExampleSpec) -> str:
+    payload = spec.payload_factory()
+    parsed = spec.model_cls.model_validate(payload)
+    canonical_payload = parsed.model_dump(mode="json")
+    return json.dumps(canonical_payload, indent=2, ensure_ascii=True) + "\n"
+
+
+def write_examples() -> list[Path]:
+    written_paths: list[Path] = []
+    for spec in ALL_EXAMPLE_SPECS:
+        output_path = EXAMPLES_DIR / spec.filename
+        output_path.write_text(render_example(spec), encoding="utf-8")
+        written_paths.append(output_path)
+    return written_paths
+
+
+def stale_examples() -> list[str]:
+    stale: list[str] = []
+    for spec in ALL_EXAMPLE_SPECS:
+        output_path = EXAMPLES_DIR / spec.filename
+        expected = render_example(spec)
+        if not output_path.exists() or output_path.read_text(encoding="utf-8") != expected:
+            stale.append(spec.filename)
+    return stale
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check that the committed JSON files match the generated canonical output.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        stale = stale_examples()
+        if stale:
+            for filename in stale:
+                print(filename)
+            return 1
+        print("All canonical examples are up to date.")
+        return 0
+
+    written_paths = write_examples()
+    for path in written_paths:
+        print(path.name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/shared/schemas/examples/policy_delta.json
+++ b/code/shared/schemas/examples/policy_delta.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T15:00:00Z",
+  "origin_node_id": "meristem_01",
+  "signature": null,
+  "delta_id": "delta_meristem_01_20260416T150000_c92d",
+  "target_node_id": "rhizome_01",
+  "base_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+  "patches": [
+    {
+      "op": "replace",
+      "path": "rules.soil_moisture_thresholds.parcel_b.min_pct",
+      "value": 32.0
+    },
+    {
+      "op": "replace",
+      "path": "rules.daily_water_budget_liters",
+      "value": 10.0
+    },
+    {
+      "op": "add",
+      "path": "rules.conservative_triggers",
+      "value": "humidity_below_25_forecast"
+    }
+  ],
+  "rationale": "Forecast Pollen trae humedad baja esperada en 24h. Subir budget y anadir trigger.",
+  "ttl_seconds": 86400,
+  "priority": "normal"
+}

--- a/code/shared/schemas/examples/policy_packet.json
+++ b/code/shared/schemas/examples/policy_packet.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T08:30:15Z",
+  "origin_node_id": "meristem_01",
+  "signature": null,
+  "policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+  "target_node_id": "rhizome_01",
+  "valid_until": "2026-04-17T08:30:15Z",
+  "version_chain": [
+    "pkt_rhizome_01_20260415T083015_1234",
+    "pkt_rhizome_01_20260416T083015_d5e7"
+  ],
+  "mode_default": "normal",
+  "rules": {
+    "watering_window": {
+      "start_hour_local": 6,
+      "end_hour_local": 9
+    },
+    "soil_moisture_thresholds": {
+      "parcel_a": {
+        "min_pct": 35.0,
+        "target_pct": 55.0
+      },
+      "parcel_b": {
+        "min_pct": 30.0,
+        "target_pct": 50.0
+      }
+    },
+    "max_watering_duration_s": 45,
+    "daily_water_budget_liters": 8.0,
+    "tank_minimum_pct": 15.0,
+    "require_vision_confirmation": false,
+    "conservative_triggers": [
+      "tank_level_below_30",
+      "no_pollen_visit_48h",
+      "policy_expires_within_3h"
+    ]
+  },
+  "rationale": "Post-lluvia del 15 abril. Humedad general alta. Subir umbrales parcela B que suele retener mas.",
+  "notes": "Primera iteracion tras validacion semanal."
+}

--- a/code/shared/schemas/examples/rhizome_snapshot.json
+++ b/code/shared/schemas/examples/rhizome_snapshot.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T14:32:05Z",
+  "origin_node_id": "rhizome_01",
+  "signature": null,
+  "snapshot_id": "snap_rhizome_01_20260416T143205_a3f2",
+  "mode": "normal",
+  "active_policy_id": "pkt_rhizome_01_20260416T083015_d5e7",
+  "active_policy_expires_at": "2026-04-17T08:30:15Z",
+  "sensors": {
+    "soil_moisture_a_pct": 38.2,
+    "soil_moisture_b_pct": 41.7,
+    "tank_level_pct": 72.0,
+    "flow_rate_lpm": 0.0,
+    "last_reading_at": "2026-04-16T14:31:58Z"
+  },
+  "vision": {
+    "last_capture_at": "2026-04-16T14:25:00Z",
+    "parcel_a_status": "healthy",
+    "parcel_b_status": "healthy",
+    "visual_notes": "hojas firmes, color normal en ambas parcelas"
+  },
+  "health": {
+    "cpu_temp_c": 58.4,
+    "cpu_load_pct": 41.0,
+    "ram_used_gb": 4.8,
+    "ram_total_gb": 7.4,
+    "esp32_heartbeat_ok": true,
+    "last_esp32_ack_at": "2026-04-16T14:32:00Z"
+  },
+  "last_decision_id": "rec_rhizome_01_20260416T143000_91ba",
+  "pending_contradictions": []
+}

--- a/code/shared/schemas/examples/weather_packet.json
+++ b/code/shared/schemas/examples/weather_packet.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T12:15:00Z",
+  "origin_node_id": "pollen_01",
+  "signature": null,
+  "packet_id": "pkt_weather_pollen_01_20260416T121500_e7a2",
+  "observed_at": "2026-04-16T11:45:00Z",
+  "observed_by_node_id": "rhizome_02",
+  "provenance": "ferried",
+  "valid_until": "2026-04-16T17:45:00Z",
+  "location": {
+    "lat": 42.1828,
+    "lon": 1.9931,
+    "altitude_m": 1100.0,
+    "label": "Castellar de n'Hug, parcela A"
+  },
+  "measurements": {
+    "temperature_c": 18.4,
+    "humidity_rel_pct": 62.0,
+    "pressure_hpa": 1013.5,
+    "rain_last_1h_mm": 0.0,
+    "rain_last_24h_mm": 2.4,
+    "wind_speed_kmh": 8.2,
+    "wind_direction_deg": 220.0,
+    "solar_radiation_wm2": 485.0,
+    "uv_index": 4.8
+  },
+  "confidence": 0.85,
+  "notes": "Estacion WS90 en rhizome_02. Ultima calibracion hace 3 semanas."
+}

--- a/code/shared/schemas/tests/test_roundtrip.py
+++ b/code/shared/schemas/tests/test_roundtrip.py
@@ -1,36 +1,35 @@
-"""Tests de round-trip para los schemas compartidos."""
+"""Round-trip tests for committed canonical shared-schema examples."""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
-from schemas import (
-    ContradictionAlert,
-    DecisionReceipt,
-    PolicyDelta,
-    PolicyPacket,
-    RhizomeSnapshot,
-    WeatherPacket,
-)
-from schemas.tests.factories import canonical_examples
-
-MODEL_BY_NAME = {
-    "rhizome_snapshot": RhizomeSnapshot,
-    "policy_packet": PolicyPacket,
-    "policy_delta": PolicyDelta,
-    "weather_packet": WeatherPacket,
-    "contradiction_alert": ContradictionAlert,
-    "decision_receipt": DecisionReceipt,
-}
+from schemas.examples.generate_examples import ALL_EXAMPLE_SPECS, CORE_EXAMPLE_SPECS, EXAMPLES_DIR, stale_examples
 
 
-@pytest.mark.parametrize("name", sorted(MODEL_BY_NAME))
-def test_canonical_examples_roundtrip(name: str) -> None:
-    model_cls = MODEL_BY_NAME[name]
-    payload = canonical_examples()[name]
+def _example_path(filename: str) -> Path:
+    return EXAMPLES_DIR / filename
 
-    parsed = model_cls.model_validate(payload)
+
+@pytest.mark.parametrize("spec", CORE_EXAMPLE_SPECS, ids=lambda spec: spec.filename)
+def test_required_core_examples_exist(spec) -> None:
+    assert _example_path(spec.filename).exists()
+
+
+@pytest.mark.parametrize("spec", ALL_EXAMPLE_SPECS, ids=lambda spec: spec.filename)
+def test_committed_examples_roundtrip(spec) -> None:
+    payload = json.loads(_example_path(spec.filename).read_text(encoding="utf-8"))
+
+    parsed = spec.model_cls.model_validate(payload)
     dumped = parsed.model_dump(mode="json")
-    reparsed = model_cls.model_validate(dumped)
+    reparsed = spec.model_cls.model_validate(dumped)
 
+    assert dumped == payload
     assert reparsed.model_dump(mode="json") == dumped
+
+
+def test_generated_examples_are_up_to_date() -> None:
+    assert stale_examples() == []

--- a/code/shared/schemas/tests/test_validation.py
+++ b/code/shared/schemas/tests/test_validation.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from schemas import ContradictionAlert, DecisionReceipt, PolicyDelta, PolicyPacket, RhizomeSnapshot, WeatherPacket
-from schemas.tests.factories import (
+from schemas.examples.builders import (
     contradiction_alert_example,
     decision_receipt_example,
     policy_delta_example,


### PR DESCRIPTION
Closes #2

## Resumen
Genera y commitea los 6 ejemplos canonicos JSON que Floema y Meristem usaran como fixtures cross-language. Suma `decision_receipt_blocked.json` como caso suplementario para cubrir `executed=false` con `blocked_reason`.

## Que incluye
- `code/shared/schemas/examples/` como parte estable del paquete
- `builders.py` expone los builders canonicos programaticamente
- `generate_examples.py` regenera los .json de forma reproducible
- 6 JSON core + decision_receipt_blocked.json
- `factories.py` mantiene API de compatibilidad (no rompe imports)
- Tests actualizados: validan ficheros commiteados y chequean que generador no esta desfasado
- Makefile con `make examples` (regenera) y `make examples-check` (verifica sincronizacion)
- README shared actualizado
- Bitacora con nota sobre drift de nombres (_01 en docs vs nombres del issue)

## Testing
```
python -m schemas.examples.generate_examples --check
python -m pytest schemas/tests
# 33 passed
```

## Nota de revisor
La rama parte de un estado pre-squash de PR #13, asi que el diff visual puede mostrar archivos ya presentes en main. El **cambio neto** tras squash-merge es solo el directorio examples/ + actualizaciones de tests/Makefile/README. Verificar con `git diff main...HEAD -- code/shared/schemas/examples/`.