### PR TITLE
feat(pollen): UI splitscreen Rhizome/Policy con TTL rojo

### DIFF
--- a/bitacora/2026-04-18_pollen-ui-splitscreen_floema.md
+++ b/bitacora/2026-04-18_pollen-ui-splitscreen_floema.md
@@ -1,0 +1,13 @@
+# 2026-04-18: Implementación de UI Splitscreen (PR #9)
+
+**Nodo:** Pollen
+**Autora:** Floema
+**Referencia:** Issue #9
+
+## Cambios realizados
+- **Pantalla Partida (SplitscreenDash):** Creada utilizando `Jetpack Compose`. La vista distribuye el espacio horizontal en modo vertical, asignando el 50% superior a los estados de `Rhizome` y el 50% inferior a la métrica de `Active Policy`.
+- **Integración de Capa Falsa:** Instanciado el `RhizomeMockClient` dentro de la UI para extraer propiedades como la mode, tank level, y el `rationale_short` del `DecisionReceipt`.
+- **Feedback visual de TTL:** He añadido un cronómetro simulado manejado mediante corrutinas de Kotlin (`LaunchedEffect` y `delay(1000)`). El tiempo de `Duration.between` se calcula dinámicamente frente al `activePolicyExpiresAt`. Si el margen restante es inferior al 20% del valor inicial, la tipografía del cronómetro cambia a `Color.Red` indicando la zona crítica.
+
+## Limitaciones de Entorno
+Debido a la ausencia de acceso a un Android Emulator ni binarios del wrapper de Gradle compilados en mi entorno de *workspace* estático, la implementación de UI ha sido generada de manera puramente estática. **No he podido compilar el módulo de Jetpack Compose (`./gradlew build`)**. Por consiguiente, la verificación de comportamiento en base a la recomposición jerárquica dependerá absolutamente de comprobaciones por vuestro lado en la Pull Request o requiriendo a posteriori que Cambium levante el contenedor Android local para validarlo.

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/MainActivity.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/MainActivity.kt
@@ -1,0 +1,26 @@
+package net.sprout.pollen
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import net.sprout.pollen.ui.SplitscreenDash
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    SplitscreenDash()
+                }
+            }
+        }
+    }
+}

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/SplitscreenDash.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/SplitscreenDash.kt
@@ -1,0 +1,110 @@
+package net.sprout.pollen.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import net.sprout.pollen.schemas.DecisionReceipt
+import net.sprout.pollen.schemas.RhizomeSnapshot
+import net.sprout.pollen.sync.RhizomeMockClient
+import java.time.Instant
+import java.time.Duration
+import kotlinx.coroutines.delay
+
+@Composable
+fun SplitscreenDash() {
+    val mockClient = remember { RhizomeMockClient() }
+    val snapshot = remember { mockClient.getSnapshot() }
+    val receipt = remember { mockClient.getDecisionReceipt() }
+    
+    // Simulate current time progression to illustrate TTL countdown
+    var currentTime by remember { mutableStateOf(Instant.parse(snapshot.createdAt)) }
+    
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000)
+            currentTime = currentTime.plusSeconds(60) // Accelerate time for testing visual updates
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Upper Half: Rhizome State & rationale_short
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            RhizomeStatePanel(snapshot, receipt)
+        }
+
+        Divider(color = Color.DarkGray, thickness = 2.dp)
+
+        // Lower Half: Active Policy & TTL
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            ActivePolicyPanel(snapshot, currentTime)
+        }
+    }
+}
+
+@Composable
+fun RhizomeStatePanel(snapshot: RhizomeSnapshot, receipt: DecisionReceipt) {
+    Column {
+        Text(text = "Rhizome State", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(text = "Mode: ${snapshot.mode}")
+        Text(text = "Tank Level: ${snapshot.sensors.tankLevelPct}%")
+        Text(text = "Soil A/B: ${snapshot.sensors.soilMoistureAPct}% / ${snapshot.sensors.soilMoistureBPct}%")
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = "Last Decision", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(text = "Action: ${receipt.action}")
+        Text(text = "Rationale: ${receipt.rationaleShort}", color = Color.Gray)
+    }
+}
+
+@Composable
+fun ActivePolicyPanel(snapshot: RhizomeSnapshot, currentTime: Instant) {
+    val creationTime = Instant.parse(snapshot.createdAt) // Roughly when policy was activated for this calculation
+    val expiryTime = Instant.parse(snapshot.activePolicyExpiresAt)
+    val totalDuration = Duration.between(creationTime, expiryTime).seconds
+    val remainingDuration = Duration.between(currentTime, expiryTime).seconds
+    
+    // Critical zone is < 20%
+    val isCritical = if (totalDuration > 0) {
+        remainingDuration.toDouble() / totalDuration < 0.20
+    } else {
+        true
+    }
+
+    val ttlColor = if (isCritical) Color.Red else Color.Unspecified
+
+    Column {
+        Text(text = "Active Policy", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(text = "ID: ${snapshot.activePolicyId}")
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        Text(text = "TTL Indicator", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(
+            text = "Expires at: ${snapshot.activePolicyExpiresAt}",
+            color = ttlColor,
+            fontWeight = if (isCritical) FontWeight.Bold else FontWeight.Normal
+        )
+        Text(
+            text = if (remainingDuration > 0) "Remaining TTL: $remainingDuration seconds" else "POLICY EXPIRED",
+            color = ttlColor,
+            fontWeight = if (isCritical) FontWeight.Bold else FontWeight.Normal
+        )
+    }
+}


### PR DESCRIPTION
Closes #9

## Estado: HOLD hasta que CI pase

Autora declaró no poder compilar en su entorno (sin Android SDK ni Gradle wrapper inicializable). No mergear hasta que el workflow de CI (issue pendiente de crear) valide build + tests.

## Que incluye

- `MainActivity.kt` — entrypoint Compose
- `ui/SplitscreenDash.kt` — layout dividido con `Column + Box + Divider`
  - Mitad superior: `RhizomeStatePanel` con mode, tank level, soil moisture, ultima decision (action + rationale_short)
  - Mitad inferior: `ActivePolicyPanel` con ID de policy activa, TTL remaining, texto/peso en rojo cuando `remaining/total < 0.20`
- `LaunchedEffect` con bucle `delay(1000)` que avanza el reloj 60s cada segundo (solo para ilustrar el cambio visual; no es produccion)

## Dependencias de schema

Usa nombres de campo que deben existir en los data classes Kotlin mergeados en PR #18:
- `snapshot.mode`, `snapshot.sensors.tankLevelPct`, `snapshot.sensors.soilMoistureAPct/BPct`
- `snapshot.activePolicyId`, `snapshot.activePolicyExpiresAt`
- `receipt.action`, `receipt.rationaleShort`

El CI verifica si encajan. Si no, error de compilacion → Floema corrige.

## Checklist pre-merge

- [ ] Workflow CI Android montado (issue aparte, Cambium)
- [ ] Build con `./gradlew build` pasa en CI
- [ ] Tests de instrumentacion (o al menos unitarios de Compose) pasan en CI
- [ ] Verificacion visual del splitscreen con TTL critico (manual o screenshot test)