### PR TITLE
feat(meristem): policy_engine sobre Gemma E4B + endpoints ingest/policies/deltas (closes #28)

### DIFF
--- a/bitacora/2026-04-18_drafts-subissue-30-gaps_meristem.md
+++ b/bitacora/2026-04-18_drafts-subissue-30-gaps_meristem.md
@@ -1,0 +1,208 @@
+# Draft de sub-issue: huecos entre §30 y schemas v1.0 detectados antes de empezar #28
+
+**Fecha:** 2026-04-18
+**Autor:** Meristem
+**Area:** Meristem
+**Tipo:** Propuesta (sub-issue bloqueante de #28)
+
+Cambium en su ultimo mensaje sobre #28: *"Criterios de aceptacion mandan. Si
+chocas con algun hueco en schemas o en el spec §30, abres sub-issue antes de
+empezar a parchear por tu cuenta. No quiero drift de contratos."*
+
+Antes de crear `feat/meristem-policy-engine` hice reconocimiento de
+`code/shared/schemas/policy_packet.py`, `policy_delta.py`,
+`contradiction_alert.py` y sus ejemplos en `code/shared/schemas/examples/`,
+cruzandolos con `docs/30_safety_rules.md` §3. Encuentro tres tensiones reales
+que afectan los criterios de aceptacion de #28. Las dejo en un sub-issue para
+que Cambium (y Xilema, porque §30 es suyo) decidan antes de que yo escriba
+codigo que de por sentado una interpretacion.
+
+---
+
+## Sub-issue C — Clarificar contrato entre §30 (firmware) y schemas v1.0 (P0, bloqueante de #28)
+
+**Titulo:** `Clarificar interaccion §30 firmware ↔ PolicyPacket/PolicyDelta/ContradictionAlert v1.0`
+
+**Labels:** `node:meristem`, `area:infra`, `priority:P0`, `blocks:#28`
+
+**Body:**
+
+```markdown
+## Contexto
+
+Durante el arranque de #28 (policy_engine Meristem) hago el check pre-emit de
+`docs/30_safety_rules.md` §3 sobre `PolicyPacket` y sobre la proyeccion de
+`PolicyDelta` aplicada a una packet activa. Tres puntos del spec §30 no son
+computables o son ambiguos dados los schemas v1.0 y los fixtures canonicos
+mergeados en ba7e1ae. Abro el issue antes de parchear para evitar drift.
+
+Referencia cruzada:
+- `docs/30_safety_rules.md` §3.1 y §3.2
+- `code/shared/schemas/policy_packet.py` (v1.0)
+- `code/shared/schemas/policy_delta.py` (v1.0)
+- `code/shared/schemas/contradiction_alert.py` (v1.0)
+- `code/shared/schemas/examples/policy_packet.json` (canonical fixture)
+
+## Gap 1 — `tank_minimum_pct`: schema permite 10%, §30 exige 20%, fixture usa 15%
+
+**Situacion.** `PolicyRules.tank_minimum_pct` valida `>= 10.0` (linea 53 de
+`policy_packet.py`). §30.1 hard-limit es **20%**. El fixture canonico
+`examples/policy_packet.json` tiene `"tank_minimum_pct": 15.0`.
+
+Si Meristem emite una packet con `tank_minimum_pct=15`:
+- Schema valida OK.
+- Firmware lo ignora igual (el 20% esta hardcoded en el ESP32).
+- Pero el campo en la packet sugiere a un lector humano que 15% es permisible,
+  cuando no lo es en la capa fisica.
+
+**Preguntas para Cambium / Xilema:**
+
+1. ¿`tank_minimum_pct` en PolicyPacket es el *piso politico* (Meristem quiere
+   ser mas conservador que el firmware) o es el *piso fisico* (debe reflejar
+   §30)?
+2. Si es piso politico: debe documentarse en `20_data_contracts.md` que este
+   campo **no puede relajar §30** aunque el schema lo permita. Mi validador
+   pre-emit lo bloqueara con `< 20.0` y el fixture canonico hay que
+   actualizarlo a `>= 20.0`.
+3. Si es piso fisico: el schema deberia cambiar a `Field(ge=20.0)` y el
+   fixture tambien. Eso seria un bump de schema (1.1?), fuera de mi scope.
+
+**Propuesta por defecto (si no hay respuesta explicita antes de #28):**
+interpretarlo como piso politico-con-suelo-duro. Mi validador rechaza packets
+con `tank_minimum_pct < 20`. El fixture con 15% sigue siendo valido para
+`/ingest` (porque `/ingest` no acepta PolicyPacket; solo RhizomeSnapshot,
+DecisionReceipt, WeatherPacket, ContradictionAlert — ver #28 criterios). Pero
+si algun dia Meristem persiste una policy para test usando ese fixture como
+semilla, se reescribe el valor a 20 antes de guardarla. Documentado en
+bitacora.
+
+## Gap 2 — Rate limits §30 (8/h, 48/dia) no computables desde PolicyPacket
+
+**Situacion.** §30.1 define **8 aperturas/hora** y **48/dia** como hard
+limits. El criterio de aceptacion de #28 dice:
+
+> Sumas por zona que permitan > 8 aperturas/hora o > 48/dia dados los
+> parametros de la politica
+
+PolicyPacket v1.0 no tiene campos de frecuencia ni scheduling. Los unicos
+parametros presupuestales son `max_watering_duration_s` y
+`daily_water_budget_liters`. Para derivar "cuantas aperturas implica este
+presupuesto" hace falta **caudal nominal de la bomba** (L/s), que no esta en
+ningun schema — es parametro fisico del hardware de Xilema.
+
+Aunque lo estimara con un caudal por defecto, la estimacion seria arbitraria
+y la regla cruzaria de "hard limit auditable" a "heuristica meristem".
+
+**Interpretacion de fallback del criterio:**
+
+La regla 8/h y 48/dia vive enteramente en el firmware. Meristem no puede
+violarla desde un PolicyPacket porque el packet **no es un schedule**. Lo
+unico que Meristem puede hacer es reaccionar a `REJECTED RATE_LIMIT_*` que el
+firmware emita — eso llega via DecisionReceipt, y ahi si hay algo que
+consolidar (§10.7 del propio §30 ya lo dice: si el patron persiste, emitir
+ContradictionAlert).
+
+**Preguntas para Cambium:**
+
+1. ¿El criterio de #28 "sumas por zona" se refiere a algo que no estoy
+   viendo en el schema? Si hay una interpretacion que se pueda computar solo
+   desde PolicyPacket, la he pasado por alto.
+2. Si no: ¿podemos reescribir el criterio para que diga "Meristem no puede
+   emitir reglas que afecten directamente a la cadencia de apertura porque
+   el schema v1.0 no lo permite, y las violaciones observadas via
+   `REJECTED RATE_LIMIT_*` se consolidan en ContradictionAlert severity
+   warning/critical segun persistencia"? Eso lo implemento en #28 sin
+   problema. Lo que no puedo implementar es el check a-priori sobre la
+   packet porque los datos no estan.
+
+## Gap 3 — Concurrencia de zonas no expresable en PolicyPacket
+
+**Situacion.** §30.2 dice "Zonas simultaneas abiertas: 1". Criterio de #28:
+
+> Cualquier regla que implique zonas simultaneas (concurrencia > 1)
+
+PolicyPacket v1.0 no tiene ningun campo que describa concurrencia, timing o
+secuencia. Es imposible expresar "permitir dos zonas a la vez" en el schema
+actual. El check es vacio por construccion.
+
+**Propuesta:** marcar el check como **trivially satisfied** (no-op) en la
+implementacion, con un comentario apuntando a este issue. Si en el futuro
+PolicyPacket v1.1 introduce campos de scheduling, el check se implementa de
+verdad entonces. Mientras tanto, el firmware sigue garantizandolo con
+`REJECTED ZONE_IN_USE`.
+
+## Gap 4 — `ContradictionType` no tiene caso para "policy viola §30"
+
+**Situacion.** Criterio de #28:
+
+> Validador bloquea y emite `ContradictionAlert` severity=warning
+
+Los 6 `ContradictionType` en `schemas/enums.py` (inferidos de
+`contradiction_alert.py`) son `sensor_vs_vision`, `policy_expired`,
+`deposit_inconsistent`, `flow_vs_pump`, `weather_conflict`, `tank_underflow`.
+Ninguno encaja con "Meristem intento emitir una politica cuyos parametros
+violan §30". El mas cercano para el caso `tank_minimum_pct<20` es
+`tank_underflow`, pero los required keys son
+`{tank_level_pct, minimum_threshold_pct}` que no aplican (esto no es un
+underflow observado, es un parametro politico fuera de rango).
+
+**Opciones:**
+
+1. Anadir `policy_violates_firmware` al enum `ContradictionType` + entry en
+   `EVIDENCE_REQUIRED_KEYS` con `{rule_violated, proposed_value,
+   firmware_limit}`. Es cambio de schema → bump minor a v1.1. **Fuera de mi
+   scope** (requiere decision de Cambium).
+2. Reinterpretar el criterio: Meristem **no emite** ContradictionAlert en
+   este caso; simplemente loguea el intento bloqueado en
+   `decisions_log` (tabla meristem local, spec §7) y responde 422 al cliente
+   que pidio el delta. ContradictionAlert queda reservado a su uso canonico
+   (contradicciones observadas en el mundo, no en packets emitidos).
+3. Usar `tank_underflow` solo para el caso `tank_minimum_pct<20`, con las
+   evidence keys rellenadas de forma que pasen el validador, y omitir alert
+   para los otros casos. Parece hack.
+
+**Propuesta por defecto (si no hay respuesta explicita):** opcion 2. Mas
+limpia semanticamente y no toca schema. El rastro auditable queda en
+`decisions_log` + bitacora + respuesta 422.
+
+## Que necesito para desbloquear #28
+
+Respuesta (aunque sea breve) sobre al menos Gap 1 y Gap 2. Gap 3 y Gap 4
+tengo propuestas por defecto que puedo aplicar sin cambiar contratos, pero
+las documento por transparencia.
+
+Si Cambium prefiere que avance con las "propuestas por defecto" de los
+cuatro gaps, asi lo dejo escrito en la bitacora del PR de #28 y seguimos. El
+unico gap donde la propuesta por defecto tiene friccion con un artefacto
+canonico existente es Gap 1 (fixture con 15%).
+
+## Fuera de alcance
+
+- Cambios de schema (bumps a v1.1). Son decision de Cambium/Xilema, no mias.
+- Retomar §10.7 de `30_safety_rules.md` sobre severity escalation de
+  `RATE_LIMIT` observados (eso es logica de consolidacion, PR futuro de
+  Meristem).
+
+## Referencias
+
+- #28 (policy_engine Meristem, bloqueado por este)
+- `docs/30_safety_rules.md` §3.1, §3.2, §10.7
+- `code/shared/schemas/policy_packet.py` v1.0
+- `code/shared/schemas/contradiction_alert.py` v1.0
+- `code/shared/schemas/examples/policy_packet.json`
+```
+
+---
+
+## Agrupacion preferida
+
+Sub-issue aparte, **bloqueante de #28**. No empiezo `feat/meristem-policy-engine`
+hasta tener respuesta al menos sobre Gap 1 y Gap 2.
+
+Si Cambium responde "tira con las propuestas por defecto", arranco #28
+inmediatamente y documento la interpretacion en la bitacora del PR.
+
+Cambium: si prefieres que #28 siga adelante con las propuestas por defecto
+sin abrir este issue formalmente (porque son mas aclaraciones que cambios),
+dimelo y lo dejo todo como nota en la bitacora de #28 en vez de como
+sub-issue. Mi duda es sobre orden-de-decision, no sobre la sustancia.

--- a/bitacora/2026-04-19_policy-engine-meristem_meristem.md
+++ b/bitacora/2026-04-19_policy-engine-meristem_meristem.md
@@ -1,0 +1,140 @@
+# Policy engine Meristem — implementacion y resolucion de los 4 gaps de §30
+
+**Fecha:** 2026-04-19
+**Autor:** Meristem
+**Area:** Meristem
+**Tipo:** PR bitacora (cierra #28)
+
+## Contexto
+
+Segundo PR de Meristem sobre el andamio mergeado en #17 (cd326b2). Entrega
+el razonamiento estrategico real: endpoints `/ingest`, `/policies/*`,
+`/deltas/*`, validador pre-emit de los limites duros del firmware §30, y el
+nucleo de consolidacion `policy_engine.consolidate(...)` con llamada real a
+Ollama E4B via structured output.
+
+Arranque documentado en la bitacora complementaria
+`2026-04-18_drafts-subissue-30-gaps_meristem.md` (reconocimiento previo que
+detecto 4 tensiones entre §30 y schemas v1.0). Cambium cerro los 4 gaps el
+2026-04-19 y me desbloqueo; este PR aplica las decisiones acordadas.
+
+## Resolucion de los 4 gaps
+
+| Gap | Tension | Decision de Cambium | Implementacion |
+|---|---|---|---|
+| 1 | `tank_minimum_pct` schema `>=10`, §30 `>=20`, fixture a 15 | §30 manda. Validador rechaza `<20`. Fixture canonico se sube a 20 en este mismo PR via `builders.py`. Schema queda en 10 (bump a v1.1 no se aborda ahora). | `safety_rules.FIRMWARE_TANK_MINIMUM_PCT = 20.0`. `code/shared/schemas/examples/builders.py` subido a 20.0; JSONs regenerados via `make generate-examples`. Rationale del `decision_receipt_blocked` actualizado coherentemente (11% → 18%, "15%" → "20%"). |
+| 2 | Rate limits 8/h y 48/dia no computables desde PolicyPacket | No-op en pre-emit. Se consolidan post-hoc via `REJECTED RATE_LIMIT_*` observados en DecisionReceipts. | No implementado en este PR. Documentado como N/A en `safety_rules.check_policy_packet` (comentario explicito). PR futuro para consumir `DecisionReceipt` agregados. |
+| 3 | Concurrencia de zonas (1 max) no expresable en PolicyPacket | No-op con comentario. | Mismo modulo, mismo comentario. El firmware lo garantiza con `REJECTED ZONE_IN_USE`. |
+| 4 | `ContradictionType` no cubre "policy viola §30" | Opcion 2: `decisions_log` local + 422 con `reason=violates_safety_rule`. `ContradictionAlert` queda para contradicciones observadas, no pre-emit. | Aplicado en `routes.propose_delta` y en `policy_engine.consolidate`: intento bloqueado escribe fila en `decisions_log` con `action="blocked_by_safety"` o `"blocked_invalid_schema"`. 422 al cliente con violaciones desglosadas. |
+
+## Decisiones de diseno de este PR
+
+**Endpoint `/ingest` con envelope `{kind, payload}`.** Alternativas consideradas:
+(a) sub-paths por tipo `/ingest/snapshot`..., (b) adivinar el tipo por forma
+del payload. Escogi envelope explicito por claridad y por evitar ambiguedad
+cuando dos schemas comparten campos. Sus cuatro `kind` validos estan en
+`routes.INGEST_KINDS`; anadir un kind nuevo es un diff unilinea + un test.
+
+**`/deltas/propose` valida sincrono.** El spec permite validacion en batch
+asincrona, pero este PR no expone job de consolidacion (queda para el
+siguiente). Un delta valido sale como `validated`; `pending` queda reservado
+para el flujo futuro. El estado `pending` ya vive en el schema de la tabla
+`deltas` y `/deltas/pending/*` lista lo que haya, este o no alimentado en
+este PR.
+
+**Proyeccion de delta sobre base.** Validar el delta aislado no basta:
+`replace rules.max_watering_duration_s = 60` es valido en si pero la
+proyeccion podria quedar bien; en cambio `= 120` si necesita comparar contra
+el limite duro. La proyeccion se hace en `safety_rules.project_delta` con
+mutacion de un `model_dump()` y re-validacion completa via pydantic. Eso
+tambien detecta patches que rompen invariantes inter-campo (ej: `target_pct
+< min_pct`): se rechazan como `projection_invalid_schema`.
+
+**Policy engine no expuesto por HTTP.** `consolidate(...)` es API interna
+para invocar desde un consolidator job futuro o desde tests. Integrarlo en
+un endpoint (p.ej. `POST /policies/consolidate/{rhizome_id}`) requeriria
+ademas decidir que subset de evidencia se pasa al LLM, y eso es logica de
+consolidator (fuera de alcance). El test negativo del engine ("LLM devuelve
+packet con duration=120 => no persiste") cubre el criterio #28 con `_FakeOllama`.
+
+**Timeout del cliente Ollama a 120s por defecto.** `/api/generate` con E4B
+en hardware modesto tarda 20-40s segun tamano del user prompt. El timeout
+del `ping` queda aparte a 2s.
+
+## Tests (55 pasan, 1 skip)
+
+```
+tests/test_health.py            3 passed   /health + SQLite init + shadow-on-raises
+tests/test_settings.py         13 passed   defaults + parsing
+tests/test_llm_client.py        3 passed   ping ok/fail, modelo expuesto
+tests/test_schemas_importable 1 passed   6 schemas importables desde shared
+tests/test_shadow_off.py        1 passed   subproceso verifica no-leak runtime
+tests/test_safety_rules.py     12 passed   unit del validador §30
+tests/test_ingest.py            7 passed   fixtures canonicos + 422
+tests/test_policies.py          3 passed   GET activa / 404 / expirada
+tests/test_deltas.py            7 passed   pending + propose (OK + 409 + 422)
+tests/test_policy_engine.py     5 passed   happy + §30 + invalid_schema + prompt
+tests/test_smoke_ollama.py      1 skipped  (no daemon en CI)
+```
+
+Regresion: los 20 tests del bootstrap siguen verdes (incluido el negativo
+critico `test_shadow_off.py`).
+
+Tests de `code/shared/schemas/tests/` siguen verdes (33 passed) tras editar
+`builders.py` y regenerar los JSONs canonicos.
+
+## Entregables
+
+- `code/meristem/src/safety_rules.py` — validador pre-emit §30.
+- `code/meristem/src/policy_engine.py` — consolidator (API interna).
+- `code/meristem/src/routes.py` — 4 endpoints HTTP.
+- `code/meristem/src/persistence.py` — helpers CRUD sobre las 5 tablas.
+- `code/meristem/src/llm_client.py` — `generate_json()` con structured output.
+- `code/meristem/src/prompts/system_v1.txt` — prompt funcional.
+- 6 suites de tests nuevas.
+- `code/meristem/README.md` actualizado (endpoints, engine, tests).
+- `code/shared/schemas/examples/builders.py` — `tank_minimum_pct` 15 → 20 (Gap 1).
+- `code/shared/schemas/examples/policy_packet.json` y `decision_receipt_blocked.json` — regenerados.
+- Drafts-file del 2026-04-18 incluido (reconocimiento previo).
+
+## Latencia
+
+El smoke test (`test_smoke_ollama.py`) mide E2E contra un Ollama real. No
+corre en CI. Budget fijado a 90s con objetivo 60s (spec §6). Cuando Bea lo
+ejecute en el portatil, anota el resultado como comentario en la PR para
+cerrar el criterio.
+
+## Fuera de alcance (PRs siguientes)
+
+- Consolidator job automatico (disparador por N evidencias).
+- Endpoint `POST /policies/consolidate` que invoque el engine.
+- Consolidacion post-hoc de `REJECTED RATE_LIMIT_*` observados (Gap 2 + §30 §10.7).
+- Meristem sombra activo (`compare.py` real). Flag sigue off.
+- RAG / memoria estacional.
+- Revocaciones programadas (schema no lo modela en v1.0).
+
+## Riesgos y deuda asumida
+
+- **Gap 1 inconsistente a nivel de schema.** Schema sigue aceptando `>=10`
+  aunque el validador nuestro rechace `<20`. Si manana Pollen propone un
+  delta que deja la policy en 15, el schema lo valida y el validador lo
+  rechaza. El comportamiento es correcto (fail-closed), pero el contrato
+  queda con friccion. Cambium autorizo dejarlo asi y aplazar el bump a v1.1.
+- **`generate_json` confia en `format=<schema>` de Ollama.** Versiones
+  anteriores a 0.1.30 no lo soportan; ahi cae a `format="json"` sin
+  garantia estructural y la validacion pydantic absorbe el posible drift.
+  `ollama --version` deberia salir en el README de deployment cuando lo
+  haya.
+- **El smoke test puede fallar en CI si alguien anade soporte Ollama.** El
+  marker `@pytest.mark.ollama` lo aisla; ademas el `client.ping()` skipea
+  si el daemon no responde. Hay que recordar no correr `-m ollama` en CI.
+
+## Referencias
+
+- Issue #28 (policy_engine, cerrado por este PR).
+- Drafts-file `bitacora/2026-04-18_drafts-subissue-30-gaps_meristem.md`.
+- Respuesta de Cambium a los 4 gaps (2026-04-19, en canal Bea).
+- `docs/12_meristem_spec.md` §5, §6, §7.
+- `docs/20_data_contracts.md` v1.0.
+- `docs/30_safety_rules.md` §3.
+- `CONTRIBUTING.md` §11.1 (multi-agent clone), §12 (flujo de tablero).

--- a/bitacora/2026-04-19_thinking-mode-e4b-latencia_meristem.md
+++ b/bitacora/2026-04-19_thinking-mode-e4b-latencia_meristem.md
@@ -1,0 +1,202 @@
+# Thinking mode en Gemma 4 E4B, latencia real, y reformulación de issues post-#37
+
+**Fecha:** 2026-04-19
+**Autor:** Meristem
+**Area:** Meristem
+**Tipo:** hallazgos de verificacion + replanteo de roadmap post-merge
+**Destinatario:** Cambium (para decisiones sobre las 3 issues que quedaban pendientes)
+
+## Qué pasó
+
+Tras abrir #37 con el policy engine, me pediste en tu review: (a) responder
+a los 2 puntos concretos en el PR, (b) correr el smoke test contra Ollama
+real para fijar latencia, (c) no empezar ninguna de las 3 issues post-merge
+("consolidator job", "A/B thinking mode", "activación sombra 26B MoE")
+hasta que #37 estuviese mergeado.
+
+Este documento recoge todo lo que he hecho con Bea entre tu review y este
+momento, y las implicaciones para esas 3 issues. **El PR #37 sigue listo
+para squash-merge tal como está**; lo de aquí es material para decidir
+*qué* abrimos después y en qué orden.
+
+## Lo que se hizo con Bea
+
+### 1. Respuesta a los 2 puntos del PR
+
+- Confirmado explícitamente en comment del PR que `consolidate()` NO
+  re-ensaya Ollama. Una sola llamada a `llm.generate_json`; si falla,
+  propaga la excepción y se loguea en `decisions_log` con action
+  `blocked_invalid_schema` o `blocked_by_safety`. Retry/backoff es
+  responsabilidad del consolidator job futuro.
+- Anotada la línea de idempotencia de `/deltas/propose` en `README.md`
+  (commit `3049dbf`).
+
+### 2. Smoke test contra Ollama real
+
+Ejecutado por Bea en su portátil (16 GB, CPU pura, sin GPU). Ruta de
+depuración:
+
+1. Primer run: skipped. Causa: `localhost` en Windows resuelve IPv6 `::1`
+   primero, Ollama bindea IPv4 `0.0.0.0`, httpx se quedaba colgado dentro
+   del timeout de 2s del `ping()`.
+2. Fix: `$env:OLLAMA_HOST="http://127.0.0.1:11434"` fuerza IPv4.
+3. Segundo run: timeout a 120s (default del `OllamaClient`). Causa: la
+   llamada real del engine excede ese cap.
+4. Fix: commit `7628ff2` sube el timeout del cliente a 300s solo en el
+   smoke. El test ya completa.
+5. Tercer run: `AssertionError: latencia 238.7s excede budget de 90s`.
+   **El engine completa correctamente y persiste una PolicyPacket válida**;
+   solo falla el assert del budget.
+
+### 3. Diagnóstico con contadores de Ollama
+
+Bea pidió pulir más el análisis antes de que cerrásemos. Amplié un script
+temporal `diag_ollama.py` (ya borrado) que mide matriz 2×2 de
+`prompt × format` leyendo `prompt_eval_count`, `eval_count`,
+`prompt_eval_duration`, `eval_duration`.
+
+Resultados clave:
+
+| Variante | Wall | Input tok | Output tok |
+|---|---|---|---|
+| A prompt corto + `format=json` | 4.3s | 33 | 8 |
+| B prompt corto + `format=schema` | 60.7s | 65 | 347 |
+| C prompt engine + `format=json` | **236.6s** | 2152 | 431 |
+| D prompt engine + `format=schema` | 51.5s¹ | 2152 | 320 |
+| E prompt engine **SIN dup schema** + `format=schema` | 48.4s¹ | 658 | 298 |
+
+¹ D y E no son cold: aprovechan el KV cache de C (mismo prefix). Cold
+estimado real de D ≈ 216s; cold real de E ≈ 96s.
+
+**Interpretación corregida**:
+
+- Output tokens/s en CPU es **constante ~6.2-6.9 t/s**. Techo del hardware.
+- Input cold processing en CPU ≈ **13 t/s**.
+- Forzar schema **no** ralentiza el decoding. Solo aumenta el volumen de
+  output (~300 tokens obligatorios por rellenar todos los campos del
+  schema).
+- El cuello cold es el **tamaño del input**. `build_user_prompt` duplica
+  el schema entero como texto dentro del prompt además de pasarlo en
+  `format=`. Input de 658 → 2152 tokens, 120s extra.
+- El spec "<60s" no es alcanzable en CPU pura; output mínimo por schema
+  (~300 tok × 1/6.5 t/s) ya son 46s sin contar input cold.
+
+### 4. Conversación sobre real-time
+
+Bea aclaró explícitamente que los nodos **no necesitan comunicación en
+tiempo real**. Pueden responder con delays y asincronía entre ellos.
+
+Esto reencuadra todo: **Meristem es asíncrono por diseño**. Ciclo real:
+Pollen acumula evidencia durante horas → llama a Meristem → Meristem
+piensa 4 minutos → emite PolicyPacket con TTL de horas → Rhizome aplica
+la política cacheada en microsegundos. El "<60s" del spec era optimización
+para demo fluida, no requisito funcional del sistema. 4 minutos de
+consolidación para una política que vale 6-24h es la proporción correcta.
+
+Lo dejo anotado aquí para que quede en el repo como decisión formal: el
+budget <60s se mantiene como *objetivo con GPU o modelo optimizado*, no
+como condición de aceptación.
+
+### 5. Thinking mode en Gemma 4 E4B
+
+Primera ronda: probé `think=true` via `/api/generate` con `format=schema`
+(la combinación que usa `consolidate()` hoy). Resultado: campo `thinking`
+vacío, output tokens idénticos al baseline. Concluí erróneamente que E4B
+no soportaba thinking en Ollama.
+
+Bea aportó investigación detallada sobre la API de Ollama con ejemplos
+concretos (`ollama.chat(think=True)`, `message.thinking`, etc.). Re-probé
+con 5 sondas discriminativas:
+
+| Endpoint | `think` | `format` | Campo thinking | Chars |
+|---|---|---|---|---|
+| `/api/generate` | ✓ | — | ✓ | 1615 |
+| `/api/generate` | — | — | — | 0 (control) |
+| `/api/generate` | ✓ | `json` | ✗ | **0** |
+| `/api/chat` | ✓ | — | ✓ | 1622 |
+| `/api/chat` | ✓ | `json` | ✓ | **1925** |
+
+**Hallazgos**:
+
+1. **Gemma 4 E4B SÍ soporta thinking nativo en Ollama**. Mi primera
+   conclusión era errónea. El modelo razona estructuradamente en inglés
+   y emite la respuesta final en el idioma del usuario.
+2. **`/api/generate` + `format=json` suprime thinking**. Bug o limitación
+   no documentada; es un quirk del endpoint.
+3. **`/api/chat` + `format=json` respeta thinking** y devuelve ambos
+   campos (`message.thinking` y `message.content`) limpios.
+
+Implicación directa para Meristem: `OllamaClient.generate_json()` usa hoy
+`/api/generate`, que es exactamente la combinación que bloquea thinking.
+Migrar a `/api/chat` lo habilita.
+
+Coste esperado en latencia: thinking genera ~500-600 tokens extra en
+output (1925 chars observados en F4b). A 6.7 t/s en CPU ≈ +90s sobre el
+baseline. E2E cold pasaría de ~240s a ~330s. Aceptable dado que Meristem
+no es real-time.
+
+## Implicaciones para las 3 issues post-merge
+
+### Issue 1: "Consolidator job"
+
+Sin cambios. El diseño sigue siendo válido: disparo automático de
+`consolidate()` por N evidencias acumuladas o ventana temporal, con
+retry/backoff si Ollama no responde, circuit breaker, métricas en
+`decisions_log`. Scope independiente del hallazgo de thinking.
+
+**Orden propuesto: primera**. Es la que más valor entrega sola.
+
+### Issue 2: "A/B thinking-mode en Meristem E4B" — reformulada
+
+La formulación original asumía que podíamos activar thinking con un
+simple flag. Con los hallazgos de arriba, el scope real es:
+
+1. Añadir `OllamaClient.chat_json(system, user, schema, think=True)` usando
+   `/api/chat`. Lee `message.thinking` y `message.content`.
+2. Cambiar `policy_engine.consolidate()` para usar esa vía.
+3. Persistir `message.thinking` en `decisions_log` como auditoría del
+   razonamiento (action = `consolidation_with_thinking`).
+4. Ejecutar A/B: misma batería de evidencia, una rama con thinking, otra
+   sin. Métrica propuesta: acuerdo estructural ≥10pp entre policies
+   emitidas por ambas ramas (las diferencias serían interpretables: con
+   thinking el modelo justifica mejor `rationale`, etc.).
+5. Si la mejora es ≥10pp y la latencia extra es <50% sobre baseline,
+   activar thinking por default.
+
+**Orden propuesto: segunda**. Depende del consolidator job para poder
+comparar N ciclos automáticamente.
+
+### Issue 3: "Activación del sombra Gemma 26B MoE via `compare.py`"
+
+Sin cambios materiales, pero con refuerzo: el blog que Bea localizó
+(devexpert.io) demuestra thinking mode en **Gemma 4 26B**. Si el sombra
+también soporta thinking (probable por ser misma familia), la activación
+del sombra es el natural escalón siguiente a la issue 2: comparar
+**local con thinking** vs **sombra con thinking** para decidir si el
+sombra aporta suficiente edge.
+
+**Orden propuesto: tercera**. Depende de la 2 para tener la infraestructura
+de A/B comparativa ya construida.
+
+## Estado operativo
+
+- PR #37: listo para squash-merge. Dos comentarios tuyos respondidos.
+  Segundo comment técnico añadido con el análisis completo.
+- Commit `7628ff2` (smoke timeout 300s) incluido en el PR.
+- `diag_ollama.py`: borrado del working tree, no va al repo.
+- Clone de vuelta en `main` limpio para el siguiente agente tras commit
+  de esta bitácora.
+
+## Lo que espero de ti
+
+Cuando mergees #37, decidir:
+
+1. Si confirmas el orden propuesto de las 3 issues (consolidator → A/B
+   thinking → sombra 26B) o prefieres otra secuencia.
+2. Si la reformulación de la issue 2 te encaja o prefieres un scope
+   distinto.
+3. Si la optimización de "no duplicar schema en prompt" se hace en la
+   issue 1 (consolidator) o en la 2 (A/B thinking) — desde mi lado es
+   trivial; va como PR pequeño en cualquiera de las dos.
+
+No arranco ninguna hasta tu visto bueno, como acordamos.

--- a/code/meristem/README.md
+++ b/code/meristem/README.md
@@ -97,7 +97,7 @@ El `conftest.py` de los tests ya anade `code/shared` al path, asi que `python -m
 | `POST` | `/ingest` | Pollen empuja evidencia. Envelope `{"kind": "...", "payload": {...}}`. Kinds validos: `rhizome_snapshot`, `decision_receipt`, `weather_packet`, `contradiction_alert`. Responde 202 con `{stored_id, kind}`. 422 si el payload no valida el schema del kind. |
 | `GET` | `/policies/{rhizome_id}` | Policy activa (no expirada) mas reciente para ese nodo. 404 si no hay. |
 | `GET` | `/deltas/pending/{rhizome_id}` | Lista los `PolicyDelta` con status `pending` para ese nodo. |
-| `POST` | `/deltas/propose` | Pollen propone un `PolicyDelta`. Meristem valida el schema, comprueba que la `base_policy_id` sea la policy activa del nodo (409 si no), proyecta el delta y valida la proyeccion contra §30. Responde 201 si validated, 422 con `reason=violates_safety_rule` y lista de violaciones si no. |
+| `POST` | `/deltas/propose` | Pollen propone un `PolicyDelta`. Meristem valida el schema, comprueba que la `base_policy_id` sea la policy activa del nodo (409 si no), proyecta el delta y valida la proyeccion contra §30. Responde 201 si validated, 422 con `reason=violates_safety_rule` y lista de violaciones si no. **Idempotente por `delta_id`: reenviar el mismo delta sobrescribe la fila existente.** |
 
 ### Limites duros del firmware (docs/30 §3) aplicados pre-emit
 

--- a/code/meristem/README.md
+++ b/code/meristem/README.md
@@ -20,7 +20,7 @@ Detalle completo en [`docs/12_meristem_spec.md`](../../docs/12_meristem_spec.md)
 - `sqlite3` para persistencia
 - `google-genai` **solo si** `SHADOW_ENABLED=true` (Meristem sombra para validacion en dev)
 
-## Estructura actual (bootstrap)
+## Estructura actual
 
 ```
 meristem/
@@ -30,26 +30,32 @@ meristem/
 ├── .env.example
 ├── src/
 │   ├── __init__.py
-│   ├── main.py             # FastAPI app, /health
+│   ├── main.py             # FastAPI app, /health + router /ingest, /policies, /deltas
+│   ├── routes.py           # endpoints HTTP
 │   ├── settings.py         # env vars -> Settings
-│   ├── llm_client.py       # Ollama client (stub)
-│   ├── persistence.py      # SQLite schema init
+│   ├── llm_client.py       # Ollama client (ping + generate_json)
+│   ├── persistence.py      # SQLite schema + helpers CRUD
+│   ├── safety_rules.py     # validador pre-emit §30 (max_duration, tank_min)
+│   ├── policy_engine.py    # consolidacion: evidence + policy -> LLM -> validate -> persist
 │   ├── prompts/
-│   │   └── system_v1.txt   # draft del system prompt de Meristem
+│   │   └── system_v1.txt   # system prompt de Meristem
 │   └── shadow/             # Meristem sombra (solo dev, flag-gated)
 │       ├── __init__.py
-│       ├── shadow_client.py
-│       └── compare.py
+│       └── shadow_client.py
 └── tests/
     ├── conftest.py
     ├── test_settings.py
     ├── test_health.py
-    ├── test_shadow_off.py      # negativo: shadow no carga con flag off
+    ├── test_shadow_off.py         # negativo: shadow no carga con flag off
     ├── test_schemas_importable.py
-    └── test_llm_client.py
+    ├── test_llm_client.py
+    ├── test_safety_rules.py       # validador §30 (unit)
+    ├── test_ingest.py             # /ingest con fixtures canonicos + 422
+    ├── test_policies.py           # GET /policies/{rhizome_id}
+    ├── test_deltas.py             # /deltas/pending + /deltas/propose (§30)
+    ├── test_policy_engine.py      # engine con LLM mock (happy + §30)
+    └── test_smoke_ollama.py       # marcado @pytest.mark.ollama (skip sin daemon)
 ```
-
-El policy_engine real (consolidacion + llamada a E4B) entra en PR siguiente, con su propia bitacora.
 
 ## Variables de entorno
 
@@ -85,18 +91,42 @@ El `conftest.py` de los tests ya anade `code/shared` al path, asi que `python -m
 
 ## Endpoints
 
-- `GET /health` — liveness
+| Metodo | Path | Descripcion |
+|---|---|---|
+| `GET` | `/health` | Liveness + metadata (version, modelo, shadow_enabled). |
+| `POST` | `/ingest` | Pollen empuja evidencia. Envelope `{"kind": "...", "payload": {...}}`. Kinds validos: `rhizome_snapshot`, `decision_receipt`, `weather_packet`, `contradiction_alert`. Responde 202 con `{stored_id, kind}`. 422 si el payload no valida el schema del kind. |
+| `GET` | `/policies/{rhizome_id}` | Policy activa (no expirada) mas reciente para ese nodo. 404 si no hay. |
+| `GET` | `/deltas/pending/{rhizome_id}` | Lista los `PolicyDelta` con status `pending` para ese nodo. |
+| `POST` | `/deltas/propose` | Pollen propone un `PolicyDelta`. Meristem valida el schema, comprueba que la `base_policy_id` sea la policy activa del nodo (409 si no), proyecta el delta y valida la proyeccion contra §30. Responde 201 si validated, 422 con `reason=violates_safety_rule` y lista de violaciones si no. |
 
-Endpoints de ingest/emision (`/ingest`, `/policies/*`, `/deltas/*`) se anaden en PR siguiente.
+### Limites duros del firmware (docs/30 §3) aplicados pre-emit
+
+`safety_rules.py` bloquea la emision/aceptacion si un PolicyPacket o la proyeccion de un PolicyDelta infringe:
+
+- `rules.max_watering_duration_s > 60` → bloquea (§30.1).
+- `rules.tank_minimum_pct < 20` → bloquea (§30.2).
+
+Rate limits 8/h y 48/dia y concurrencia de zonas NO son pre-checkables desde PolicyPacket v1.0 (no hay campos de scheduling ni caudal). Se consolidaran post-hoc via `REJECTED RATE_LIMIT_*` observados en DecisionReceipts en un PR futuro. Ver bitacora `2026-04-18_drafts-subissue-30-gaps_meristem.md` y aclaracion de Cambium (2026-04-19).
+
+## Policy engine
+
+`policy_engine.consolidate(db_path, target_node_id, evidence, llm)` es la API interna (no expuesta HTTP en este PR):
+
+1. Lee la policy activa y la pasa al user prompt como contexto.
+2. Llama a Ollama con `system_v1.txt` + schema de `PolicyPacket` como structured output.
+3. Valida la salida contra `PolicyPacket` (pydantic).
+4. Si es valida, aplica `safety_rules.check_policy_packet`.
+5. Si pasa, persiste como policy activa. Si no, loguea el intento en `decisions_log` con action `blocked_by_safety` o `blocked_invalid_schema` y retorna `EngineResult(packet=None, reason=...)`.
 
 ## Tests
 
 ```bash
 cd code/meristem
-python -m pytest tests -v
+python -m pytest tests -v               # suite completa (skippea Ollama smoke)
+python -m pytest -m ollama tests -v     # solo smoke, requiere daemon + gemma4:e4b
 ```
 
-Cobertura del bootstrap: settings, /health + init SQLite, cliente Ollama, shadow off por construccion, importacion de los 6 schemas canonicos.
+Cobertura: settings, /health + init SQLite, cliente Ollama, shadow off por construccion, importacion de los 6 schemas canonicos, validador §30 (unit + integrado), los 4 endpoints, policy_engine con LLM mock.
 
 ## Regla dura del sombra
 

--- a/code/meristem/pyproject.toml
+++ b/code/meristem/pyproject.toml
@@ -23,3 +23,6 @@ shadow = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+markers = [
+    "ollama: test que requiere un daemon Ollama activo (skip automatico si no responde).",
+]

--- a/code/meristem/src/llm_client.py
+++ b/code/meristem/src/llm_client.py
@@ -1,12 +1,17 @@
 """Cliente Ollama para el modelo local (Gemma 4 E4B).
 
-Este modulo es un **stub** en el bootstrap: configura el cliente HTTP y expone
-`ping()` para verificar que el daemon responde. El razonamiento real (llamada
-a `/api/generate` o `/api/chat` con prompts del policy_engine) entra en el PR
-siguiente junto con su bitacora.
+Dos operaciones:
+- `ping()`: chequeo de salud contra `/api/tags`. Usado por el smoke test.
+- `generate_json(system, user, schema)`: llamada a `/api/generate` con
+  structured output. Ollama (>=0.1.30) acepta `format` como JSON schema dict
+  y garantiza salida parseable. El modulo no asume `pydantic` aqui — devuelve
+  el dict y deja que el caller valide con su schema.
 """
 
 from __future__ import annotations
+
+import json
+from typing import Any
 
 import httpx
 
@@ -16,7 +21,10 @@ from .settings import Settings
 class OllamaClient:
     """Wrapper minimo sobre el endpoint HTTP de Ollama."""
 
-    def __init__(self, settings: Settings, timeout_s: float = 5.0) -> None:
+    def __init__(self, settings: Settings, timeout_s: float = 120.0) -> None:
+        # timeout alto por defecto porque /api/generate con structured output
+        # sobre E4B tipicamente tarda 20-40s en hardware modesto. El ping
+        # usa su propio timeout corto sobre el mismo cliente.
         self._host = settings.ollama_host.rstrip("/")
         self._model = settings.ollama_model
         self._client = httpx.Client(base_url=self._host, timeout=timeout_s)
@@ -25,13 +33,52 @@ class OllamaClient:
     def model(self) -> str:
         return self._model
 
-    def ping(self) -> bool:
+    def ping(self, timeout_s: float = 2.0) -> bool:
         """Consulta `/api/tags`. Devuelve True si Ollama responde 200."""
         try:
-            response = self._client.get("/api/tags")
+            response = self._client.get("/api/tags", timeout=timeout_s)
         except httpx.HTTPError:
             return False
         return response.status_code == 200
+
+    def generate_json(
+        self,
+        system: str,
+        user: str,
+        schema: dict[str, Any] | None = None,
+        temperature: float = 0.2,
+    ) -> dict[str, Any]:
+        """Invoca `/api/generate` pidiendo JSON como salida.
+
+        Si `schema` es un JSON Schema, Ollama fuerza el formato contra el.
+        Si es None, se pide solo `format="json"` (valido pero sin garantia
+        de estructura).
+
+        Levanta:
+        - httpx.HTTPError si el daemon no responde o devuelve != 2xx.
+        - ValueError si la respuesta no es JSON parseable.
+        """
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "system": system,
+            "prompt": user,
+            "stream": False,
+            "options": {"temperature": temperature},
+        }
+        payload["format"] = schema if schema is not None else "json"
+
+        response = self._client.post("/api/generate", json=payload)
+        response.raise_for_status()
+        body = response.json()
+        raw = body.get("response", "")
+        if not raw:
+            raise ValueError("Ollama devolvio respuesta vacia")
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Ollama no devolvio JSON parseable: {raw[:200]}"
+            ) from exc
 
     def close(self) -> None:
         self._client.close()

--- a/code/meristem/src/main.py
+++ b/code/meristem/src/main.py
@@ -1,7 +1,12 @@
 """Entrypoint HTTP de Meristem (FastAPI).
 
-Bootstrap: solo expone `/health`. Los endpoints de ingest y emision de
-policies se montan en PRs posteriores junto con el policy_engine.
+Expone:
+- `/health`               → liveness + metadata.
+- `/ingest`               → Pollen empuja evidencia.
+- `/policies/{rhizome_id}`→ policy activa.
+- `/deltas/pending/{rhizome_id}` + `/deltas/propose`.
+
+Ver `src/routes.py`.
 
 Shadow (Meristem sombra contra Gemma 4 31B cloud) solo se importa si el
 flag `SHADOW_ENABLED` esta activo. Con flag apagado, `google.genai` no debe
@@ -14,6 +19,7 @@ from fastapi import FastAPI
 
 from . import __version__
 from .persistence import init_db
+from .routes import router as api_router
 from .settings import Settings, load_settings
 
 
@@ -37,6 +43,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "shadow_enabled": settings.shadow_enabled,
         }
 
+    app.include_router(api_router)
     return app
 
 

--- a/code/meristem/src/persistence.py
+++ b/code/meristem/src/persistence.py
@@ -1,22 +1,23 @@
 """Persistencia local de Meristem.
 
-SQLite, sin servidor externo. En el bootstrap solo garantizamos que las
-tablas existen para que el PR del policy_engine pueda empezar a escribir.
+SQLite, sin servidor externo. Tablas (spec 12_meristem_spec.md §7):
 
-Tablas (spec 12_meristem_spec.md §7):
 - `evidence`: snapshots, alerts, packets entrantes (raw JSON).
 - `policies`: policy_packets emitidos.
-- `deltas`: policy_deltas propuestos/validados/revocados.
-- `decisions_log`: decisiones importadas via Pollen para auditoria.
+- `deltas`: policy_deltas propuestos/validados/rechazados.
+- `decisions_log`: decisiones importadas via Pollen + intentos bloqueados
+  por safety_rules (auditoria local, ver §30 Gap 4).
 - `shadow_comparisons`: diffs local vs sombra (solo si SHADOW_ENABLED).
 """
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator
 
 _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS evidence (
@@ -27,6 +28,9 @@ CREATE TABLE IF NOT EXISTS evidence (
     payload_json TEXT NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_evidence_kind ON evidence(kind);
+CREATE INDEX IF NOT EXISTS idx_evidence_origin ON evidence(origin_node_id);
+
 CREATE TABLE IF NOT EXISTS policies (
     policy_id TEXT PRIMARY KEY,
     target_node_id TEXT NOT NULL,
@@ -35,17 +39,22 @@ CREATE TABLE IF NOT EXISTS policies (
     payload_json TEXT NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_policies_target ON policies(target_node_id);
+
 CREATE TABLE IF NOT EXISTS deltas (
     delta_id TEXT PRIMARY KEY,
     target_node_id TEXT NOT NULL,
     base_policy_id TEXT NOT NULL,
     status TEXT NOT NULL,
+    reason TEXT,
     created_at TEXT NOT NULL,
     payload_json TEXT NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_deltas_target_status ON deltas(target_node_id, status);
+
 CREATE TABLE IF NOT EXISTS decisions_log (
-    decision_id TEXT PRIMARY KEY,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     origin_node_id TEXT NOT NULL,
     received_at TEXT NOT NULL,
     action TEXT NOT NULL,
@@ -62,6 +71,13 @@ CREATE TABLE IF NOT EXISTS shadow_comparisons (
 );
 """
 
+# Estados posibles del campo `deltas.status`. Son los que usa /deltas/propose
+# y /deltas/pending. `pending` existe para el flujo ideal (Pollen propone,
+# Meristem valida en batch) aunque en este PR /deltas/propose valida sincrono.
+DELTA_STATUS_PENDING = "pending"
+DELTA_STATUS_VALIDATED = "validated"
+DELTA_STATUS_REJECTED = "rejected"
+
 
 def init_db(db_path: str | Path) -> None:
     """Crea las tablas si no existen. Idempotente."""
@@ -75,10 +91,148 @@ def init_db(db_path: str | Path) -> None:
 
 @contextmanager
 def connect(db_path: str | Path) -> Iterator[sqlite3.Connection]:
-    """Context manager que devuelve una conexion SQLite con row_factory."""
+    """Context manager con row_factory preconfigurada."""
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     try:
         yield conn
     finally:
         conn.close()
+
+
+def _utcnow_zulu() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Evidence
+# ---------------------------------------------------------------------------
+
+def insert_evidence(
+    db_path: str | Path,
+    kind: str,
+    origin_node_id: str,
+    payload: dict[str, Any],
+) -> int:
+    """Persiste un payload de evidence. Devuelve el rowid asignado."""
+    with connect(db_path) as conn:
+        cur = conn.execute(
+            "INSERT INTO evidence(received_at, kind, origin_node_id, payload_json) "
+            "VALUES (?, ?, ?, ?)",
+            (_utcnow_zulu(), kind, origin_node_id, json.dumps(payload)),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# Policies
+# ---------------------------------------------------------------------------
+
+def upsert_policy(db_path: str | Path, packet: dict[str, Any]) -> None:
+    """Persiste una PolicyPacket ya validada. Si ya existe policy_id, la
+    sustituye — idempotencia por policy_id.
+    """
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO policies"
+            "(policy_id, target_node_id, created_at, valid_until, payload_json) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                packet["policy_id"],
+                packet["target_node_id"],
+                packet["created_at"],
+                packet["valid_until"],
+                json.dumps(packet),
+            ),
+        )
+        conn.commit()
+
+
+def get_active_policy(
+    db_path: str | Path, target_node_id: str, now: datetime | None = None
+) -> dict[str, Any] | None:
+    """Devuelve la PolicyPacket activa (no expirada) mas reciente para el
+    nodo, o None si no hay ninguna.
+    """
+    now = now or datetime.now(timezone.utc)
+    now_str = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT payload_json FROM policies "
+            "WHERE target_node_id = ? AND valid_until > ? "
+            "ORDER BY created_at DESC LIMIT 1",
+            (target_node_id, now_str),
+        ).fetchone()
+    if row is None:
+        return None
+    return json.loads(row["payload_json"])
+
+
+# ---------------------------------------------------------------------------
+# Deltas
+# ---------------------------------------------------------------------------
+
+def insert_delta(
+    db_path: str | Path,
+    delta: dict[str, Any],
+    status: str,
+    reason: str | None = None,
+) -> None:
+    """Persiste un PolicyDelta con su status (`pending`/`validated`/`rejected`)."""
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO deltas"
+            "(delta_id, target_node_id, base_policy_id, status, reason, "
+            "created_at, payload_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                delta["delta_id"],
+                delta["target_node_id"],
+                delta["base_policy_id"],
+                status,
+                reason,
+                delta["created_at"],
+                json.dumps(delta),
+            ),
+        )
+        conn.commit()
+
+
+def list_deltas(
+    db_path: str | Path, target_node_id: str, status: str
+) -> list[dict[str, Any]]:
+    """Lista los deltas en un estado para un nodo. Ordenados por created_at asc."""
+    with connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT payload_json FROM deltas "
+            "WHERE target_node_id = ? AND status = ? "
+            "ORDER BY created_at ASC",
+            (target_node_id, status),
+        ).fetchall()
+    return [json.loads(r["payload_json"]) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Decisions log (auditoria local)
+# ---------------------------------------------------------------------------
+
+def append_decision_log(
+    db_path: str | Path,
+    origin_node_id: str,
+    action: str,
+    payload: dict[str, Any],
+) -> int:
+    """Anade una entrada al log de decisiones. Uso:
+    - Decisiones importadas via Pollen (action = receipt.action, payload = receipt).
+    - Intentos de emision bloqueados por safety_rules (action = 'blocked_by_safety',
+      payload = {packet/delta intentado, violaciones}). Ver §30 Gap 4.
+    """
+    with connect(db_path) as conn:
+        cur = conn.execute(
+            "INSERT INTO decisions_log(origin_node_id, received_at, action, payload_json) "
+            "VALUES (?, ?, ?, ?)",
+            (origin_node_id, _utcnow_zulu(), action, json.dumps(payload)),
+        )
+        conn.commit()
+        return int(cur.lastrowid)

--- a/code/meristem/src/policy_engine.py
+++ b/code/meristem/src/policy_engine.py
@@ -1,0 +1,153 @@
+"""Consolidador de evidencia + emision de PolicyPacket.
+
+Flujo (spec 12 §6):
+
+    evidence + active_policy  ──►  prompt  ──►  Ollama E4B  ──►  JSON raw
+                                                                      │
+                                                                      ▼
+                                                             PolicyPacket.validate
+                                                                      │
+                                                                      ▼
+                                                             safety_rules.check
+                                                                 ┌────┴────┐
+                                                             OK  │         │ violaciones
+                                                                 ▼         ▼
+                                                          persist()   log blocked
+                                                                      return None
+
+Reglas clave:
+- Si el JSON del modelo no valida el schema → no persiste, devuelve None y
+  loguea el intento.
+- Si valida el schema pero viola §30 → no persiste, loguea el intento en
+  `decisions_log` con action="blocked_by_safety" (ver Gap 4 del draft de
+  sub-issue 2026-04-18), devuelve None.
+- Si todo OK → persiste como policy activa, devuelve la packet.
+
+Este modulo NO esta expuesto como endpoint en este PR. Se invoca desde un
+consolidator job (fuera de alcance, PR siguiente) o desde tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+from schemas import PolicyPacket
+
+from . import safety_rules
+from .llm_client import OllamaClient
+from .persistence import (
+    append_decision_log,
+    get_active_policy,
+    upsert_policy,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+_SYSTEM_PROMPT_PATH = _PROMPTS_DIR / "system_v1.txt"
+
+
+@dataclass(frozen=True)
+class EngineResult:
+    """Resultado de un ciclo de consolidacion."""
+
+    packet: PolicyPacket | None
+    reason: str | None  # None si OK; "invalid_schema" / "violates_safety_rule" si no
+    violations: list[dict[str, Any]] | None = None
+
+
+def load_system_prompt() -> str:
+    return _SYSTEM_PROMPT_PATH.read_text(encoding="utf-8")
+
+
+def build_user_prompt(
+    target_node_id: str,
+    evidence: list[dict[str, Any]],
+    active_policy: dict[str, Any] | None,
+) -> str:
+    """Formatea el contexto para la llamada al modelo.
+
+    El schema se incluye textualmente para anclar la salida; Ollama lo usa
+    tambien como `format` en la llamada HTTP, pero duplicarlo en el prompt
+    mejora la coherencia en modelos pequenos (E4B).
+    """
+    schema_json = json.dumps(PolicyPacket.model_json_schema(), indent=2)
+    active_block = (
+        json.dumps(active_policy, indent=2)
+        if active_policy is not None
+        else "null"
+    )
+    evidence_block = json.dumps(evidence, indent=2)
+
+    return (
+        f"Nodo objetivo: {target_node_id}\n\n"
+        f"Politica actualmente activa (o null si no hay):\n{active_block}\n\n"
+        f"Evidencia reciente ({len(evidence)} items):\n{evidence_block}\n\n"
+        f"Schema PolicyPacket v1.0 al que debe ajustarse tu salida:\n{schema_json}\n\n"
+        "Emite UN solo JSON que valide contra el schema. Nada mas."
+    )
+
+
+def consolidate(
+    db_path: str | Path,
+    target_node_id: str,
+    evidence: list[dict[str, Any]],
+    llm: OllamaClient,
+) -> EngineResult:
+    """Ejecuta un ciclo de consolidacion para `target_node_id`.
+
+    `evidence` es la lista de payloads crudos ya acumulados por /ingest
+    (normalmente ultimos N snapshots + weather packets + alerts). El caller
+    decide que subset pasa; aqui se usa tal cual.
+    """
+    system = load_system_prompt()
+    active = get_active_policy(db_path, target_node_id)
+    user = build_user_prompt(target_node_id, evidence, active)
+
+    schema = PolicyPacket.model_json_schema()
+    raw = llm.generate_json(system=system, user=user, schema=schema)
+
+    try:
+        packet = PolicyPacket.model_validate(raw)
+    except ValidationError as exc:
+        logger.warning(
+            "LLM produjo JSON que no valida PolicyPacket: %s", exc.errors()
+        )
+        append_decision_log(
+            db_path,
+            origin_node_id="meristem_01",
+            action="blocked_invalid_schema",
+            payload={"raw_output": raw, "errors": exc.errors()},
+        )
+        return EngineResult(
+            packet=None, reason="invalid_schema", violations=None
+        )
+
+    violations = safety_rules.check_policy_packet(packet)
+    if violations:
+        logger.warning(
+            "LLM produjo PolicyPacket que viola §30: %s",
+            [v.rule for v in violations],
+        )
+        append_decision_log(
+            db_path,
+            origin_node_id="meristem_01",
+            action="blocked_by_safety",
+            payload={
+                "attempted_packet": packet.model_dump(mode="json"),
+                "violations": [v.to_dict() for v in violations],
+            },
+        )
+        return EngineResult(
+            packet=None,
+            reason=safety_rules.REASON_VIOLATES_SAFETY_RULE,
+            violations=[v.to_dict() for v in violations],
+        )
+
+    upsert_policy(db_path, packet.model_dump(mode="json"))
+    return EngineResult(packet=packet, reason=None, violations=None)

--- a/code/meristem/src/prompts/system_v1.txt
+++ b/code/meristem/src/prompts/system_v1.txt
@@ -1,25 +1,40 @@
 Eres Meristem, el nodo estrategico de Sprout, una red agricola local-first.
 
-Tu rol:
-- Consolidar evidencia recibida de multiples parcelas via Pollen (snapshots,
-  alertas de contradiccion, weather packets).
+Rol:
+- Consolidar evidencia recibida de parcelas via Pollen (snapshots, alertas
+  de contradiccion, weather packets, decision receipts).
 - Revisar si las politicas vigentes siguen siendo adecuadas.
-- Emitir nuevas politicas (PolicyPacket) o cambios incrementales
-  (PolicyDelta) cuando el contexto lo exige.
+- Emitir una PolicyPacket nueva que Rhizome aplicara hasta su expiracion.
+
+No emites comandos, no decides regar ahora. Decides COMO debe razonar
+Rhizome durante las proximas horas. Rhizome ejecuta, tu orientas.
 
 Principios duros (no negociables):
 - Nunca ordenas acciones inmediatas. Emites politicas con TTL.
-- Toda politica tiene caducidad explicita (`valid_until`).
-- Cuando hay contradicciones entre parcelas, prefiere la prudencia.
-- Cuando los datos tienen mas de 48 h, marca menor confianza.
-- Respeta SIEMPRE los limites duros del firmware ESP32:
-  * max_watering_duration_s <= 60
-  * tank_minimum_pct >= 20
-  * max 8 aperturas/hora por zona, 48/dia
-  * zonas simultaneas = 1
-  Si generas una politica que viola estos limites, el firmware la rechaza y
-  se emite ContradictionAlert. Evitalo.
-- Produces SOLO JSON valido conforme al schema provisto.
+- Toda politica tiene caducidad explicita (`valid_until`, minimo 1 hora
+  despues de `created_at`).
+- Cuando hay contradicciones entre parcelas o entre sensor y vision,
+  prefiere la prudencia: modo "conservative", tank_minimum_pct mas alto,
+  daily_water_budget_liters mas bajo.
+- Cuando los datos tienen mas de 48 h, marca menor confianza en la
+  rationale y sube los umbrales conservadores.
+- Respeta SIEMPRE los limites duros del firmware ESP32 (docs/30 §3). El
+  firmware los aplicara igual; si los violas, solo generas ruido en alertas:
+    * rules.max_watering_duration_s <= 60 (el firmware corta a 60s).
+    * rules.tank_minimum_pct >= 20 (proteccion de la bomba sumergible).
+    * Una zona a la vez (el firmware rechaza concurrencia).
+    * Max 8 aperturas/hora y 48/dia por zona (el firmware hace rate-limit).
+  Estos limites son minimos absolutos: si la evidencia lo justifica, puedes
+  ser mas conservador (tank_minimum_pct=30, duracion 30s), nunca menos.
 
-Este prompt es el draft v1 del bootstrap. Se itera en PRs posteriores con
-su bitacora.
+Restricciones de salida:
+- Produces SOLO un JSON valido conforme al schema PolicyPacket v1.0 que se
+  incluye en el user prompt. Nada de prosa fuera del JSON.
+- schema_version siempre "1.0".
+- origin_node_id siempre "meristem_01".
+- version_chain debe incluir el policy_id previo (si lo hay) seguido del
+  nuevo. Si no hay previo, solo el nuevo.
+- rationale breve y concreta (< 400 chars): que evidencia pesa mas, que
+  cambia respecto a la politica anterior.
+
+Estilo: sobrio, tecnico, sin floritura. Eres un consolidador, no un narrador.

--- a/code/meristem/src/routes.py
+++ b/code/meristem/src/routes.py
@@ -1,0 +1,237 @@
+"""Endpoints HTTP de Meristem.
+
+Montados sobre un APIRouter que `main.create_app` incluye. La config
+(db_path principalmente) se lee desde `request.app.state.settings`.
+
+Endpoints:
+
+- POST /ingest             — Pollen empuja evidencia (snapshot/receipt/weather/alert).
+- GET  /policies/{target}  — lee la policy activa del target (o 404).
+- GET  /deltas/pending/{target} — lista deltas en estado `pending`.
+- POST /deltas/propose     — Pollen propone un delta; Meristem lo valida
+                             contra §30 y lo persiste como validated/rejected.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, ValidationError
+from schemas import (
+    ContradictionAlert,
+    DecisionReceipt,
+    PolicyDelta,
+    PolicyPacket,
+    RhizomeSnapshot,
+    WeatherPacket,
+)
+
+from . import persistence, safety_rules
+
+router = APIRouter()
+
+
+# Mapeo `kind` → modelo pydantic. Controla el discriminador de /ingest y la
+# lista de tipos de evidencia que Meristem acepta consumir.
+INGEST_KINDS: dict[str, type] = {
+    "rhizome_snapshot": RhizomeSnapshot,
+    "decision_receipt": DecisionReceipt,
+    "weather_packet": WeatherPacket,
+    "contradiction_alert": ContradictionAlert,
+}
+
+
+class IngestEnvelope(BaseModel):
+    """Envoltorio minimo para /ingest: `kind` + `payload` crudo.
+
+    El payload se valida contra el modelo correspondiente a `kind` dentro
+    del handler; aqui solo tipamos el envelope.
+    """
+
+    kind: Literal[
+        "rhizome_snapshot",
+        "decision_receipt",
+        "weather_packet",
+        "contradiction_alert",
+    ]
+    payload: dict[str, Any]
+
+
+class IngestResponse(BaseModel):
+    stored_id: int
+    kind: str
+
+
+def _db_path(request: Request) -> str:
+    return request.app.state.settings.db_path
+
+
+# ---------------------------------------------------------------------------
+# POST /ingest
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/ingest",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=IngestResponse,
+)
+def ingest(envelope: IngestEnvelope, request: Request) -> IngestResponse:
+    model_cls = INGEST_KINDS[envelope.kind]
+    try:
+        parsed = model_cls.model_validate(envelope.payload)
+    except ValidationError as exc:
+        # Reemitimos como 422 con los errores pydantic, sin exponer stacktrace.
+        raise HTTPException(
+            status_code=422,  # Unprocessable Content. Constante renombrada en Starlette nuevo; usamos literal para evitar DeprecationWarning cross-version.
+            detail={"kind": envelope.kind, "errors": exc.errors()},
+        )
+
+    canonical = parsed.model_dump(mode="json")
+    stored_id = persistence.insert_evidence(
+        _db_path(request),
+        kind=envelope.kind,
+        origin_node_id=canonical["origin_node_id"],
+        payload=canonical,
+    )
+    return IngestResponse(stored_id=stored_id, kind=envelope.kind)
+
+
+# ---------------------------------------------------------------------------
+# GET /policies/{rhizome_id}
+# ---------------------------------------------------------------------------
+
+@router.get("/policies/{rhizome_id}")
+def get_policy(rhizome_id: str, request: Request) -> dict[str, Any]:
+    policy = persistence.get_active_policy(_db_path(request), rhizome_id)
+    if policy is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"rhizome_id": rhizome_id, "reason": "no_active_policy"},
+        )
+    return policy
+
+
+# ---------------------------------------------------------------------------
+# GET /deltas/pending/{rhizome_id}
+# ---------------------------------------------------------------------------
+
+@router.get("/deltas/pending/{rhizome_id}")
+def list_pending_deltas(
+    rhizome_id: str, request: Request
+) -> dict[str, Any]:
+    deltas = persistence.list_deltas(
+        _db_path(request), rhizome_id, persistence.DELTA_STATUS_PENDING
+    )
+    return {"rhizome_id": rhizome_id, "deltas": deltas, "count": len(deltas)}
+
+
+# ---------------------------------------------------------------------------
+# POST /deltas/propose
+# ---------------------------------------------------------------------------
+
+class DeltaProposeResponse(BaseModel):
+    delta_id: str
+    status: str
+    reason: str | None = None
+    violations: list[dict[str, Any]] | None = None
+
+
+@router.post("/deltas/propose", status_code=status.HTTP_201_CREATED)
+def propose_delta(
+    payload: dict[str, Any], request: Request
+) -> DeltaProposeResponse:
+    # Paso 1: validar schema del delta.
+    try:
+        delta = PolicyDelta.model_validate(payload)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,  # Unprocessable Content. Constante renombrada en Starlette nuevo; usamos literal para evitar DeprecationWarning cross-version.
+            detail={"kind": "policy_delta", "errors": exc.errors()},
+        )
+
+    db = _db_path(request)
+
+    # Paso 2: la policy base debe existir y no haber expirado. Sin base no se
+    # puede proyectar el delta, asi que no se puede evaluar §30.
+    active = persistence.get_active_policy(db, delta.target_node_id)
+    if active is None or active["policy_id"] != delta.base_policy_id:
+        detail = {
+            "delta_id": delta.delta_id,
+            "reason": "base_policy_not_active",
+            "base_policy_id": delta.base_policy_id,
+            "active_policy_id": active["policy_id"] if active else None,
+        }
+        # Persistimos como rejected para auditoria antes de devolver error.
+        persistence.insert_delta(
+            db,
+            delta=delta.model_dump(mode="json"),
+            status=persistence.DELTA_STATUS_REJECTED,
+            reason="base_policy_not_active",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=detail
+        )
+
+    # Paso 3: proyectar delta sobre base y validar §30.
+    try:
+        base_packet = PolicyPacket.model_validate(active)
+        violations = safety_rules.check_delta_against_base(
+            delta, base_packet
+        )
+    except ValidationError as exc:
+        # Proyeccion invalida a nivel de schema (ej: target_pct < min_pct tras
+        # el patch). Tratamos como violacion "suave" del contrato.
+        persistence.insert_delta(
+            db,
+            delta=delta.model_dump(mode="json"),
+            status=persistence.DELTA_STATUS_REJECTED,
+            reason="projection_invalid_schema",
+        )
+        raise HTTPException(
+            status_code=422,  # Unprocessable Content. Constante renombrada en Starlette nuevo; usamos literal para evitar DeprecationWarning cross-version.
+            detail={
+                "delta_id": delta.delta_id,
+                "reason": "projection_invalid_schema",
+                "errors": exc.errors(),
+            },
+        )
+
+    if violations:
+        violation_dicts = [v.to_dict() for v in violations]
+        persistence.insert_delta(
+            db,
+            delta=delta.model_dump(mode="json"),
+            status=persistence.DELTA_STATUS_REJECTED,
+            reason=safety_rules.REASON_VIOLATES_SAFETY_RULE,
+        )
+        # Rastro auditable del intento (Gap 4: no usamos ContradictionAlert).
+        persistence.append_decision_log(
+            db,
+            origin_node_id=delta.origin_node_id,
+            action="blocked_by_safety",
+            payload={
+                "attempted_delta": delta.model_dump(mode="json"),
+                "violations": violation_dicts,
+            },
+        )
+        raise HTTPException(
+            status_code=422,  # Unprocessable Content. Constante renombrada en Starlette nuevo; usamos literal para evitar DeprecationWarning cross-version.
+            detail={
+                "delta_id": delta.delta_id,
+                "reason": safety_rules.REASON_VIOLATES_SAFETY_RULE,
+                "violations": violation_dicts,
+            },
+        )
+
+    # Paso 4: delta valido. Persistimos como validated.
+    persistence.insert_delta(
+        db,
+        delta=delta.model_dump(mode="json"),
+        status=persistence.DELTA_STATUS_VALIDATED,
+        reason=None,
+    )
+    return DeltaProposeResponse(
+        delta_id=delta.delta_id,
+        status=persistence.DELTA_STATUS_VALIDATED,
+    )

--- a/code/meristem/src/safety_rules.py
+++ b/code/meristem/src/safety_rules.py
@@ -1,0 +1,152 @@
+"""Pre-emit validador de limites duros del firmware sobre PolicyPacket y
+PolicyDelta.
+
+Filosofia (docs/30_safety_rules.md §3): el firmware ESP32 impone limites
+hardcoded que no se pueden relajar desde Python. Si Meristem emite una
+politica con `max_watering_duration_s=120`, el firmware la ignora y corta a
+60s igual. Este modulo se anticipa a ese rechazo: bloquea la emision en
+origen y deja rastro auditable del intento, evitando ruido en el tablero de
+alertas y DecisionReceipts de `BLOCK`.
+
+Los schemas v1.0 permiten rangos mas amplios que §30 (ej: schema permite
+`tank_minimum_pct>=10`, §30 exige 20). Este modulo implementa la version
+estricta de §30 — es lo que Cambium llamo "piso politico con suelo duro" en
+su mensaje de 2026-04-19 cerrando los 4 gaps detectados.
+
+Cobertura:
+- `rules.max_watering_duration_s <= 60`                   [§3.1]
+- `rules.tank_minimum_pct >= 20.0`                        [§3.2]
+- Rate limits (8/h, 48/dia)  → NO expresable en v1.0     [Gap 2]
+- Concurrencia zonas          → NO expresable en v1.0     [Gap 3]
+
+Gap 2 y 3 se consolidan post-hoc via `REJECTED RATE_LIMIT_*` y
+`REJECTED ZONE_IN_USE` observados en DecisionReceipts (fuera del scope de
+este PR). Ver bitacora 2026-04-18_drafts-subissue-30-gaps_meristem.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from schemas import PolicyDelta, PolicyPacket
+from schemas.enums import PatchOperation
+
+# Limites espejo de docs/30_safety_rules.md §3. Si §30 cambia, esto tambien.
+# No se lee de config — son limites fisicos del firmware.
+FIRMWARE_MAX_WATERING_DURATION_S: int = 60
+FIRMWARE_TANK_MINIMUM_PCT: float = 20.0
+
+# Rason unica que se expone al cliente cuando el validador bloquea. Cambium
+# (2026-04-19 Gap 4): el rechazo se devuelve como 422 con esta reason; no se
+# emite ContradictionAlert porque los tipos canonicos no cubren el caso.
+REASON_VIOLATES_SAFETY_RULE: str = "violates_safety_rule"
+
+
+@dataclass(frozen=True)
+class SafetyViolation:
+    """Un parametro de politica que excede un limite duro del firmware."""
+
+    rule: str
+    proposed_value: Any
+    firmware_limit: Any
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule": self.rule,
+            "proposed_value": self.proposed_value,
+            "firmware_limit": self.firmware_limit,
+            "detail": self.detail,
+        }
+
+
+def check_policy_packet(packet: PolicyPacket) -> list[SafetyViolation]:
+    """Valida un PolicyPacket contra §30. Lista vacia si todo esta bien."""
+    violations: list[SafetyViolation] = []
+
+    duration = packet.rules.max_watering_duration_s
+    if duration > FIRMWARE_MAX_WATERING_DURATION_S:
+        violations.append(
+            SafetyViolation(
+                rule="rules.max_watering_duration_s",
+                proposed_value=duration,
+                firmware_limit=FIRMWARE_MAX_WATERING_DURATION_S,
+                detail=(
+                    f"El firmware corta a {FIRMWARE_MAX_WATERING_DURATION_S}s "
+                    f"por §30.1; la politica pide {duration}s."
+                ),
+            )
+        )
+
+    tank_min = packet.rules.tank_minimum_pct
+    if tank_min < FIRMWARE_TANK_MINIMUM_PCT:
+        violations.append(
+            SafetyViolation(
+                rule="rules.tank_minimum_pct",
+                proposed_value=tank_min,
+                firmware_limit=FIRMWARE_TANK_MINIMUM_PCT,
+                detail=(
+                    f"El firmware exige >= {FIRMWARE_TANK_MINIMUM_PCT}% "
+                    f"por §30.2; la politica pide {tank_min}%."
+                ),
+            )
+        )
+
+    # Rate limits §30.1 (8/h, 48/dia) y concurrencia §30.2: no-op en v1.0.
+    # PolicyPacket no modela scheduling ni cadencia. Ver Gap 2 y Gap 3.
+
+    return violations
+
+
+def check_delta_against_base(
+    delta: PolicyDelta, base: PolicyPacket
+) -> list[SafetyViolation]:
+    """Proyecta el delta sobre la packet base y valida la proyeccion.
+
+    Es la forma correcta de validar un delta: un patch puede parecer inocuo
+    visto solo ("replace rules.max_watering_duration_s = 120") pero la
+    proyeccion resultante es la que termina llegando al firmware.
+    """
+    projected = project_delta(delta, base)
+    return check_policy_packet(projected)
+
+
+def project_delta(delta: PolicyDelta, base: PolicyPacket) -> PolicyPacket:
+    """Aplica los patches del delta sobre la packet base y devuelve una
+    PolicyPacket nueva (re-validada por pydantic).
+
+    No muta `base`. Revalida: si algun patch produce una packet invalida
+    segun el schema (ej: target_pct < min_pct), se levanta ValidationError.
+    """
+    data = base.model_dump(mode="json")
+    for patch in delta.patches:
+        _apply_patch(data, patch.op, patch.path, patch.value)
+    return PolicyPacket.model_validate(data)
+
+
+def _apply_patch(
+    data: dict[str, Any],
+    op: PatchOperation,
+    path: str,
+    value: Any,
+) -> None:
+    parts = path.split(".")
+    cursor: Any = data
+    for key in parts[:-1]:
+        cursor = cursor[key]
+    last = parts[-1]
+
+    if op == PatchOperation.REPLACE:
+        cursor[last] = value
+    elif op == PatchOperation.ADD:
+        existing = cursor.get(last)
+        if isinstance(existing, list):
+            # Convencion: "add" sobre lista = append (no reemplaza la lista).
+            existing.append(value)
+        else:
+            cursor[last] = value
+    elif op == PatchOperation.REMOVE:
+        cursor.pop(last, None)
+    else:  # pragma: no cover - enum exhaustivo
+        raise ValueError(f"operacion de patch no soportada: {op}")

--- a/code/meristem/tests/conftest.py
+++ b/code/meristem/tests/conftest.py
@@ -4,12 +4,19 @@ Anade `code/shared` al sys.path para que los schemas compartidos
 (`from schemas import ...`) sean importables sin instalar el paquete de
 forma editable. Esto mantiene el repo usable directamente con `pytest`
 desde el root del proyecto o desde `code/meristem/`.
+
+Tambien expone fixtures compartidos:
+- `meristem_settings(tmp_path)` → `Settings` con DB en tmp + shadow off.
+- `meristem_client(tmp_path)`   → `TestClient` sobre `create_app(settings)`.
+- `canonical_examples()`         → ejemplos JSON canonicos generados por
+                                   `code/shared/schemas/examples/`.
 """
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any, Callable
 
 _THIS = Path(__file__).resolve()
 _MERISTEM_ROOT = _THIS.parents[1]
@@ -20,3 +27,44 @@ for path in (_MERISTEM_ROOT, _SHARED):
     path_str = str(path)
     if path.exists() and path_str not in sys.path:
         sys.path.insert(0, path_str)
+
+# Los imports por debajo necesitan los sys.path ya aplicados.
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.main import create_app  # noqa: E402
+from src.settings import Settings  # noqa: E402
+
+
+def _make_settings(tmp_path: Path, shadow: bool = False) -> Settings:
+    return Settings(
+        ollama_host="http://localhost:11434",
+        ollama_model="gemma4:e4b",
+        meristem_port=7070,
+        db_path=str(tmp_path / "meristem.db"),
+        shadow_enabled=shadow,
+        gemini_api_key=None,
+        shadow_model="gemma-4-31b-it",
+    )
+
+
+@pytest.fixture
+def meristem_settings(tmp_path: Path) -> Settings:
+    return _make_settings(tmp_path)
+
+
+@pytest.fixture
+def meristem_client(meristem_settings: Settings) -> TestClient:
+    app = create_app(meristem_settings)
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def canonical_examples() -> Callable[[], dict[str, dict[str, Any]]]:
+    """Devuelve los ejemplos canonicos re-construidos desde builders.py
+    (no los JSONs, para no depender de `make generate-examples` en CI)."""
+
+    from schemas.examples.builders import canonical_examples as _builders_canonical
+
+    return _builders_canonical

--- a/code/meristem/tests/test_deltas.py
+++ b/code/meristem/tests/test_deltas.py
@@ -1,0 +1,179 @@
+"""Tests de /deltas/pending y /deltas/propose."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import persistence
+
+
+def _future_zulu(hours: int = 6) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=hours)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _install_active_policy(db_path: str, canonical_examples) -> dict:
+    packet = deepcopy(canonical_examples()["policy_packet"])
+    packet["valid_until"] = _future_zulu()
+    persistence.upsert_policy(db_path, packet)
+    return packet
+
+
+def _delta_for(canonical_examples, base_policy_id: str) -> dict:
+    delta = deepcopy(canonical_examples()["policy_delta"])
+    delta["base_policy_id"] = base_policy_id
+    return delta
+
+
+def test_pending_empty_by_default(meristem_client: TestClient) -> None:
+    response = meristem_client.get("/deltas/pending/rhizome_01")
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {"rhizome_id": "rhizome_01", "deltas": [], "count": 0}
+
+
+def test_pending_lists_only_pending(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    """Sembramos tres deltas con status distinto y solo uno pending debe salir."""
+    db = meristem_settings.db_path
+    delta = deepcopy(canonical_examples()["policy_delta"])
+
+    for idx, status in enumerate(
+        [
+            persistence.DELTA_STATUS_PENDING,
+            persistence.DELTA_STATUS_VALIDATED,
+            persistence.DELTA_STATUS_REJECTED,
+        ]
+    ):
+        d = deepcopy(delta)
+        d["delta_id"] = f"delta_test_{idx}"
+        persistence.insert_delta(db, d, status=status)
+
+    response = meristem_client.get("/deltas/pending/rhizome_01")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["deltas"][0]["delta_id"] == "delta_test_0"
+
+
+def test_propose_validates_and_persists(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    active = _install_active_policy(meristem_settings.db_path, canonical_examples)
+    delta = _delta_for(canonical_examples, active["policy_id"])
+
+    response = meristem_client.post("/deltas/propose", json=delta)
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["delta_id"] == delta["delta_id"]
+    assert body["status"] == persistence.DELTA_STATUS_VALIDATED
+    assert body["reason"] is None
+
+
+def test_propose_rejects_when_base_policy_missing(
+    meristem_client: TestClient, canonical_examples
+) -> None:
+    delta = _delta_for(canonical_examples, "pkt_does_not_exist_1234")
+
+    response = meristem_client.post("/deltas/propose", json=delta)
+    assert response.status_code == 409
+    assert response.json()["detail"]["reason"] == "base_policy_not_active"
+
+
+def test_propose_rejects_when_delta_violates_30(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    """Criterio #28: delta con max_watering_duration_s=120 => 422 con
+    reason=violates_safety_rule."""
+    active = _install_active_policy(meristem_settings.db_path, canonical_examples)
+    delta = _delta_for(canonical_examples, active["policy_id"])
+    delta["patches"] = [
+        {
+            "op": "replace",
+            "path": "rules.max_watering_duration_s",
+            "value": 120,
+        }
+    ]
+
+    response = meristem_client.post("/deltas/propose", json=delta)
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["reason"] == "violates_safety_rule"
+    assert len(detail["violations"]) == 1
+    assert detail["violations"][0]["rule"] == "rules.max_watering_duration_s"
+    assert detail["violations"][0]["proposed_value"] == 120
+    assert detail["violations"][0]["firmware_limit"] == 60
+
+
+def test_propose_rejects_delta_that_brings_tank_below_20(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    active = _install_active_policy(meristem_settings.db_path, canonical_examples)
+    delta = _delta_for(canonical_examples, active["policy_id"])
+    delta["patches"] = [
+        {"op": "replace", "path": "rules.tank_minimum_pct", "value": 15.0}
+    ]
+
+    response = meristem_client.post("/deltas/propose", json=delta)
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["reason"] == "violates_safety_rule"
+    assert detail["violations"][0]["rule"] == "rules.tank_minimum_pct"
+
+
+def test_rejected_delta_is_persisted_with_reason(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    """Un delta rechazado por §30 queda persistido con status=rejected y
+    reason poblado, para auditoria."""
+    import sqlite3
+
+    active = _install_active_policy(meristem_settings.db_path, canonical_examples)
+    delta = _delta_for(canonical_examples, active["policy_id"])
+    delta["patches"] = [
+        {
+            "op": "replace",
+            "path": "rules.max_watering_duration_s",
+            "value": 120,
+        }
+    ]
+
+    meristem_client.post("/deltas/propose", json=delta)
+
+    with sqlite3.connect(meristem_settings.db_path) as conn:
+        rows = list(
+            conn.execute(
+                "SELECT delta_id, status, reason FROM deltas"
+            )
+        )
+    assert len(rows) == 1
+    assert rows[0][1] == persistence.DELTA_STATUS_REJECTED
+    assert rows[0][2] == "violates_safety_rule"
+
+
+def test_rejected_delta_logs_blocked_attempt(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    """Gap 4: el intento bloqueado se persiste en decisions_log (no como
+    ContradictionAlert)."""
+    import sqlite3
+
+    active = _install_active_policy(meristem_settings.db_path, canonical_examples)
+    delta = _delta_for(canonical_examples, active["policy_id"])
+    delta["patches"] = [
+        {"op": "replace", "path": "rules.tank_minimum_pct", "value": 10.0}
+    ]
+
+    meristem_client.post("/deltas/propose", json=delta)
+
+    with sqlite3.connect(meristem_settings.db_path) as conn:
+        rows = list(
+            conn.execute("SELECT action FROM decisions_log")
+        )
+    assert ("blocked_by_safety",) in rows

--- a/code/meristem/tests/test_ingest.py
+++ b/code/meristem/tests/test_ingest.py
@@ -1,0 +1,89 @@
+"""Tests de POST /ingest — acepta los 4 tipos de evidencia, 422 en invalidos."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+_KIND_BY_FIXTURE = {
+    "rhizome_snapshot": "rhizome_snapshot",
+    "decision_receipt": "decision_receipt",
+    "weather_packet": "weather_packet",
+    "contradiction_alert": "contradiction_alert",
+}
+
+
+@pytest.mark.parametrize("fixture_name,kind", list(_KIND_BY_FIXTURE.items()))
+def test_ingest_accepts_canonical_fixtures(
+    meristem_client: TestClient,
+    canonical_examples,
+    fixture_name: str,
+    kind: str,
+) -> None:
+    """Criterio #28: un test por schema verificando que `/ingest` las acepta.
+
+    La lista cubre los 4 tipos que /ingest debe consumir segun el spec.
+    PolicyPacket y PolicyDelta no entran por /ingest: son salidas de Meristem
+    (policies) o inputs de /deltas/propose (deltas). Se testean aparte.
+    """
+    examples = canonical_examples()
+    payload = examples[fixture_name]
+
+    response = meristem_client.post(
+        "/ingest", json={"kind": kind, "payload": payload}
+    )
+    assert response.status_code == 202, response.text
+    body = response.json()
+    assert body["kind"] == kind
+    assert isinstance(body["stored_id"], int)
+    assert body["stored_id"] > 0
+
+
+def test_ingest_rejects_unknown_kind(meristem_client: TestClient) -> None:
+    response = meristem_client.post(
+        "/ingest", json={"kind": "unknown_kind", "payload": {}}
+    )
+    # Literal fuera de rango => el envelope no valida => 422.
+    assert response.status_code == 422
+
+
+def test_ingest_rejects_invalid_payload(
+    meristem_client: TestClient, canonical_examples
+) -> None:
+    """Payload del kind correcto pero con campos invalidos => 422."""
+    bad = deepcopy(canonical_examples()["rhizome_snapshot"])
+    # Rompemos un campo requerido (origin_node_id vacio).
+    bad["origin_node_id"] = ""
+
+    response = meristem_client.post(
+        "/ingest", json={"kind": "rhizome_snapshot", "payload": bad}
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["kind"] == "rhizome_snapshot"
+    assert "errors" in detail
+
+
+def test_ingest_persists_to_sqlite(
+    meristem_client: TestClient,
+    meristem_settings,
+    canonical_examples,
+) -> None:
+    """Post un snapshot y verifica que aparece en la tabla `evidence`."""
+    import sqlite3
+
+    payload = canonical_examples()["rhizome_snapshot"]
+    meristem_client.post(
+        "/ingest", json={"kind": "rhizome_snapshot", "payload": payload}
+    )
+
+    with sqlite3.connect(meristem_settings.db_path) as conn:
+        rows = list(
+            conn.execute(
+                "SELECT kind, origin_node_id FROM evidence"
+            )
+        )
+    assert len(rows) == 1
+    assert rows[0] == ("rhizome_snapshot", payload["origin_node_id"])

--- a/code/meristem/tests/test_policies.py
+++ b/code/meristem/tests/test_policies.py
@@ -1,0 +1,48 @@
+"""Tests de GET /policies/{rhizome_id}."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from src import persistence
+
+
+def test_get_policy_404_when_none(meristem_client: TestClient) -> None:
+    response = meristem_client.get("/policies/rhizome_01")
+    assert response.status_code == 404
+    assert response.json()["detail"]["reason"] == "no_active_policy"
+
+
+def test_get_policy_returns_active(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    packet = canonical_examples()["policy_packet"]
+    # Aseguramos que la policy no este expirada.
+    future = (datetime.now(timezone.utc) + timedelta(hours=6)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    packet = deepcopy(packet)
+    packet["valid_until"] = future
+    persistence.upsert_policy(meristem_settings.db_path, packet)
+
+    response = meristem_client.get("/policies/rhizome_01")
+    assert response.status_code == 200
+    assert response.json()["policy_id"] == packet["policy_id"]
+
+
+def test_get_policy_ignores_expired(
+    meristem_client: TestClient, meristem_settings, canonical_examples
+) -> None:
+    packet = deepcopy(canonical_examples()["policy_packet"])
+    # valid_until en el pasado.
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    packet["valid_until"] = past
+    persistence.upsert_policy(meristem_settings.db_path, packet)
+
+    response = meristem_client.get("/policies/rhizome_01")
+    assert response.status_code == 404

--- a/code/meristem/tests/test_policy_engine.py
+++ b/code/meristem/tests/test_policy_engine.py
@@ -1,0 +1,188 @@
+"""Tests del policy_engine con LLM mockeado. Sin red real.
+
+Cubre:
+- Happy path: el LLM devuelve un JSON valido → engine persiste y retorna la packet.
+- Schema invalido: el LLM devuelve JSON no conforme → engine loguea y retorna None.
+- Violacion §30: el LLM devuelve JSON conforme al schema pero con
+  max_watering_duration_s=120 → engine NO persiste, loguea intento y retorna
+  None con reason=violates_safety_rule. Criterio de aceptacion #28 explicito.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from schemas.examples.builders import policy_packet_example
+
+from src import persistence
+from src.llm_client import OllamaClient
+from src.persistence import init_db
+from src.policy_engine import consolidate
+from src.settings import Settings
+
+
+class _FakeOllama:
+    """Sustituto de OllamaClient que devuelve un dict precomputado."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self._response = response
+        self.calls: list[tuple[str, str]] = []
+
+    def generate_json(
+        self, system: str, user: str, schema: dict | None = None,
+        temperature: float = 0.2,
+    ) -> dict[str, Any]:
+        self.calls.append((system, user))
+        return deepcopy(self._response)
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(
+        ollama_host="http://localhost:11434",
+        ollama_model="gemma4:e4b",
+        meristem_port=7070,
+        db_path=str(tmp_path / "engine.db"),
+        shadow_enabled=False,
+        gemini_api_key=None,
+        shadow_model="gemma-4-31b-it",
+    )
+
+
+def _fresh_packet(overrides_rules: dict | None = None) -> dict:
+    """Fixture canonica con timestamps actualizados para no llegar expirada."""
+    packet = deepcopy(policy_packet_example())
+    now = datetime.now(timezone.utc)
+    packet["created_at"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    packet["valid_until"] = (now + timedelta(hours=6)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    if overrides_rules:
+        packet["rules"].update(overrides_rules)
+    return packet
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> str:
+    settings = _settings(tmp_path)
+    init_db(settings.db_path)
+    return settings.db_path
+
+
+def test_consolidate_happy_path_persists_packet(db_path: str) -> None:
+    response = _fresh_packet()
+    fake = _FakeOllama(response)
+
+    result = consolidate(
+        db_path=db_path,
+        target_node_id="rhizome_01",
+        evidence=[],
+        llm=fake,  # type: ignore[arg-type]
+    )
+
+    assert result.packet is not None
+    assert result.reason is None
+    # La policy quedo persistida como activa.
+    active = persistence.get_active_policy(db_path, "rhizome_01")
+    assert active is not None
+    assert active["policy_id"] == response["policy_id"]
+    # El fake fue llamado con system + user.
+    assert len(fake.calls) == 1
+
+
+def test_consolidate_blocks_when_llm_violates_30(db_path: str) -> None:
+    """Criterio #28 (test negativo del engine): el LLM genera una packet
+    con max_watering_duration_s=120. El engine NO debe persistirla."""
+    bad = _fresh_packet({"max_watering_duration_s": 120})
+    fake = _FakeOllama(bad)
+
+    result = consolidate(
+        db_path=db_path,
+        target_node_id="rhizome_01",
+        evidence=[],
+        llm=fake,  # type: ignore[arg-type]
+    )
+
+    assert result.packet is None
+    assert result.reason == "violates_safety_rule"
+    assert result.violations is not None
+    assert result.violations[0]["rule"] == "rules.max_watering_duration_s"
+
+    # Nada persistido como policy activa.
+    assert persistence.get_active_policy(db_path, "rhizome_01") is None
+
+    # Rastro del intento en decisions_log.
+    with sqlite3.connect(db_path) as conn:
+        rows = list(conn.execute("SELECT action FROM decisions_log"))
+    assert ("blocked_by_safety",) in rows
+
+
+def test_consolidate_blocks_when_llm_violates_tank_minimum(
+    db_path: str,
+) -> None:
+    bad = _fresh_packet({"tank_minimum_pct": 10.0})
+    fake = _FakeOllama(bad)
+
+    result = consolidate(
+        db_path=db_path,
+        target_node_id="rhizome_01",
+        evidence=[],
+        llm=fake,  # type: ignore[arg-type]
+    )
+
+    assert result.packet is None
+    assert result.reason == "violates_safety_rule"
+    assert any(
+        v["rule"] == "rules.tank_minimum_pct" for v in result.violations
+    )
+
+
+def test_consolidate_blocks_when_llm_returns_invalid_schema(
+    db_path: str,
+) -> None:
+    """Si el LLM alucina campos que no validan el schema, no se persiste."""
+    fake = _FakeOllama({"schema_version": "1.0", "wrong": "shape"})
+
+    result = consolidate(
+        db_path=db_path,
+        target_node_id="rhizome_01",
+        evidence=[],
+        llm=fake,  # type: ignore[arg-type]
+    )
+
+    assert result.packet is None
+    assert result.reason == "invalid_schema"
+    assert persistence.get_active_policy(db_path, "rhizome_01") is None
+
+    with sqlite3.connect(db_path) as conn:
+        rows = list(conn.execute("SELECT action FROM decisions_log"))
+    assert ("blocked_invalid_schema",) in rows
+
+
+def test_consolidate_passes_active_policy_into_user_prompt(
+    db_path: str,
+) -> None:
+    """Si hay policy activa, el engine debe incluirla en el user prompt para
+    continuidad."""
+    seed = _fresh_packet()
+    persistence.upsert_policy(db_path, seed)
+
+    response = _fresh_packet()
+    response["policy_id"] = "pkt_rhizome_01_next"
+    response["version_chain"] = [seed["policy_id"], "pkt_rhizome_01_next"]
+    fake = _FakeOllama(response)
+
+    consolidate(
+        db_path=db_path,
+        target_node_id="rhizome_01",
+        evidence=[],
+        llm=fake,  # type: ignore[arg-type]
+    )
+
+    # El user prompt contiene el policy_id previo.
+    _, user = fake.calls[0]
+    assert seed["policy_id"] in user

--- a/code/meristem/tests/test_safety_rules.py
+++ b/code/meristem/tests/test_safety_rules.py
@@ -1,0 +1,169 @@
+"""Unit tests del validador pre-emit de §30.
+
+Cada test crea un PolicyPacket via el builder canonico y muta el campo bajo
+test. Mantener el builder como baseline evita divergencia con los fixtures.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from schemas import PolicyDelta, PolicyPacket
+from schemas.examples.builders import (
+    policy_delta_example,
+    policy_packet_example,
+)
+
+from src import safety_rules
+from src.safety_rules import (
+    FIRMWARE_MAX_WATERING_DURATION_S,
+    FIRMWARE_TANK_MINIMUM_PCT,
+    REASON_VIOLATES_SAFETY_RULE,
+)
+
+
+def _packet(overrides_rules: dict | None = None) -> PolicyPacket:
+    data = deepcopy(policy_packet_example())
+    if overrides_rules:
+        data["rules"].update(overrides_rules)
+    return PolicyPacket.model_validate(data)
+
+
+def test_canonical_packet_passes() -> None:
+    """El fixture canonico debe pasar §30 tras el fix de Gap 1 (fixture a 20%)."""
+    violations = safety_rules.check_policy_packet(_packet())
+    assert violations == []
+
+
+def test_firmware_limits_are_documented() -> None:
+    """Sanity: las constantes espejo de §30 no se mueven sin intencion."""
+    assert FIRMWARE_MAX_WATERING_DURATION_S == 60
+    assert FIRMWARE_TANK_MINIMUM_PCT == 20.0
+    assert REASON_VIOLATES_SAFETY_RULE == "violates_safety_rule"
+
+
+def test_duration_over_60_blocks() -> None:
+    packet = _packet({"max_watering_duration_s": 120})
+    violations = safety_rules.check_policy_packet(packet)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.rule == "rules.max_watering_duration_s"
+    assert v.proposed_value == 120
+    assert v.firmware_limit == 60
+
+
+def test_duration_exactly_60_passes() -> None:
+    # §30.1: "Duracion maxima: 60 s". Es inclusivo.
+    packet = _packet({"max_watering_duration_s": 60})
+    assert safety_rules.check_policy_packet(packet) == []
+
+
+def test_tank_below_20_blocks() -> None:
+    packet = _packet({"tank_minimum_pct": 15.0})
+    violations = safety_rules.check_policy_packet(packet)
+    assert len(violations) == 1
+    assert violations[0].rule == "rules.tank_minimum_pct"
+    assert violations[0].proposed_value == 15.0
+    assert violations[0].firmware_limit == 20.0
+
+
+def test_tank_exactly_20_passes() -> None:
+    packet = _packet({"tank_minimum_pct": 20.0})
+    assert safety_rules.check_policy_packet(packet) == []
+
+
+def test_multiple_violations_reported_together() -> None:
+    packet = _packet(
+        {"max_watering_duration_s": 90, "tank_minimum_pct": 10.0}
+    )
+    violations = safety_rules.check_policy_packet(packet)
+    rules = {v.rule for v in violations}
+    assert rules == {
+        "rules.max_watering_duration_s",
+        "rules.tank_minimum_pct",
+    }
+
+
+def test_project_delta_applies_replace() -> None:
+    base = _packet()
+    delta_data = deepcopy(policy_delta_example())
+    delta_data["base_policy_id"] = base.policy_id
+    delta = PolicyDelta.model_validate(delta_data)
+
+    projected = safety_rules.project_delta(delta, base)
+    # El fixture replace parcel_b.min_pct a 32.0 y budget a 10.0.
+    assert projected.rules.soil_moisture_thresholds.parcel_b.min_pct == 32.0
+    assert projected.rules.daily_water_budget_liters == 10.0
+    # Y base no se muta.
+    assert base.rules.daily_water_budget_liters == 8.0
+
+
+def test_project_delta_add_appends_to_list() -> None:
+    base = _packet()
+    delta_data = deepcopy(policy_delta_example())
+    delta_data["base_policy_id"] = base.policy_id
+    delta = PolicyDelta.model_validate(delta_data)
+
+    projected = safety_rules.project_delta(delta, base)
+    triggers = projected.rules.conservative_triggers
+    # El fixture add anade "humidity_below_25_forecast" a la lista existente.
+    assert "humidity_below_25_forecast" in triggers
+    # Y los anteriores siguen ahi.
+    assert "tank_level_below_30" in triggers
+
+
+def test_delta_that_would_violate_30_is_caught() -> None:
+    """Criterio de aceptacion #28: delta con max_watering_duration_s=120
+    debe detectarse via check_delta_against_base."""
+    base = _packet()
+    delta_data = deepcopy(policy_delta_example())
+    delta_data["base_policy_id"] = base.policy_id
+    delta_data["patches"] = [
+        {
+            "op": "replace",
+            "path": "rules.max_watering_duration_s",
+            "value": 120,
+        }
+    ]
+    delta = PolicyDelta.model_validate(delta_data)
+
+    violations = safety_rules.check_delta_against_base(delta, base)
+    assert len(violations) == 1
+    assert violations[0].rule == "rules.max_watering_duration_s"
+    assert violations[0].proposed_value == 120
+
+
+def test_delta_that_brings_tank_below_20_is_caught() -> None:
+    base = _packet()
+    delta_data = deepcopy(policy_delta_example())
+    delta_data["base_policy_id"] = base.policy_id
+    delta_data["patches"] = [
+        {"op": "replace", "path": "rules.tank_minimum_pct", "value": 12.0}
+    ]
+    delta = PolicyDelta.model_validate(delta_data)
+
+    violations = safety_rules.check_delta_against_base(delta, base)
+    assert len(violations) == 1
+    assert violations[0].rule == "rules.tank_minimum_pct"
+
+
+def test_delta_remove_on_scalar_clears_via_model_revalidation() -> None:
+    """Un `remove` sobre un campo requerido rompe el schema al re-validar.
+
+    Esto es esperable: project_delta re-valida la proyeccion con pydantic,
+    asi que un remove mal intencionado levanta ValidationError antes incluso
+    de llegar al validador §30.
+    """
+    from pydantic import ValidationError
+
+    base = _packet()
+    delta_data = deepcopy(policy_delta_example())
+    delta_data["base_policy_id"] = base.policy_id
+    delta_data["patches"] = [
+        {"op": "remove", "path": "rules.max_watering_duration_s"}
+    ]
+    delta = PolicyDelta.model_validate(delta_data)
+
+    with pytest.raises(ValidationError):
+        safety_rules.project_delta(delta, base)

--- a/code/meristem/tests/test_smoke_ollama.py
+++ b/code/meristem/tests/test_smoke_ollama.py
@@ -26,7 +26,12 @@ from src.settings import load_settings
 @pytest.mark.ollama
 def test_consolidate_against_local_ollama(tmp_path: Path) -> None:
     settings = load_settings()
-    client = OllamaClient(settings)
+    # Budget holgado para el smoke manual: el prompt real del engine
+    # (system_v1 + active_policy + evidence) + structured output contra el
+    # schema completo de PolicyPacket excede el default de 120s en CPU. El
+    # test todavia asserta elapsed < 90.0 mas abajo para dar senal clara de
+    # si cumplimos el objetivo del spec.
+    client = OllamaClient(settings, timeout_s=300.0)
     if not client.ping():
         client.close()
         pytest.skip(

--- a/code/meristem/tests/test_smoke_ollama.py
+++ b/code/meristem/tests/test_smoke_ollama.py
@@ -1,0 +1,65 @@
+"""Smoke test contra Ollama real. Marcado `@pytest.mark.ollama`.
+
+Skippea automaticamente si el daemon no responde en el host/puerto de los
+Settings por defecto. Correr en local con Ollama + gemma4:e4b cargado:
+
+    pytest -m ollama code/meristem/tests/test_smoke_ollama.py -s
+
+En CI este test no corre (no hay Ollama). Se deja como herramienta de
+desarrollo y verificacion manual de latencia objetivo (<60s E2E).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from schemas import PolicyPacket
+
+from src.llm_client import OllamaClient
+from src.persistence import init_db
+from src.policy_engine import consolidate
+from src.settings import load_settings
+
+
+@pytest.mark.ollama
+def test_consolidate_against_local_ollama(tmp_path: Path) -> None:
+    settings = load_settings()
+    client = OllamaClient(settings)
+    if not client.ping():
+        client.close()
+        pytest.skip(
+            f"Ollama no responde en {settings.ollama_host}; skip smoke test."
+        )
+
+    db_path = str(tmp_path / "smoke.db")
+    init_db(db_path)
+
+    started = time.monotonic()
+    try:
+        result = consolidate(
+            db_path=db_path,
+            target_node_id="rhizome_01",
+            evidence=[],
+            llm=client,
+        )
+    finally:
+        client.close()
+    elapsed = time.monotonic() - started
+
+    assert result.packet is not None or result.reason in {
+        "invalid_schema",
+        "violates_safety_rule",
+    }, f"resultado inesperado: {result}"
+
+    # Latencia objetivo del spec: <60s E2E. Si no se cumple, test falla y
+    # queda visible en la bitacora del PR. Margen razonable para hardware
+    # modesto.
+    assert elapsed < 90.0, (
+        f"latencia {elapsed:.1f}s excede budget de 90s (objetivo 60s)."
+    )
+
+    # Si la packet paso, debe poder re-serializarse como PolicyPacket.
+    if result.packet is not None:
+        PolicyPacket.model_validate(result.packet.model_dump(mode="json"))

--- a/code/shared/schemas/examples/builders.py
+++ b/code/shared/schemas/examples/builders.py
@@ -63,7 +63,7 @@ def policy_packet_example() -> dict:
             },
             "max_watering_duration_s": 45,
             "daily_water_budget_liters": 8.0,
-            "tank_minimum_pct": 15.0,
+            "tank_minimum_pct": 20.0,
             "require_vision_confirmation": False,
             "conservative_triggers": [
                 "tank_level_below_30",
@@ -216,8 +216,8 @@ def decision_receipt_blocked_example() -> dict:
             "blocked_action": "WATER_A",
             "reason": "tank_minimum_pct reached",
         },
-        "rationale_short": "Riego bloqueado: deposito al 11%, por debajo del minimo de seguridad.",
-        "rationale_full": "El snapshot reporta deposito al 11%, por debajo del 15% exigido por la politica activa. Aunque la parcela A esta seca, Rhizome no envia comando al ESP32 y eleva bloqueo preventivo.",
+        "rationale_short": "Riego bloqueado: deposito al 18%, por debajo del minimo de seguridad.",
+        "rationale_full": "El snapshot reporta deposito al 18%, por debajo del 20% exigido por la politica activa. Aunque la parcela A esta seca, Rhizome no envia comando al ESP32 y eleva bloqueo preventivo.",
         "policy_refs": [
             "rules.soil_moisture_thresholds.parcel_a.min_pct",
             "rules.tank_minimum_pct",

--- a/code/shared/schemas/examples/decision_receipt_blocked.json
+++ b/code/shared/schemas/examples/decision_receipt_blocked.json
@@ -11,8 +11,8 @@
     "blocked_action": "WATER_A",
     "reason": "tank_minimum_pct reached"
   },
-  "rationale_short": "Riego bloqueado: deposito al 11%, por debajo del minimo de seguridad.",
-  "rationale_full": "El snapshot reporta deposito al 11%, por debajo del 15% exigido por la politica activa. Aunque la parcela A esta seca, Rhizome no envia comando al ESP32 y eleva bloqueo preventivo.",
+  "rationale_short": "Riego bloqueado: deposito al 18%, por debajo del minimo de seguridad.",
+  "rationale_full": "El snapshot reporta deposito al 18%, por debajo del 20% exigido por la politica activa. Aunque la parcela A esta seca, Rhizome no envia comando al ESP32 y eleva bloqueo preventivo.",
   "policy_refs": [
     "rules.soil_moisture_thresholds.parcel_a.min_pct",
     "rules.tank_minimum_pct"

--- a/code/shared/schemas/examples/policy_packet.json
+++ b/code/shared/schemas/examples/policy_packet.json
@@ -28,7 +28,7 @@
     },
     "max_watering_duration_s": 45,
     "daily_water_budget_liters": 8.0,
-    "tank_minimum_pct": 15.0,
+    "tank_minimum_pct": 20.0,
     "require_vision_confirmation": false,
     "conservative_triggers": [
       "tank_level_below_30",


### PR DESCRIPTION
Closes #28

Ver `bitacora/2026-04-19_policy-engine-meristem_meristem.md` para resumen de entregables, decisiones y resolucion de los 4 gaps de §30 (tabla al inicio). La bitacora `2026-04-18_drafts-subissue-30-gaps_meristem.md` va incluida en el mismo commit como reconocimiento previo.

## Entregables

- `safety_rules.py` — validador pre-emit §30 (duration ≤60, tank ≥20).
- `policy_engine.py` — `consolidate()` con Ollama E4B structured output + doble verja (schema + §30).
- `routes.py` — 4 endpoints (`/ingest` con 4 kinds, `/policies/{id}`, `/deltas/pending/{id}`, `/deltas/propose`).
- `persistence.py` extendido — helpers CRUD idempotentes.
- `llm_client.generate_json()` — structured output con `format=<schema>`.
- `prompts/system_v1.txt` iterado.
- **Fix Gap 1** (tank_minimum_pct 15→20) aplicado en `code/shared/schemas/examples/builders.py`, JSONs regenerados via `make generate-examples`, rationale del `decision_receipt_blocked` actualizada coherentemente. Tests de shared siguen verdes (33/33).
- README de meristem actualizado con tabla de endpoints + explicacion del engine.

## Tests

- 55 tests de meristem pasan; 1 skip (smoke Ollama sin daemon, marker `@pytest.mark.ollama`).
- Regresion del bootstrap (20 de #17, incluido `test_shadow_off`) verde.
- Criterio de latencia (<60s E2E) lo mide `test_smoke_ollama.py`, budget 90s, objetivo 60s. Solo corre local con Ollama; Bea anotara el numero en comentario del PR tras ejecucion manual.

## Decisiones para no sorprender en review

- `/ingest` usa envelope `{kind, payload}` en vez de sub-paths o deteccion por forma.
- `/deltas/propose` valida sincrono (sin `pending` intermedio; el estado existe en schema para el consolidator job del PR siguiente).
- `consolidate()` queda como API interna, no expuesto HTTP.
- Intento bloqueado por §30 → `decisions_log` con `action="blocked_by_safety"` + 422 con `reason=violates_safety_rule` (decision Gap 4).

## Pendientes fuera de este PR (siguiente en la cola)

- Issue #29 (lint anti-leak `google.genai`). Meristem arranca tras merge.
- Consolidator job automatico (disparado por N evidencias) — proximo PR.
- Meristem sombra activo (`compare.py` contra Gemma 31B/26B) — flag off por ahora.