### PR TITLE
docs(contributing): formaliza naming de ejemplos canonicos (#23)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,21 @@ Seguir [guia oficial de naming de Google](https://ai.google/documents/32/Externa
 - `fix/<zona>-<descripcion>` = bugfixes
 - Ejemplo: `feat/rhizome-audio-sensor`
 
+### Ejemplos canonicos (fixtures JSON)
+
+Viven en `code/shared/examples/`. Regla:
+
+- `<schema>.json` = fixture canonico unico por schema. Es el ejemplo de referencia,
+  el que se usa en tests y documentacion. Un solo archivo por schema.
+  Ejemplos: `rhizome_snapshot.json`, `weather_packet.json`, `policy_packet.json`.
+- `<schema>_<variante>.json` = variantes deliberadas que cubren un caso distinto
+  al canonico (estado de bloqueo, contradiccion, modo conservador, etc.).
+  Ejemplos: `decision_receipt_blocked.json`, `contradiction_alert_sensor_vs_vision.json`.
+
+**Regla dura:** si anades una variante, debe quedar claro en el nombre que varianta
+del canonico es. No metas campos nuevos al canonico solo para cubrir un caso;
+crea una variante.
+
 ---
 
 ## 7. Secretos y credenciales

--- a/code/shared/README.md
+++ b/code/shared/README.md
@@ -37,6 +37,12 @@ shared/
 - Los JSON canonicos se generan con `python schemas/examples/generate_examples.py`
 - Los round-trips Python viven en `schemas/tests/`
 
+### Naming de ejemplos
+
+Convencion formalizada en [CONTRIBUTING §6](../../CONTRIBUTING.md#6-convenciones-de-naming):
+- `<schema>.json` = canonico unico por schema
+- `<schema>_<variante>.json` = variantes deliberadas (caso de bloqueo, contradiccion, etc.)
+
 ## Validacion
 
 ### Python (Rhizome, Meristem)


### PR DESCRIPTION
## Summary

- CONTRIBUTING §6: subseccion nueva "Ejemplos canonicos (fixtures JSON)" con la convencion `<schema>.json` / `<schema>_<variante>.json`
- `code/shared/README.md`: cross-ref a CONTRIBUTING §6

## Contexto

La convencion ya se practicaba en PR #19 (Xilema) pero no estaba formalizada. Este PR la fija para futuros.

## Test plan

- [x] Doc-only, sin impacto en code
- [x] Enlaces markdown validos

Closes #23