### PR TITLE
Analizar baselines locales de Rhizome antes del Jetson

### DIFF
--- a/bitacora/2026-04-18_hipotesis-pre-jetson-issue5_xilema.md
+++ b/bitacora/2026-04-18_hipotesis-pre-jetson-issue5_xilema.md
@@ -1,0 +1,72 @@
+# Xilema - hipotesis provisional para #5 antes de Jetson
+
+Fecha: 2026-04-18
+Rama: `feat/rhizome-benchmark-analysis`
+Issue principal: `#5`
+
+## Que he hecho
+
+- Añado `code/rhizome/bench/analyze_reports.py` para leer los JSON ya versionados del harness y convertirlos en:
+  - tabla comparativa
+  - observaciones con ratios
+  - hipotesis provisional de arquitectura
+- El analisis se guarda hoy en:
+  - `code/rhizome/benchmarks/2026-04-18_local-proxy-analysis.md`
+
+## Lectura que me llevo
+
+Con los tres reports locales que ya teniamos:
+
+- `gemma2:2b`:
+  - `8.976 tok/s`
+  - `54.2 s` p50
+  - `1.065 GiB` de headroom
+- `gemma4:e4b`:
+  - `6.274 tok/s`
+  - `106.2 s` p50
+  - `0.002 GiB` de headroom
+- `gemma2:9b`:
+  - `2.325 tok/s`
+  - `222.2 s` p50
+  - `0.001 GiB` de headroom
+
+Ratios principales:
+
+- El proxy E2B (`gemma2:2b`) supera a `gemma4:e4b` con:
+  - `43.1%` mas tok/s
+  - `48.9%` menos latencia p50
+- El proxy E2B supera al proxy E4B (`gemma2:9b`) con:
+  - `286.1%` mas tok/s
+  - `75.6%` menos latencia p50
+
+## Hipotesis provisional
+
+Mi lectura fuerte, antes de medir Jetson, es esta:
+
+1. `Rhizome` debe optimizar su camino critico local para modelos clase `E2B`.
+2. Cualquier configuracion clase `E4B` queda fuera del loop de decision local hasta que Jetson demuestre claramente lo contrario.
+3. Mantendria `Ollama` como plan A solo si en Jetson cumple a la vez:
+   - `>= 5 tok/s` sostenidos en texto
+   - `<= 15 s` p95 multimodal
+   - sin OOM
+   - con al menos `0.5 GiB` de headroom tras warm restart
+4. Si falla cualquiera de esos puntos, el candidato natural a fallback es `llama.cpp`.
+
+## Por que me parece una conclusion razonable
+
+- El propio `docs/10_rhizome_spec.md` ya fija `>=5 tok/s` para texto y `<15s` para multimodal.
+- Incluso en el portatil de 16 GB, `gemma4:e4b` queda practicamente sin margen de memoria.
+- El proxy `9b` directamente cae por debajo del suelo de Rhizome.
+- El hueco entre `gemma2:2b` y `gemma4:e4b` no parece cosmetico; apunta a una diferencia de clase de uso, no solo de comodidad.
+
+## Lo que aun NO cierro
+
+Esto no cierra `#5` porque falta lo esencial:
+
+- repeticion en Jetson Orin Nano Super
+- termicas sostenidas
+- warm restarts en Jetson
+- comparativa equivalente contra `llama.cpp`
+- medicion multimodal real
+
+Pero ya me deja una postura inicial defendible para no entrar a la semana del hardware sin criterio.

--- a/code/rhizome/Makefile
+++ b/code/rhizome/Makefile
@@ -1,6 +1,9 @@
 PYTHON ?= python
 
-.PHONY: benchmark check-prompts generate-prompts test
+.PHONY: analyze-benchmarks benchmark check-prompts generate-prompts test
+
+analyze-benchmarks:
+	$(PYTHON) -m bench.analyze_reports --write-default-output
 
 generate-prompts:
 	$(PYTHON) -m bench.build_prompt_set

--- a/code/rhizome/bench/README.md
+++ b/code/rhizome/bench/README.md
@@ -22,6 +22,7 @@ Desde `code/rhizome/`:
 ```bash
 make generate-prompts
 make check-prompts
+make analyze-benchmarks
 python -m bench.run_ollama_benchmark --model gemma4:e4b --hardware-label hp-probook-460-g11
 ```
 
@@ -30,3 +31,4 @@ python -m bench.run_ollama_benchmark --model gemma4:e4b --hardware-label hp-prob
 - El harness soporta `image_paths`, aunque la primera version del prompt set es texto puro.
 - `power_watts_avg` queda en `null` cuando el host no expone una lectura portable.
 - En Jetson el runner se reutiliza sin cambiar el formato de salida; solo cambia el modelo y, si hace falta, el endpoint.
+- `analyze_reports.py` convierte los JSON comprometidos en una hipotesis provisional de arquitectura para `#5`.

--- a/code/rhizome/bench/analyze_reports.py
+++ b/code/rhizome/bench/analyze_reports.py
@@ -1,0 +1,241 @@
+"""Analyze committed benchmark reports and derive provisional architecture notes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .common import BENCHMARKS_DIR, bytes_to_gib, utc_now_iso
+
+RHIZOME_MIN_TEXT_TOKENS_PER_SEC = 5.0
+RHIZOME_MAX_MULTIMODAL_LATENCY_MS = 15_000.0
+MIN_SAFE_MEMORY_HEADROOM_GIB = 0.5
+DEFAULT_ANALYSIS_OUTPUT = BENCHMARKS_DIR / "2026-04-18_local-proxy-analysis.md"
+
+
+@dataclass(frozen=True)
+class BenchmarkReport:
+    """Compact benchmark view used for comparisons."""
+
+    path: Path
+    captured_at: str
+    model_name: str
+    host_label: str
+    host_model: str | None
+    host_total_memory_bytes: int | None
+    requests_ok: int
+    requests_total: int
+    wall_clock_ms_p50: float | None
+    wall_clock_ms_p95: float | None
+    first_token_latency_ms_p50: float | None
+    first_token_latency_ms_p95: float | None
+    tokens_per_second_avg: float | None
+    memory_peak_used_gib_max: float | None
+
+    @property
+    def requests_ok_display(self) -> str:
+        return f"{self.requests_ok}/{self.requests_total}"
+
+    @property
+    def memory_headroom_gib(self) -> float | None:
+        if self.host_total_memory_bytes is None or self.memory_peak_used_gib_max is None:
+            return None
+        total_gib = bytes_to_gib(self.host_total_memory_bytes)
+        if total_gib is None:
+            return None
+        return round(total_gib - self.memory_peak_used_gib_max, 3)
+
+    @property
+    def meets_text_threshold(self) -> bool | None:
+        if self.tokens_per_second_avg is None:
+            return None
+        return self.tokens_per_second_avg >= RHIZOME_MIN_TEXT_TOKENS_PER_SEC
+
+    @property
+    def meets_headroom_threshold(self) -> bool | None:
+        headroom = self.memory_headroom_gib
+        if headroom is None:
+            return None
+        return headroom >= MIN_SAFE_MEMORY_HEADROOM_GIB
+
+
+def _load_report(path: Path) -> BenchmarkReport:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    summary = payload["summary"]
+    host = payload["host"]
+    model = payload["model"]
+    return BenchmarkReport(
+        path=path,
+        captured_at=payload["captured_at"],
+        model_name=model["name"],
+        host_label=host.get("label") or host.get("hostname") or "unknown-host",
+        host_model=host.get("model"),
+        host_total_memory_bytes=host.get("total_memory_bytes"),
+        requests_ok=summary["requests_ok"],
+        requests_total=summary["requests_total"],
+        wall_clock_ms_p50=summary.get("wall_clock_ms_p50"),
+        wall_clock_ms_p95=summary.get("wall_clock_ms_p95"),
+        first_token_latency_ms_p50=summary.get("first_token_latency_ms_p50"),
+        first_token_latency_ms_p95=summary.get("first_token_latency_ms_p95"),
+        tokens_per_second_avg=summary.get("tokens_per_second_avg"),
+        memory_peak_used_gib_max=summary.get("memory_peak_used_gib_max"),
+    )
+
+
+def load_benchmark_reports(directory: Path = BENCHMARKS_DIR) -> list[BenchmarkReport]:
+    reports: list[BenchmarkReport] = []
+    for path in sorted(directory.glob("*.json")):
+        reports.append(_load_report(path))
+    reports.sort(key=lambda report: (report.captured_at, report.model_name))
+    return reports
+
+
+def _ratio_pct(faster_value: float | None, slower_value: float | None) -> float | None:
+    if faster_value is None or slower_value is None or slower_value == 0:
+        return None
+    return round(((faster_value / slower_value) - 1.0) * 100.0, 1)
+
+
+def _reduction_pct(reference_value: float | None, lower_value: float | None) -> float | None:
+    if reference_value is None or lower_value is None or reference_value == 0:
+        return None
+    return round((1.0 - (lower_value / reference_value)) * 100.0, 1)
+
+
+def build_observations(reports: list[BenchmarkReport]) -> list[str]:
+    observations: list[str] = []
+    by_host: dict[str, dict[str, BenchmarkReport]] = {}
+    for report in reports:
+        by_host.setdefault(report.host_label, {})[report.model_name] = report
+
+    for host_label, host_reports in by_host.items():
+        e2b_proxy = host_reports.get("gemma2:2b")
+        gemma4_e4b = host_reports.get("gemma4:e4b")
+        e4b_proxy = host_reports.get("gemma2:9b")
+
+        if e2b_proxy and gemma4_e4b:
+            tok_gain = _ratio_pct(e2b_proxy.tokens_per_second_avg, gemma4_e4b.tokens_per_second_avg)
+            lat_reduction = _reduction_pct(gemma4_e4b.wall_clock_ms_p50, e2b_proxy.wall_clock_ms_p50)
+            observations.append(
+                f"En `{host_label}`, el proxy E2B (`gemma2:2b`) supera a `gemma4:e4b` con "
+                f"{tok_gain}% mas tok/s y {lat_reduction}% menos latencia p50."
+            )
+
+        if e2b_proxy and e4b_proxy:
+            tok_gain = _ratio_pct(e2b_proxy.tokens_per_second_avg, e4b_proxy.tokens_per_second_avg)
+            lat_reduction = _reduction_pct(e4b_proxy.wall_clock_ms_p50, e2b_proxy.wall_clock_ms_p50)
+            observations.append(
+                f"En `{host_label}`, el proxy E2B (`gemma2:2b`) supera al proxy E4B (`gemma2:9b`) con "
+                f"{tok_gain}% mas tok/s y {lat_reduction}% menos latencia p50."
+            )
+
+        if e4b_proxy and e4b_proxy.meets_text_threshold is False:
+            observations.append(
+                f"`{e4b_proxy.model_name}` cae por debajo del minimo de Rhizome (`{RHIZOME_MIN_TEXT_TOKENS_PER_SEC}` tok/s) "
+                f"con `{e4b_proxy.tokens_per_second_avg}` tok/s."
+            )
+
+        if gemma4_e4b and gemma4_e4b.meets_headroom_threshold is False:
+            observations.append(
+                f"`gemma4:e4b` deja solo `{gemma4_e4b.memory_headroom_gib}` GiB de headroom en `{host_label}`, "
+                f"por debajo del margen prudente de `{MIN_SAFE_MEMORY_HEADROOM_GIB}` GiB."
+            )
+
+    return observations
+
+
+def build_preliminary_hypothesis(reports: list[BenchmarkReport]) -> list[str]:
+    if not reports:
+        return [
+            "Aun no hay reports comprometidos; la hipotesis de arquitectura sigue bloqueada hasta tener baselines.",
+        ]
+
+    return [
+        "Hipotesis provisional: Rhizome debe optimizar el loop local de decision para modelos clase E2B; "
+        "cualquier E4B queda fuera del camino critico hasta que Jetson demuestre lo contrario.",
+        f"Umbral provisional para mantener Ollama como primario en Jetson: >=`{RHIZOME_MIN_TEXT_TOKENS_PER_SEC}` tok/s "
+        f"en texto sostenido, p95 multimodal <=`{int(RHIZOME_MAX_MULTIMODAL_LATENCY_MS/1000)}` s, sin OOM y con al menos "
+        f"`{MIN_SAFE_MEMORY_HEADROOM_GIB}` GiB de headroom tras warm restart.",
+        "Candidato a fallback `llama.cpp`: cualquier configuracion de Ollama que no cargue, caiga por debajo del umbral de tok/s, "
+        "supere el p95 multimodal o pierda estabilidad entre corridas calientes.",
+    ]
+
+
+def render_markdown_analysis(reports: list[BenchmarkReport]) -> str:
+    lines = [
+        "# Local proxy analysis for Rhizome",
+        "",
+        f"Generated at: `{utc_now_iso()}`",
+        "",
+        "## Thresholds carried into #5",
+        "",
+        f"- Rhizome text floor from `docs/10_rhizome_spec.md`: `>= {RHIZOME_MIN_TEXT_TOKENS_PER_SEC}` tok/s.",
+        f"- Rhizome multimodal ceiling from `docs/10_rhizome_spec.md`: `<= {int(RHIZOME_MAX_MULTIMODAL_LATENCY_MS/1000)}` s.",
+        f"- Provisional memory headroom guardrail for warm restarts: `>= {MIN_SAFE_MEMORY_HEADROOM_GIB}` GiB free after peak.",
+        "",
+        "## Reports",
+        "",
+        "| Model | Host | Requests OK | p50 ms | p95 ms | tok/s avg | RAM peak GiB | Headroom GiB | Text floor |",
+        "|------|------|------------:|-------:|-------:|----------:|-------------:|-------------:|-----------|",
+    ]
+
+    for report in reports:
+        text_floor = "yes" if report.meets_text_threshold else "no"
+        lines.append(
+            "| "
+            f"`{report.model_name}` | `{report.host_label}` | {report.requests_ok_display} | "
+            f"{report.wall_clock_ms_p50 if report.wall_clock_ms_p50 is not None else 'n/a'} | "
+            f"{report.wall_clock_ms_p95 if report.wall_clock_ms_p95 is not None else 'n/a'} | "
+            f"{report.tokens_per_second_avg if report.tokens_per_second_avg is not None else 'n/a'} | "
+            f"{report.memory_peak_used_gib_max if report.memory_peak_used_gib_max is not None else 'n/a'} | "
+            f"{report.memory_headroom_gib if report.memory_headroom_gib is not None else 'n/a'} | "
+            f"{text_floor} |"
+        )
+
+    observations = build_observations(reports)
+    lines.extend(["", "## Observations", ""])
+    if observations:
+        lines.extend(f"- {observation}" for observation in observations)
+    else:
+        lines.append("- No hay suficientes reports para observaciones comparativas.")
+
+    hypothesis = build_preliminary_hypothesis(reports)
+    lines.extend(["", "## Provisional architecture hypothesis", ""])
+    lines.extend(f"- {item}" for item in hypothesis)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--directory", type=Path, default=BENCHMARKS_DIR, help="Directory containing benchmark JSON reports.")
+    parser.add_argument("--output", type=Path, default=None, help="Optional path to write the markdown analysis.")
+    parser.add_argument(
+        "--write-default-output",
+        action="store_true",
+        help="Write the analysis to the default markdown file in benchmarks/.",
+    )
+    args = parser.parse_args()
+
+    reports = load_benchmark_reports(args.directory)
+    markdown = render_markdown_analysis(reports)
+
+    output_path: Path | None = args.output
+    if args.write_default_output:
+        output_path = DEFAULT_ANALYSIS_OUTPUT
+
+    if output_path is not None:
+        output_path.write_text(markdown + "\n", encoding="utf-8")
+        print(output_path)
+        return 0
+
+    print(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/rhizome/benchmarks/2026-04-18_local-proxy-analysis.md
+++ b/code/rhizome/benchmarks/2026-04-18_local-proxy-analysis.md
@@ -1,0 +1,31 @@
+# Local proxy analysis for Rhizome
+
+Generated at: `2026-04-18T13:35:14Z`
+
+## Thresholds carried into #5
+
+- Rhizome text floor from `docs/10_rhizome_spec.md`: `>= 5.0` tok/s.
+- Rhizome multimodal ceiling from `docs/10_rhizome_spec.md`: `<= 15` s.
+- Provisional memory headroom guardrail for warm restarts: `>= 0.5` GiB free after peak.
+
+## Reports
+
+| Model | Host | Requests OK | p50 ms | p95 ms | tok/s avg | RAM peak GiB | Headroom GiB | Text floor |
+|------|------|------------:|-------:|-------:|----------:|-------------:|-------------:|-----------|
+| `gemma4:e4b` | `hp-probook-460-g11` | 2/2 | 106211.69 | 117911.55 | 6.274 | 15.463 | 0.002 | yes |
+| `gemma2:2b` | `hp-probook-460-g11` | 4/4 | 54232.529 | 67759.539 | 8.976 | 14.4 | 1.065 | yes |
+| `gemma2:9b` | `hp-probook-460-g11` | 1/1 | 222169.97 | 222169.97 | 2.325 | 15.464 | 0.001 | no |
+
+## Observations
+
+- En `hp-probook-460-g11`, el proxy E2B (`gemma2:2b`) supera a `gemma4:e4b` con 43.1% mas tok/s y 48.9% menos latencia p50.
+- En `hp-probook-460-g11`, el proxy E2B (`gemma2:2b`) supera al proxy E4B (`gemma2:9b`) con 286.1% mas tok/s y 75.6% menos latencia p50.
+- `gemma2:9b` cae por debajo del minimo de Rhizome (`5.0` tok/s) con `2.325` tok/s.
+- `gemma4:e4b` deja solo `0.002` GiB de headroom en `hp-probook-460-g11`, por debajo del margen prudente de `0.5` GiB.
+
+## Provisional architecture hypothesis
+
+- Hipotesis provisional: Rhizome debe optimizar el loop local de decision para modelos clase E2B; cualquier E4B queda fuera del camino critico hasta que Jetson demuestre lo contrario.
+- Umbral provisional para mantener Ollama como primario en Jetson: >=`5.0` tok/s en texto sostenido, p95 multimodal <=`15` s, sin OOM y con al menos `0.5` GiB de headroom tras warm restart.
+- Candidato a fallback `llama.cpp`: cualquier configuracion de Ollama que no cargue, caiga por debajo del umbral de tok/s, supere el p95 multimodal o pierda estabilidad entre corridas calientes.
+

--- a/code/rhizome/benchmarks/README.md
+++ b/code/rhizome/benchmarks/README.md
@@ -31,3 +31,14 @@ Ejemplo:
 ## Alcance actual
 
 Las corridas versionadas aqui son una validacion local del harness y de los prompts. No sustituyen el benchmark objetivo de `#5`, que sigue pendiente de repetirse en Jetson Orin Nano Super y de compararse contra `llama.cpp`.
+
+## Analisis derivado
+
+Para sintetizar ratios y una hipotesis provisional de arquitectura:
+
+```bash
+cd code/rhizome
+make analyze-benchmarks
+```
+
+Salida actual: `2026-04-18_local-proxy-analysis.md`

--- a/code/rhizome/tests/test_bench_analysis.py
+++ b/code/rhizome/tests/test_bench_analysis.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from bench.analyze_reports import BenchmarkReport, build_observations, build_preliminary_hypothesis, render_markdown_analysis
+
+
+def _report(model_name: str, *, tok_s: float, p50: float, peak_gib: float) -> BenchmarkReport:
+    return BenchmarkReport(
+        path=Path(f"{model_name}.json"),
+        captured_at="2026-04-18T08:00:00Z",
+        model_name=model_name,
+        host_label="hp-probook-460-g11",
+        host_model="HP ProBook 460 16 inch G11 Notebook PC",
+        host_total_memory_bytes=16 * 1024**3,
+        requests_ok=1,
+        requests_total=1,
+        wall_clock_ms_p50=p50,
+        wall_clock_ms_p95=p50,
+        first_token_latency_ms_p50=p50 * 0.9,
+        first_token_latency_ms_p95=p50 * 0.9,
+        tokens_per_second_avg=tok_s,
+        memory_peak_used_gib_max=peak_gib,
+    )
+
+
+def test_build_observations_highlights_e2b_advantage() -> None:
+    reports = [
+        _report("gemma2:2b", tok_s=9.0, p50=54000.0, peak_gib=14.4),
+        _report("gemma4:e4b", tok_s=6.0, p50=106000.0, peak_gib=15.46),
+        _report("gemma2:9b", tok_s=2.3, p50=222000.0, peak_gib=15.46),
+    ]
+
+    observations = build_observations(reports)
+
+    assert any("supera a `gemma4:e4b`" in observation for observation in observations)
+    assert any("cae por debajo del minimo" in observation for observation in observations)
+
+
+def test_render_markdown_analysis_includes_hypothesis() -> None:
+    reports = [
+        _report("gemma2:2b", tok_s=9.0, p50=54000.0, peak_gib=14.4),
+        _report("gemma4:e4b", tok_s=6.0, p50=106000.0, peak_gib=15.46),
+    ]
+
+    rendered = render_markdown_analysis(reports)
+    hypothesis = build_preliminary_hypothesis(reports)
+
+    assert "# Local proxy analysis for Rhizome" in rendered
+    assert "## Provisional architecture hypothesis" in rendered
+    assert hypothesis[0] in rendered


### PR DESCRIPTION
Closes #31
Refs #5

## Resumen
- añade `code/rhizome/bench/analyze_reports.py` para leer los reports JSON ya versionados y derivar comparativas + hipotesis provisional
- agrega target `make analyze-benchmarks` y documentacion asociada
- versiona `code/rhizome/benchmarks/2026-04-18_local-proxy-analysis.md` con la lectura actual de `gemma2:2b`, `gemma2:9b` y `gemma4:e4b`
- deja bitacora con la postura provisional para Rhizome: E2B en el camino critico y E4B fuera hasta prueba en Jetson
- añade tests minimos del analizador

## Como probar
1. `cd code/rhizome`
2. `python -m pytest tests`
3. `python -m bench.analyze_reports --write-default-output`
4. revisar `benchmarks/2026-04-18_local-proxy-analysis.md`

## Notas
- Esta PR no cierra `#5`; solo adelanta el analisis comparativo previo al hardware.
- Los umbrales quedan como hipotesis provisional hasta repetir la matriz en Jetson y medir `llama.cpp`.