### PR TITLE
feat(pollen): GemmaEngine stub + stream a SplitscreenDash (closes #10)

### DIFF
--- a/bitacora/2026-04-18_pollen-gemma-engine-10_floema.md
+++ b/bitacora/2026-04-18_pollen-gemma-engine-10_floema.md
@@ -1,0 +1,14 @@
+# 2026-04-18: Implementación de Gemma Engine (PR #10)
+
+**Nodo:** Pollen
+**Autora:** Floema
+**Referencia:** Issue #10
+
+## Cambios realizados
+- **Motor de Inferencia (GemmaEngine):** Se ha estructurado el empaquetado de la clase `GemmaEngine` bajo `net.sprout.pollen.inference`. Esta clase recibe en su inicialización el `Context` del runtime de Android (pensando en instanciar el `LlmInference` de MediaPipe en un futuro cercano).
+- **Flujo de Auditoría (runAudit):** Se definió el método `runAudit` tomando como entrada `RhizomeSnapshot` y `DecisionReceipt`. Retorna un objeto asíncrono tipado como `Flow<AuditEvent>`. 
+- **Mocking temporal:** De acuerdo con las limitaciones del entorno estático y preparando el camino para el peso (MBs) de los tensores base (`gemma-4-e2b.bin`), actualmente el motor emula el *Time-To-First-Token* y la latencia inter-token utilizando corrutinas simuladas (`delay`). El resultado se mapea correctamente sobre la estructura sellada `AuditResult.NoDiscrepancy` tal y como manda el contrato de datos.
+- **Integración UI (PollenViewModel):** Construida la persistencia de estado con `ViewModel` y combinada en los elementos de Composition local (`SplitscreenDash.kt`), renderizando en directo cada uno de los tokens emitidos.
+
+## Validación
+Al publicarse en rama `feat/pollen-gemma-engine-10`, me apoyo en el pipeline oficial (`pollen-ci.yml`) recién configurado por Cambium. El código no levanta aserciones lógicas complejas ni dependencias C++ cruzadas, por lo que el test unitario y la instrumentación de Kotlin en GitHub Actions debe dar luz verde. Quedo a la espera del reporte CI.

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/MainActivity.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/MainActivity.kt
@@ -8,17 +8,23 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import net.sprout.pollen.ui.SplitscreenDash
+import net.sprout.pollen.ui.PollenViewModel
+import net.sprout.pollen.inference.GemmaEngine
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        val engine = GemmaEngine(this)
+        val viewModel = PollenViewModel(engine)
+
         setContent {
             MaterialTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    SplitscreenDash()
+                    SplitscreenDash(viewModel)
                 }
             }
         }

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/inference/GemmaEngine.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/inference/GemmaEngine.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import net.sprout.pollen.schemas.AuditEvent
-import net.sprout.pollen.schemas.AuditResult
 import net.sprout.pollen.schemas.DecisionReceipt
 import net.sprout.pollen.schemas.RhizomeSnapshot
+// AuditEvent / AuditResult viven en el mismo paquete (GemmaContracts.kt),
+// no hace falta import. Fix de compilacion por Cambium (Floema OOO 19-20 abril).
 // import com.google.mediapipe.tasks.genai.llminference.LlmInference
 
 class GemmaEngine(private val context: Context, private val modelPath: String = "/data/local/tmp/gemma-4-e2b.bin") {

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/inference/GemmaEngine.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/inference/GemmaEngine.kt
@@ -1,0 +1,46 @@
+package net.sprout.pollen.inference
+
+import android.content.Context
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import net.sprout.pollen.schemas.AuditEvent
+import net.sprout.pollen.schemas.AuditResult
+import net.sprout.pollen.schemas.DecisionReceipt
+import net.sprout.pollen.schemas.RhizomeSnapshot
+// import com.google.mediapipe.tasks.genai.llminference.LlmInference
+
+class GemmaEngine(private val context: Context, private val modelPath: String = "/data/local/tmp/gemma-4-e2b.bin") {
+
+    // private var llmInference: LlmInference? = null
+    // init { 
+    //     // Setup LlmInference. LlmInferenceOptions...
+    // }
+
+    fun runAudit(snapshot: RhizomeSnapshot, receipt: DecisionReceipt): Flow<AuditEvent> = flow {
+        // Here we format the prompt using the data schemas.
+        val prompt = buildString {
+            appendLine("Role: You are Pollen, an auditor node using Gemma 4 E2B.")
+            appendLine("Task: Analyze Rhizome's rationale against its metrics.")
+            appendLine("Rhizome Snapshot: Mode=${snapshot.mode}, Tank=${snapshot.sensors.tankLevelPct}%, Moisture A/B=${snapshot.sensors.soilMoistureAPct}%/${snapshot.sensors.soilMoistureBPct}%")
+            appendLine("Decision: ${receipt.action} - Rationale: ${receipt.rationaleShort}")
+        }
+
+        // Simulating the prompt processing delay
+        delay(500)
+
+        // Simulating token streaming from MediaPipe
+        val simulatedResponse = "Analyzing Rhizome decision...\nMetrics align with conservative threshold logic.\nNo conflicts found in the policy execution.\nConclusion: No discrepancy."
+        val tokens = simulatedResponse.split(" ")
+        
+        for (i in tokens.indices) {
+            val tokenStr = tokens[i] + if (i < tokens.size - 1) " " else ""
+            emit(AuditEvent.Token(tokenStr))
+            delay(150) // Simulating TTFT and inter-token latency
+        }
+        
+        // Simulating the structured JSON parse from the output text
+        delay(300)
+        emit(AuditEvent.Done(AuditResult.NoDiscrepancy(rationale = "Metrics align with conservative threshold logic. No conflicts found in the policy execution.")))
+    }
+}

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/PollenViewModel.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/PollenViewModel.kt
@@ -1,0 +1,48 @@
+package net.sprout.pollen.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import net.sprout.pollen.inference.AuditEvent
+import net.sprout.pollen.inference.AuditResult
+import net.sprout.pollen.inference.GemmaEngine
+import net.sprout.pollen.schemas.DecisionReceipt
+import net.sprout.pollen.schemas.RhizomeSnapshot
+
+sealed class AuditUiState {
+    object Idle : AuditUiState()
+    object Loading : AuditUiState()
+    data class Streaming(val text: String) : AuditUiState()
+    data class Done(val text: String, val result: AuditResult) : AuditUiState()
+    data class Error(val message: String) : AuditUiState()
+}
+
+class PollenViewModel(private val engine: GemmaEngine) : ViewModel() {
+    private val _uiState = MutableStateFlow<AuditUiState>(AuditUiState.Idle)
+    val uiState: StateFlow<AuditUiState> = _uiState.asStateFlow()
+
+    fun runAudit(snapshot: RhizomeSnapshot, receipt: DecisionReceipt) {
+        viewModelScope.launch {
+            _uiState.value = AuditUiState.Loading
+            try {
+                var accumulatedText = ""
+                engine.runAudit(snapshot, receipt).collect { event ->
+                    when (event) {
+                        is AuditEvent.Token -> {
+                            accumulatedText += event.s
+                            _uiState.value = AuditUiState.Streaming(accumulatedText)
+                        }
+                        is AuditEvent.Done -> {
+                            _uiState.value = AuditUiState.Done(accumulatedText, event.result)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                _uiState.value = AuditUiState.Error(e.localizedMessage ?: "Unknown error during inference")
+            }
+        }
+    }
+}

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/SplitscreenDash.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/SplitscreenDash.kt
@@ -16,12 +16,17 @@ import net.sprout.pollen.sync.RhizomeMockClient
 import java.time.Instant
 import java.time.Duration
 import kotlinx.coroutines.delay
+import net.sprout.pollen.inference.GemmaEngine
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.ViewModelProvider
 
 @Composable
-fun SplitscreenDash() {
+fun SplitscreenDash(viewModel: PollenViewModel) {
     val mockClient = remember { RhizomeMockClient() }
     val snapshot = remember { mockClient.getSnapshot() }
     val receipt = remember { mockClient.getDecisionReceipt() }
+    
+    val auditState by viewModel.uiState.collectAsState()
     
     // Simulate current time progression to illustrate TTL countdown
     var currentTime by remember { mutableStateOf(Instant.parse(snapshot.createdAt)) }
@@ -46,6 +51,20 @@ fun SplitscreenDash() {
 
         Divider(color = Color.DarkGray, thickness = 2.dp)
 
+        // Middle Half: Audit Streamer
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            AuditPanel(auditState) {
+                viewModel.runAudit(snapshot, receipt)
+            }
+        }
+
+        Divider(color = Color.DarkGray, thickness = 2.dp)
+
         // Lower Half: Active Policy & TTL
         Box(
             modifier = Modifier
@@ -54,6 +73,38 @@ fun SplitscreenDash() {
                 .padding(16.dp)
         ) {
             ActivePolicyPanel(snapshot, currentTime)
+        }
+    }
+}
+
+@Composable
+fun AuditPanel(state: AuditUiState, onRunAudit: () -> Unit) {
+    Column {
+        Text(text = "Gemma 4 Auditor", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(8.dp))
+        when (state) {
+            is AuditUiState.Idle -> {
+                androidx.compose.material3.Button(onClick = onRunAudit) {
+                    Text("Run Audit")
+                }
+            }
+            is AuditUiState.Loading -> {
+                Text("Loading model context...", color = Color.Gray)
+            }
+            is AuditUiState.Streaming -> {
+                Text(state.text, style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+                // Simulated generic loading indicator via text
+                Text("[Streaming...]", color = Color.Blue)
+            }
+            is AuditUiState.Done -> {
+                Text(state.text, style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+                Text("Result: ${state.result}", color = Color.Green, fontWeight = FontWeight.Bold)
+            }
+            is AuditUiState.Error -> {
+                Text("Error: ${state.message}", color = Color.Red)
+            }
         }
     }
 }

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/SplitscreenDash.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/SplitscreenDash.kt
@@ -17,8 +17,8 @@ import java.time.Instant
 import java.time.Duration
 import kotlinx.coroutines.delay
 import net.sprout.pollen.inference.GemmaEngine
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.lifecycle.ViewModelProvider
+// androidx.lifecycle.viewmodel.compose.viewModel / ViewModelProvider eran
+// imports sin uso y requerian dependencia no declarada. Removidos por Cambium.
 
 @Composable
 fun SplitscreenDash(viewModel: PollenViewModel) {


### PR DESCRIPTION
## Contexto

PR abierto por Cambium en nombre de Floema tras verificar que la rama `feat/pollen-gemma-engine-10` ya estaba pushed a origin pero sin PR asociada (detectado en la tarde del dia 4). La rama trae el stub de `GemmaEngine` + cableado al `PollenViewModel` y a `SplitscreenDash`, tal y como Floema describio en su mensaje de esta tarde.

Closes #10.

## Cambios

- `code/pollen/app/src/main/kotlin/net/sprout/pollen/inference/GemmaEngine.kt` — stub con `Flow<AuditEvent>` simulando el stream de inferencia.
- `code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/PollenViewModel.kt` — engancha el stream al estado observado por `SplitscreenDash`.
- `code/pollen/app/src/main/kotlin/net/sprout/pollen/MainActivity.kt` — inyeccion del ViewModel.
- `code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/SplitscreenDash.kt` — lectura del stream y render incremental.
- `bitacora/2026-04-18_pollen-gemma-engine-10_floema.md` — entrada de Floema con decisiones y fuera de alcance.

## Test plan

- [ ] CI `pollen-ci` verde (assembleDebug + testDebugUnitTest)
- [ ] Review visual del stream simulado cuando Floema tenga APK instrumentado

## Nota de autoria

Commits de la rama firmados por Floema. Cambium solo abre el contenedor de revision porque el paso `gh pr create` se le paso en el flujo local.