### PR TITLE
[video] guion v0 tras reframe (refs #12)

### DIFF
--- a/bitacora/2026-04-19_corola-guion-v0_corola.md
+++ b/bitacora/2026-04-19_corola-guion-v0_corola.md
@@ -1,0 +1,51 @@
+﻿# Guion v0 — racional
+
+**Fecha:** 2026-04-19
+**Autora:** Corola
+**Area:** Video / produccion
+**Tipo:** Entregable (PR contra #12, hermano del shot list v0)
+
+---
+
+## Que entrega este PR
+
+`video/script.md` v0: guion completo con VO castellano, cartelas y
+estructura alineada con `shot_list.md` v0 (PR hermano). ~106 palabras
+VO (bajo el objetivo ~180 de Cambium — margen holgado para doblaje EN).
+
+## Decisiones aplicadas
+
+1. **VO minimo, cartelas motor.** La densidad informativa vive en las cartelas (BdE, FAO, IRRIFRAME, ITU, stack Gemma). VO hace historia, no dato. Esto permite doblaje EN sin re-sincronizar datos duros.
+2. **Apertura y cierre silenciosos.** Cartela "Decide sola hoy." abre. Tripleta silenciosa cierra. Sin VO, sin idioma, sin friccion para jurado anglo.
+3. **Frase espinal "Un modelo. Tres profundidades. Tres tiempos."** en el pull-back (fin min 1). Es la tesis: E2B en Rhizome, E2B en Pollen, E4B en Meristem — mismo modelo, tres profundidades (tamaño), tres tiempos (segundos/minutos/horas). El pull-back es el momento donde esto se dice explicitamente.
+4. **Climax denso (22 palabras en 15 s).** 0:35-0:50 es el bloque mas dificil de entender para el espectador nuevo. El VO del climax debe explicar *que* pasa, no solo *mostrarlo*. Las 22 palabras estan calibradas para dar tiempo a leer el `rationale` en pantalla mientras se escucha la linea.
+5. **Meristem con cartela 26B.** Pedido explicito Bea. Cartela completa: `Meristem · Gemma 4 E4B · Ollama / MVP local 16 GB / arquitectura objetivo: 26B`. Honesto, no apologetico.
+6. **Datos duros en cartelas silenciosas:**
+   - BdE 20-30% trigo (plano 11): impacto economico agricola español.
+   - FAO 84%/36% (cierre): escala del problema — pequeñas explotaciones son la mayoria del alimento mundial.
+   - IRRIFRAME 40k central (cierre): contraste con Sprout-a-pie.
+   - ITU 85/58 (tarjeta final): contexto universal de conectividad rural.
+7. **Australia 90% fuera.** Por priorizacion (geografia lejana para jurado global), no por calidad.
+8. **Caducidad conservada como bloque complementario** (1:50-2:10). Mantiene el clavo narrativo que estaba en v0.1, pero subordinado a la tesis de circulacion.
+9. **Amanecer siguiente (2:10-2:30)** cierra el arco temporal: la politica consolidada por Meristem durante la noche aterriza al alba en Rhizome. Prueba visual de que "diferido" funciona.
+
+## Que NO hace este PR
+
+- No cierra #12. Shot list v0 esta en `feat/corola-shot-list-v0` (PR hermano).
+- No incluye version EN. Bea dobla al release, no ahora.
+- No genera prompts Veo3. Eso va en PR de postproduccion separado.
+- No fija persona VO castellano ni localizacion exterior.
+
+## Riesgos
+
+- **Duracion total no confirmada por Cambium.** Bea dice 1+1-2 con final top; brief dice ≤1 min; video/README.md e issue #12 dicen 3 min. v0 asume 3 min (cota superior brief). Si Cambium baja a <2 min, re-editar cierre (plano 14) sin perder la tripleta.
+- **Climax (0:35-0:50) es el bloque mas fragil.** Si el MVP no da rationale visible en tiempo real, el VO queda sin soporte visual. Alternativa degradada: captura estatica del rationale tras el hecho.
+- **Doblaje EN de la frase espinal.** "Un modelo. Tres profundidades. Tres tiempos." debe sonar igual de rotunda en EN. Propuesta Bea: "One model. Three depths. Three speeds." — decision suya.
+
+## Enlaces
+
+- Issue #12 (shot list + script)
+- PR hermano: `feat/corola-shot-list-v0`
+- `bitacora/2026-04-18_reframe-narrativo-pollen_cambium.md`
+- `bitacora/2026-04-19_meristem-como-revision-diferida_cambium.md`
+- `research/narrative_sources.md`

--- a/bitacora/2026-04-19_corola-guion-v0_corola.md
+++ b/bitacora/2026-04-19_corola-guion-v0_corola.md
@@ -23,7 +23,7 @@ VO (bajo el objetivo ~180 de Cambium — margen holgado para doblaje EN).
 6. **Datos duros en cartelas silenciosas:**
    - BdE 20-30% trigo (plano 11): impacto economico agricola español.
    - FAO 84%/36% (cierre): escala del problema — pequeñas explotaciones son la mayoria del alimento mundial.
-   - IRRIFRAME 40k central (cierre): contraste con Sprout-a-pie.
+   - IRRIFRAME 40k central (cierre): contraste con Sprout — "criterio que viaja con quien se mueve" (cartela ajustada en v0.2, ver `bitacora/2026-04-20_corola-guion-v02_corola.md`).
    - ITU 85/58 (tarjeta final): contexto universal de conectividad rural.
 7. **Australia 90% fuera.** Por priorizacion (geografia lejana para jurado global), no por calidad.
 8. **Caducidad conservada como bloque complementario** (1:50-2:10). Mantiene el clavo narrativo que estaba en v0.1, pero subordinado a la tesis de circulacion.

--- a/bitacora/2026-04-20_corola-guion-v02_corola.md
+++ b/bitacora/2026-04-20_corola-guion-v02_corola.md
@@ -1,0 +1,53 @@
+﻿# Guion v0.2 — ajuste narrativo sobre verbos de movilidad
+
+**Fecha:** 2026-04-20
+**Autora:** Corola
+**Area:** Video / narrativa
+**Tipo:** Ajuste sobre PR #41 en curso (hermano del ajuste shot list v0.2 en PR #40)
+
+---
+
+## Origen
+
+Mismo origen que el ajuste del shot list (PR #40, v0.2): releyendo un borrador de mail al padre de Bea — fuera de scope proyecto — Bea identifico que los verbos **"caminar"** y **"a pie"** encadenan la tesis de Pollen a un solo modo de movilidad. Racional completo en `bitacora/2026-04-20_corola-shot-list-v02_corola.md`.
+
+Resumen de la decision (copiada para que este rationale funcione standalone):
+
+1. Tesis Pollen en el video: **humana** (agricultor con movil entre parcelas).
+2. Arquitectura Pollen: **agnostica al portador** (persona andando/en bici/en camioneta/en tractor, o dron agricola). Hecho tecnico, no se cuenta en el video pero si en writeup / Q&A.
+3. Lexico del video: **verbo neutro** ("se mueve", "en ruta", "recorre", "quien se mueve"). La imagen en pantalla es humana; el lenguaje no cierra contra otros modos.
+
+## Cambios en v0.2 del guion
+
+| Bloque | v0 | v0.2 | Delta |
+|---|---|---|---|
+| 0:18-0:25 (Pollen entra) | "Alguien ya camina esta ruta." | "Alguien ya recorre esta ruta." | mismo numero palabras (5), verbo neutro |
+| 0:35-0:50 (CLIMAX) | "En el camino de A a B, el criterio se ajusta..." | "En ruta de A a B, el criterio se ajusta..." | 22 → 20 palabras |
+| 2:30-2:50 (CIERRE cartela) | "Sprout: criterio que viaja a pie." | "Sprout: criterio que viaja con quien se mueve." | cartela, no VO |
+| Principio #7 (cierre) | cita antigua | cita nueva + nota explicita: verbo neutro protege agnostia-portador | documentacion |
+
+**Total VO: 103 palabras** (antes 105, -2 por acortar climax).
+
+## Por que me convence
+
+- **VO 0:18-0:25 "recorre"** es mas limpio que "camina" y no presupone pie. Encaja con la imagen de humano con movil caminando en el plano (lo que se ve) pero no excluye otros modos si mañana esa imagen se amplia.
+- **VO climax "En ruta"** es mas conciso y mas fuerte. "En el camino" sonaba literal; "en ruta" suena a trayecto intencional con propósito. Y me ahorra 2 palabras en el bloque mas denso del video — beneficio lateral.
+- **Cartela cierre "criterio que viaja con quien se mueve"** es la frase tesis en su forma definitiva. "Quien" es gramaticalmente humano en castellano pero no encadena. La tripleta final gana: FAO (escala) → IRRIFRAME (contraste: centralizado) → Sprout (alternativa: criterio distribuido con el que se mueve). La oposicion con IRRIFRAME es ahora mas nitida.
+
+## Linea 2:10-2:30 "despierta con el criterio" — no cambia
+
+Mantengo el voto estilistico. "Despierta" no tiene el problema de "caminar": no encadena a un modo de transporte, solo a una metafora de ciclo dia/noche — que es exactamente lo que ese plano cuenta (Meristem diferido aterrizando al amanecer). Confirmado.
+
+## Impacto en otros documentos
+
+- **shot_list.md v0.2** (PR #40): ajustes paralelos. Cambios de descripcion de planos + cartela + nota en Notas de grabacion. Ver `bitacora/2026-04-20_corola-shot-list-v02_corola.md`.
+- **Writeup:** Cambium recoge la arquitectura agnostica al portador de Pollen como hecho tecnico para seccion 1. Nota explicita en el bitacora del shot list v0.2 para que la recupere al redactar.
+- **README / docs/01_architecture.md:** no toco en este PR. Si al hacer el PR de docs futuro (reframe Pollen) aparece lexico "a pie" o "caminar", se ajusta entonces.
+
+## Enlaces
+
+- PR #41 (guion v0)
+- PR #40 (shot list, commit paralelo v0.2)
+- `bitacora/2026-04-20_corola-shot-list-v02_corola.md` (racional compartido sobre agnostia-portador)
+- `bitacora/2026-04-18_reframe-narrativo-pollen_cambium.md`
+- Conversacion Bea↔Corola 2026-04-20

--- a/bitacora/2026-04-20_corola-guion-v04_corola.md
+++ b/bitacora/2026-04-20_corola-guion-v04_corola.md
@@ -1,0 +1,100 @@
+# Guion v0.4 — cartela cierre: tripleta reflexiva
+
+**Fecha:** 2026-04-20
+**Autora:** Corola
+**Rama:** `feat/corola-guion-v0`
+**PR:** [#41](https://github.com/zigiella/sprout/pull/41) (no cierra #12 por si solo)
+
+---
+
+## Origen del cambio
+
+Bea releyo el mail al padre (entregado fuera de proyecto) y propuso
+cambiar la cartela final. Su propuesta literal:
+
+> "Sprout: criterio que viaja con quien se mueve." → "Sprout: criterio
+> que se mueve, se suma y se ajusta." O algo asi.
+
+Acepto tal cual. Cambio paralelo al shot list v0.3 (PR #40).
+
+## Que cambia
+
+Tres toques dentro del guion, todos sobre la misma cartela:
+
+1. **Tabla minuto 2-3, linea 2:30-2:50** (cierre):
+   - v0.3: `Sprout: criterio que viaja con quien se mueve.`
+   - v0.4: `Sprout: criterio que se mueve, se suma y se ajusta.`
+
+2. **Principio #2 (Triptico narrativo):** actualizado para nombrar que la
+   cartela de cierre es tambien triptica, reforzando la rima estructural
+   con la frase espinal ("Un modelo. Tres profundidades. Tres tiempos.").
+
+3. **Principio #7 (Cierre sin VO):** reescrito para explicar el mapeo de
+   los tres verbos a las tres capas del sistema, y que el principio
+   agnostico al portador llega ahora al plano sintactico (sujeto unico:
+   el criterio; sin portador en la frase).
+
+**Total VO:** 101 palabras — sin cambios. La cartela es silenciosa, no
+toca al conteo hablado.
+
+## Por que la frase v0.4 es mejor que la v0.2/0.3
+
+### 1. Mapeo verbo-capa
+
+- **se mueve** → Pollen (nodo itinerante, Gemma E2B en movil LiteRT)
+- **se suma** → Meristem (consolida al cierre del dia)
+- **se ajusta** → climax A→B (policy_delta en ruta) + Rhizome (la regla
+  viva se actualiza al alba siguiente)
+
+La frase no describe solo una propiedad — describe el sistema completo
+en miniatura.
+
+### 2. Simetria con la frase espinal
+
+- Apertura del minuto 1: **"Un modelo. Tres profundidades. Tres tiempos."**
+  (triada nominal)
+- Cierre del video: **"Sprout: criterio que se mueve, se suma y se
+  ajusta."** (triada verbal)
+
+Dos tripletas con la misma cadencia. El video abre y cierra con el mismo
+patron estructural.
+
+### 3. Agnostica al maximo
+
+- v0.2 ("viaja con quien se mueve") aun presupone un portador implicito
+  ("quien").
+- v0.4 elimina el portador de la frase. Verbos reflexivos, sujeto unico:
+  el criterio. El portador (humano, bici, tractor, dron) vive en la
+  imagen, no en el lexico.
+
+### 4. Activo, no pasivo
+
+"Viaja con quien se mueve" es descriptivo — el criterio es objeto.
+"Se mueve, se suma, se ajusta" es activo — el criterio es agente. Encaja
+con la apertura "Decide sola hoy." (sujeto activo). El arco narrativo
+empieza y termina con el sistema como agente.
+
+## Lo que NO cambio
+
+- VO no toca. Cartela silenciosa.
+- Conteo palabras VO: 101, igual que v0.3.
+- Principios #1, #3-6 intactos.
+- Pendientes antes de grabar VO: sin cambios.
+- Cartela stack plano 10 (1:15-1:30): sigue con "E4B MVP / 26B objetivo"
+  en v0.4. Reformulacion en shot list v1 post-merge #40/#41, tras el
+  reframe Meristem (commit `0a6376d`).
+
+## Coherencia cross-PR
+
+- **Shot list v0.3 (PR #40):** mismo cambio en cartela plano 14. Commit
+  `7800d28`. Bitacora `2026-04-20_corola-shot-list-v03_corola.md`.
+- **Mensaje a Cambium sobre portador agnostico** (`2026-04-20_mensaje-
+  cambium-pollen-agnostico-portador_corola.md`): cita la frase v0.2. No
+  lo actualizo retroactivamente — historial fiel.
+
+## Proximos pasos
+
+- Push y comentario en PR #41.
+- Esperar merge #40/#41 por Cambium.
+- Post-merge: abrir `feat/corola-shot-list-v1` con reformulacion plano 10
+  tras reframe Meristem.

--- a/video/script.md
+++ b/video/script.md
@@ -46,7 +46,7 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 | 1:30-1:50 | Capa fisica | "El firmware rechaza lo que el modelo aun no sabe frenar." | BdE 2024: 20-30% trigo España perdido por decisiones tardias |
 | 1:50-2:10 | Caducidad | "Si llega tarde, no se usa." | REJECTED · policy_expired |
 | 2:10-2:30 | Amanecer siguiente | "A la mañana siguiente, la parcela despierta con el criterio del dia anterior." | — |
-| 2:30-2:50 | **CIERRE (e)** | — | FAO: 84% explotaciones <2 ha. Producen 36% del alimento. / IRRIFRAME: 40k explotaciones · servidor central. / Sprout: criterio que viaja con quien se mueve. |
+| 2:30-2:50 | **CIERRE (e)** | — | FAO: 84% explotaciones <2 ha. Producen 36% del alimento. / IRRIFRAME: 40k explotaciones · servidor central. / Sprout: criterio que se mueve, se suma y se ajusta. |
 | 2:50-3:00 | Tarjeta final | — | zigiella · Apache 2.0 · github.com/zigiella/sprout / ITU 2024: 85% conectividad rural global · 58% zonas remotas |
 
 ---
@@ -70,12 +70,12 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 ## Principios aplicados
 
 1. **Apertura silenciosa.** Una cartela, cero VO, cero idioma. Funciona para jurado anglo sin friccion.
-2. **Triptico narrativo:** "Un modelo. Tres profundidades. Tres tiempos." — frase espinal que aparece en pull-back (fin min 1) y se reconoce implicita en el cierre (Sprout: criterio que viaja con quien se mueve).
+2. **Triptico narrativo:** "Un modelo. Tres profundidades. Tres tiempos." — frase espinal que aparece en pull-back (fin min 1). Rima con la cartela de cierre, tambien triptica ("Sprout: criterio que se mueve, se suma y se ajusta"): dos tripletas que abren y cierran el video con la misma cadencia estructural.
 3. **Stack cartelas Gemma** en cada nodo — Gusthema (Gemma DevRel) ve la familia explicita, no inferida.
 4. **Climax 15 s** con VO denso en 0:35-0:50 (20 palabras) — es el bloque que el espectador necesita entender mejor, y donde el video se juega la tesis.
 5. **Meristem honesto:** cartela "E4B MVP / 26B objetivo". No se esconde el trade-off; se nombra.
 6. **Cartelas como motor de densidad.** Datos fuertes (BdE, FAO, IRRIFRAME, ITU) **nunca en VO**. Siempre en cartela. El dato impacta visualmente; el VO hace la historia.
-7. **Cierre sin VO.** Tripleta silenciosa de cartelas. La ultima —"Sprout: criterio que viaja con quien se mueve"— cierra la tesis que abrio la apertura silenciosa. **Verbo neutro deliberado:** no "a pie", no "caminar" — el diseño de Pollen es agnostico al portador (persona/bici/camioneta/tractor/dron), y la cartela no lo encadena a un solo modo aunque la imagen en pantalla sea humana. Ver bitacora v0.2 para racional.
+7. **Cierre sin VO.** Tripleta silenciosa de cartelas. La ultima —"Sprout: criterio que se mueve, se suma y se ajusta"— cierra la tesis que abrio la apertura silenciosa. **Tres verbos reflexivos que mapean el sistema:** se mueve (Pollen, itinerante), se suma (Meristem, consolida al cierre del dia), se ajusta (climax A→B + Rhizome, la regla viva). **Sujeto unico: el criterio.** Sin portador en la sintaxis — aplicacion maxima del principio agnostico al portador (el diseño de Pollen admite persona/bici/camioneta/tractor/dron sin refactor). Ver bitacoras v0.2 y v0.4 para racional completo.
 
 ---
 
@@ -91,6 +91,7 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 
 ## Historial de versiones
 
+- **v0.4** (2026-04-20, Corola) — ajuste cartela cierre pedido por Bea tras releer el mail al padre: **"Sprout: criterio que viaja con quien se mueve."** → **"Sprout: criterio que se mueve, se suma y se ajusta."** Tres verbos reflexivos mapean las tres capas del sistema (Pollen se mueve / Meristem se suma / Rhizome y climax se ajustan), reforzando la tripleta de la frase espinal ("Un modelo. Tres profundidades. Tres tiempos."). Sujeto unico: el criterio. Sin portador en la sintaxis — aplicacion maxima del principio agnostico al portador. Actualizados principio #2 (triptico) y principio #7 (cierre sin VO). Total VO sin cambios (101 palabras — cartela es silenciosa). Cambio paralelo en shot list v0.3 (PR #40). Racional: `bitacora/2026-04-20_corola-guion-v04_corola.md`.
 - **v0.3** (2026-04-20, Corola) — ajuste VO pedido por Bea: linea 1:15-1:30 pasa de "Al final del dia, otro modelo consolida lo aprendido." a **"Al final del dia, Meristem consolida lo aprendido."** (9 palabras, -2). Nombrar Meristem en VO le da peso — es la unica aparicion del nombre en audio, la cartela ya lo nombra en pantalla pero la combinacion doble refuerza. Total VO: 101 palabras. **Nota:** la cartela stack del plano 10 ("E4B MVP / 26B objetivo") se mantiene en esta version; se reformula en shot list v1 tras el reframe de Meristem (`bitacora/2026-04-20_meristem-reframe-modelo-objetivo_cambium.md`, en main commit 0a6376d).
 - **v0.2** (2026-04-20, Corola) — ajuste narrativo pedido por Bea: los verbos "caminar" y "a pie" empequeñecen la tesis de Pollen. Sustituidos por neutros. VO 0:18-0:25: "Alguien ya camina esta ruta." → **"Alguien ya recorre esta ruta."** (5 palabras, igual). VO climax 0:35-0:50: "En el camino de A a B..." → **"En ruta de A a B..."** (20 palabras, -2). Cartela cierre 2:30-2:50: "Sprout: criterio que viaja a pie." → **"Sprout: criterio que viaja con quien se mueve."** Principio #7 anotado explicitamente: verbo neutro protege diseño agnostico al portador de Pollen. Total VO: 103 palabras. Racional completo en `bitacora/2026-04-20_corola-guion-v02_corola.md`.
 - **v0-post-review** (2026-04-20, Corola) — ajuste tras review Cambium en PR #41: linea 1:30-1:50 pasa de "El hardware bloquea lo que el modelo no deberia permitir." a **"El firmware rechaza lo que el modelo aun no sabe frenar."** (de pasivo+adversarial a activo+narrativa de capas, -1 palabra). Climax (0:35-0:50) mantenido tal cual por recomendacion explicita de Cambium. Linea 2:10-2:30 ("despierta con el criterio") mantenida por voto estilistico — busco resonancia con el amanecer en pantalla. Total VO: 105 palabras.

--- a/video/script.md
+++ b/video/script.md
@@ -43,7 +43,7 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 |---|--------|----|---------|
 | 1:00-1:15 | Timelapse | — | "... pasa el dia ..." |
 | 1:15-1:30 | Meristem | "Al final del dia, otro modelo consolida lo aprendido." | Meristem · Gemma 4 E4B · Ollama / MVP local 16 GB / arquitectura objetivo: 26B |
-| 1:30-1:50 | Capa fisica | "El hardware bloquea lo que el modelo no deberia permitir." | BdE 2024: 20-30% trigo España perdido por decisiones tardias |
+| 1:30-1:50 | Capa fisica | "El firmware rechaza lo que el modelo aun no sabe frenar." | BdE 2024: 20-30% trigo España perdido por decisiones tardias |
 | 1:50-2:10 | Caducidad | "Si llega tarde, no se usa." | REJECTED · policy_expired |
 | 2:10-2:30 | Amanecer siguiente | "A la mañana siguiente, la parcela despierta con el criterio del dia anterior." | — |
 | 2:30-2:50 | **CIERRE (e)** | — | FAO: 84% explotaciones <2 ha. Producen 36% del alimento. / IRRIFRAME: 40k explotaciones · servidor central. / Sprout: criterio que viaja a pie. |
@@ -60,10 +60,10 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 - 0:35-0:50: 22
 - 0:50-1:00: 8
 - 1:15-1:30: 11
-- 1:30-1:50: 12
+- 1:30-1:50: 11
 - 1:50-2:10: 6
 - 2:10-2:30: 15
-- **Total: ~106 palabras VO.** Margen holgado bajo el objetivo ~180. Permite doblaje EN sin apretar.
+- **Total: ~105 palabras VO.** Margen holgado bajo el objetivo ~180. Permite doblaje EN sin apretar.
 
 ---
 
@@ -91,5 +91,6 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 
 ## Historial de versiones
 
+- **v0-post-review** (2026-04-20, Corola) — ajuste tras review Cambium en PR #41: linea 1:30-1:50 pasa de "El hardware bloquea lo que el modelo no deberia permitir." a **"El firmware rechaza lo que el modelo aun no sabe frenar."** (de pasivo+adversarial a activo+narrativa de capas, -1 palabra). Climax (0:35-0:50) mantenido tal cual por recomendacion explicita de Cambium. Linea 2:10-2:30 ("despierta con el criterio") mantenida por voto estilistico — busco resonancia con el amanecer en pantalla. Total VO: 105 palabras.
 - **v0** (2026-04-19, Corola) — reset tras reframe (`2026-04-18_reframe-narrativo-pollen_cambium.md`) y Meristem diferido (`2026-04-19_meristem-como-revision-diferida_cambium.md`). 3 min con min 1 autosuficiente, climax (b) transferencia cruzada, cierre (e) Meristem diferido, cartela 26B objetivo, VO ~106 palabras. Acepta criterios #12.
 - **v0.1** (2026-04-18, Corola) — draft descartado. Construido sobre climax caducidad y Pollen como mula.

--- a/video/script.md
+++ b/video/script.md
@@ -1,0 +1,95 @@
+﻿# Script — Sprout
+
+**Version:** v0 (reset tras reframe Pollen/Meristem y ajuste duracion)
+**Fecha:** 2026-04-19
+**Autora:** Corola
+**Idioma origen:** castellano. Doblaje EN por Bea para release.
+
+Objetivo: video para **jurado tecnico** (Glenn Cameron, Kristen Quan,
+Gus Martins, Ian Ballantyne — PM/PMM/DevRel Google) que quiere ver
+**como hemos llevado Gemma 4 a su maximo uso para el bien comun**.
+
+Duracion objetivo: **1:00 top + 1:00-2:00 complementario con final top**
+(Bea explicita; Cambium pendiente de confirmar cota superior).
+Tope tecnico: 3:00.
+
+Densidad informativa: **cartelas como motor**. VO con pocas palabras.
+Silencio deliberado donde la cartela basta.
+
+~180 palabras VO castellano (objetivo Cambium).
+
+---
+
+## Estructura y VO
+
+Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
+`Cartela` es texto en pantalla. `—` = silencio intencional.
+
+### Minuto 1 (top, autosuficiente)
+
+| t | Bloque | VO | Cartela |
+|---|--------|----|---------|
+| 0:00-0:07 | Apertura | — | "Decide sola hoy." |
+| 0:07-0:13 | Rhizome | "Esta parcela decide con un modelo local." | Rhizome · Gemma 4 E2B · edge |
+| 0:13-0:18 | Receipt | "Sin red. En menos de un segundo." | decision_receipt · firmado local |
+| 0:18-0:25 | Pollen entra | "Alguien ya camina esta ruta." | Pollen · Gemma 4 E2B · movil, LiteRT |
+| 0:25-0:30 | Flash A | "El movil audita la decision con otro pase." | — |
+| 0:35-0:50 | **CLIMAX (b)** | "En el camino de A a B, el criterio se ajusta. Llega a B como politica, no como dato." | policy_delta · rationale visible |
+| 0:50-1:00 | Pull-back | "Un modelo. Tres profundidades. Tres tiempos." | "Criterio que circula en el bolsillo." |
+
+### Minutos 2-3 (complementario, final top)
+
+| t | Bloque | VO | Cartela |
+|---|--------|----|---------|
+| 1:00-1:15 | Timelapse | — | "... pasa el dia ..." |
+| 1:15-1:30 | Meristem | "Al final del dia, otro modelo consolida lo aprendido." | Meristem · Gemma 4 E4B · Ollama / MVP local 16 GB / arquitectura objetivo: 26B |
+| 1:30-1:50 | Capa fisica | "El hardware bloquea lo que el modelo no deberia permitir." | BdE 2024: 20-30% trigo España perdido por decisiones tardias |
+| 1:50-2:10 | Caducidad | "Si llega tarde, no se usa." | REJECTED · policy_expired |
+| 2:10-2:30 | Amanecer siguiente | "A la mañana siguiente, la parcela despierta con el criterio del dia anterior." | — |
+| 2:30-2:50 | **CIERRE (e)** | — | FAO: 84% explotaciones <2 ha. Producen 36% del alimento. / IRRIFRAME: 40k explotaciones · servidor central. / Sprout: criterio que viaja a pie. |
+| 2:50-3:00 | Tarjeta final | — | zigiella · Apache 2.0 · github.com/zigiella/sprout / ITU 2024: 85% conectividad rural global · 58% zonas remotas |
+
+---
+
+## Conteo de palabras VO
+
+- 0:07-0:13: 8
+- 0:13-0:18: 7
+- 0:18-0:25: 7
+- 0:25-0:30: 10
+- 0:35-0:50: 22
+- 0:50-1:00: 8
+- 1:15-1:30: 11
+- 1:30-1:50: 12
+- 1:50-2:10: 6
+- 2:10-2:30: 15
+- **Total: ~106 palabras VO.** Margen holgado bajo el objetivo ~180. Permite doblaje EN sin apretar.
+
+---
+
+## Principios aplicados
+
+1. **Apertura silenciosa.** Una cartela, cero VO, cero idioma. Funciona para jurado anglo sin friccion.
+2. **Triptico narrativo:** "Un modelo. Tres profundidades. Tres tiempos." — frase espinal que aparece en pull-back (fin min 1) y se reconoce implicita en el cierre (Sprout a pie).
+3. **Stack cartelas Gemma** en cada nodo — Gusthema (Gemma DevRel) ve la familia explicita, no inferida.
+4. **Climax 15 s** con VO denso en 0:35-0:50 (22 palabras) — es el bloque que el espectador necesita entender mejor, y donde el video se juega la tesis.
+5. **Meristem honesto:** cartela "E4B MVP / 26B objetivo". No se esconde el trade-off; se nombra.
+6. **Cartelas como motor de densidad.** Datos fuertes (BdE, FAO, IRRIFRAME, ITU) **nunca en VO**. Siempre en cartela. El dato impacta visualmente; el VO hace la historia.
+7. **Cierre sin VO.** Tripleta silenciosa de cartelas. La ultima —"Sprout: criterio que viaja a pie"— cierra la tesis que abrio la apertura silenciosa.
+
+---
+
+## Pendiente antes de grabar VO
+
+- [ ] Confirmar cota superior duracion con Cambium (Bea dice 1+1-2, limite?)
+- [ ] Fijar persona VO castellano (Bea o Corola)
+- [ ] Validacion lectura cruzada Xilema/Floema/Meristem
+- [ ] Revisar linea climax (0:35-0:50) — es la mas densa, puede beneficiarse de pulido
+- [ ] Generar version EN para doblaje Bea
+
+---
+
+## Historial de versiones
+
+- **v0** (2026-04-19, Corola) — reset tras reframe (`2026-04-18_reframe-narrativo-pollen_cambium.md`) y Meristem diferido (`2026-04-19_meristem-como-revision-diferida_cambium.md`). 3 min con min 1 autosuficiente, climax (b) transferencia cruzada, cierre (e) Meristem diferido, cartela 26B objetivo, VO ~106 palabras. Acepta criterios #12.
+- **v0.1** (2026-04-18, Corola) — draft descartado. Construido sobre climax caducidad y Pollen como mula.

--- a/video/script.md
+++ b/video/script.md
@@ -42,7 +42,7 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 | t | Bloque | VO | Cartela |
 |---|--------|----|---------|
 | 1:00-1:15 | Timelapse | — | "... pasa el dia ..." |
-| 1:15-1:30 | Meristem | "Al final del dia, otro modelo consolida lo aprendido." | Meristem · Gemma 4 E4B · Ollama / MVP local 16 GB / arquitectura objetivo: 26B |
+| 1:15-1:30 | Meristem | "Al final del dia, Meristem consolida lo aprendido." | Meristem · Gemma 4 E4B · Ollama / MVP local 16 GB / arquitectura objetivo: 26B |
 | 1:30-1:50 | Capa fisica | "El firmware rechaza lo que el modelo aun no sabe frenar." | BdE 2024: 20-30% trigo España perdido por decisiones tardias |
 | 1:50-2:10 | Caducidad | "Si llega tarde, no se usa." | REJECTED · policy_expired |
 | 2:10-2:30 | Amanecer siguiente | "A la mañana siguiente, la parcela despierta con el criterio del dia anterior." | — |
@@ -59,11 +59,11 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 - 0:25-0:30: 10
 - 0:35-0:50: 20
 - 0:50-1:00: 8
-- 1:15-1:30: 11
+- 1:15-1:30: 9
 - 1:30-1:50: 11
 - 1:50-2:10: 6
 - 2:10-2:30: 15
-- **Total: ~103 palabras VO.** Margen holgado bajo el objetivo ~180. Permite doblaje EN sin apretar.
+- **Total: ~101 palabras VO.** Margen holgado bajo el objetivo ~180. Permite doblaje EN sin apretar.
 
 ---
 
@@ -91,6 +91,7 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 
 ## Historial de versiones
 
+- **v0.3** (2026-04-20, Corola) — ajuste VO pedido por Bea: linea 1:15-1:30 pasa de "Al final del dia, otro modelo consolida lo aprendido." a **"Al final del dia, Meristem consolida lo aprendido."** (9 palabras, -2). Nombrar Meristem en VO le da peso — es la unica aparicion del nombre en audio, la cartela ya lo nombra en pantalla pero la combinacion doble refuerza. Total VO: 101 palabras. **Nota:** la cartela stack del plano 10 ("E4B MVP / 26B objetivo") se mantiene en esta version; se reformula en shot list v1 tras el reframe de Meristem (`bitacora/2026-04-20_meristem-reframe-modelo-objetivo_cambium.md`, en main commit 0a6376d).
 - **v0.2** (2026-04-20, Corola) — ajuste narrativo pedido por Bea: los verbos "caminar" y "a pie" empequeñecen la tesis de Pollen. Sustituidos por neutros. VO 0:18-0:25: "Alguien ya camina esta ruta." → **"Alguien ya recorre esta ruta."** (5 palabras, igual). VO climax 0:35-0:50: "En el camino de A a B..." → **"En ruta de A a B..."** (20 palabras, -2). Cartela cierre 2:30-2:50: "Sprout: criterio que viaja a pie." → **"Sprout: criterio que viaja con quien se mueve."** Principio #7 anotado explicitamente: verbo neutro protege diseño agnostico al portador de Pollen. Total VO: 103 palabras. Racional completo en `bitacora/2026-04-20_corola-guion-v02_corola.md`.
 - **v0-post-review** (2026-04-20, Corola) — ajuste tras review Cambium en PR #41: linea 1:30-1:50 pasa de "El hardware bloquea lo que el modelo no deberia permitir." a **"El firmware rechaza lo que el modelo aun no sabe frenar."** (de pasivo+adversarial a activo+narrativa de capas, -1 palabra). Climax (0:35-0:50) mantenido tal cual por recomendacion explicita de Cambium. Linea 2:10-2:30 ("despierta con el criterio") mantenida por voto estilistico — busco resonancia con el amanecer en pantalla. Total VO: 105 palabras.
 - **v0** (2026-04-19, Corola) — reset tras reframe (`2026-04-18_reframe-narrativo-pollen_cambium.md`) y Meristem diferido (`2026-04-19_meristem-como-revision-diferida_cambium.md`). 3 min con min 1 autosuficiente, climax (b) transferencia cruzada, cierre (e) Meristem diferido, cartela 26B objetivo, VO ~106 palabras. Acepta criterios #12.

--- a/video/script.md
+++ b/video/script.md
@@ -32,9 +32,9 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 | 0:00-0:07 | Apertura | — | "Decide sola hoy." |
 | 0:07-0:13 | Rhizome | "Esta parcela decide con un modelo local." | Rhizome · Gemma 4 E2B · edge |
 | 0:13-0:18 | Receipt | "Sin red. En menos de un segundo." | decision_receipt · firmado local |
-| 0:18-0:25 | Pollen entra | "Alguien ya camina esta ruta." | Pollen · Gemma 4 E2B · movil, LiteRT |
+| 0:18-0:25 | Pollen entra | "Alguien ya recorre esta ruta." | Pollen · Gemma 4 E2B · movil, LiteRT |
 | 0:25-0:30 | Flash A | "El movil audita la decision con otro pase." | — |
-| 0:35-0:50 | **CLIMAX (b)** | "En el camino de A a B, el criterio se ajusta. Llega a B como politica, no como dato." | policy_delta · rationale visible |
+| 0:35-0:50 | **CLIMAX (b)** | "En ruta de A a B, el criterio se ajusta. Llega a B como politica, no como dato." | policy_delta · rationale visible |
 | 0:50-1:00 | Pull-back | "Un modelo. Tres profundidades. Tres tiempos." | "Criterio que circula en el bolsillo." |
 
 ### Minutos 2-3 (complementario, final top)
@@ -46,7 +46,7 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 | 1:30-1:50 | Capa fisica | "El firmware rechaza lo que el modelo aun no sabe frenar." | BdE 2024: 20-30% trigo España perdido por decisiones tardias |
 | 1:50-2:10 | Caducidad | "Si llega tarde, no se usa." | REJECTED · policy_expired |
 | 2:10-2:30 | Amanecer siguiente | "A la mañana siguiente, la parcela despierta con el criterio del dia anterior." | — |
-| 2:30-2:50 | **CIERRE (e)** | — | FAO: 84% explotaciones <2 ha. Producen 36% del alimento. / IRRIFRAME: 40k explotaciones · servidor central. / Sprout: criterio que viaja a pie. |
+| 2:30-2:50 | **CIERRE (e)** | — | FAO: 84% explotaciones <2 ha. Producen 36% del alimento. / IRRIFRAME: 40k explotaciones · servidor central. / Sprout: criterio que viaja con quien se mueve. |
 | 2:50-3:00 | Tarjeta final | — | zigiella · Apache 2.0 · github.com/zigiella/sprout / ITU 2024: 85% conectividad rural global · 58% zonas remotas |
 
 ---
@@ -57,25 +57,25 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 - 0:13-0:18: 7
 - 0:18-0:25: 7
 - 0:25-0:30: 10
-- 0:35-0:50: 22
+- 0:35-0:50: 20
 - 0:50-1:00: 8
 - 1:15-1:30: 11
 - 1:30-1:50: 11
 - 1:50-2:10: 6
 - 2:10-2:30: 15
-- **Total: ~105 palabras VO.** Margen holgado bajo el objetivo ~180. Permite doblaje EN sin apretar.
+- **Total: ~103 palabras VO.** Margen holgado bajo el objetivo ~180. Permite doblaje EN sin apretar.
 
 ---
 
 ## Principios aplicados
 
 1. **Apertura silenciosa.** Una cartela, cero VO, cero idioma. Funciona para jurado anglo sin friccion.
-2. **Triptico narrativo:** "Un modelo. Tres profundidades. Tres tiempos." — frase espinal que aparece en pull-back (fin min 1) y se reconoce implicita en el cierre (Sprout a pie).
+2. **Triptico narrativo:** "Un modelo. Tres profundidades. Tres tiempos." — frase espinal que aparece en pull-back (fin min 1) y se reconoce implicita en el cierre (Sprout: criterio que viaja con quien se mueve).
 3. **Stack cartelas Gemma** en cada nodo — Gusthema (Gemma DevRel) ve la familia explicita, no inferida.
-4. **Climax 15 s** con VO denso en 0:35-0:50 (22 palabras) — es el bloque que el espectador necesita entender mejor, y donde el video se juega la tesis.
+4. **Climax 15 s** con VO denso en 0:35-0:50 (20 palabras) — es el bloque que el espectador necesita entender mejor, y donde el video se juega la tesis.
 5. **Meristem honesto:** cartela "E4B MVP / 26B objetivo". No se esconde el trade-off; se nombra.
 6. **Cartelas como motor de densidad.** Datos fuertes (BdE, FAO, IRRIFRAME, ITU) **nunca en VO**. Siempre en cartela. El dato impacta visualmente; el VO hace la historia.
-7. **Cierre sin VO.** Tripleta silenciosa de cartelas. La ultima —"Sprout: criterio que viaja a pie"— cierra la tesis que abrio la apertura silenciosa.
+7. **Cierre sin VO.** Tripleta silenciosa de cartelas. La ultima —"Sprout: criterio que viaja con quien se mueve"— cierra la tesis que abrio la apertura silenciosa. **Verbo neutro deliberado:** no "a pie", no "caminar" — el diseño de Pollen es agnostico al portador (persona/bici/camioneta/tractor/dron), y la cartela no lo encadena a un solo modo aunque la imagen en pantalla sea humana. Ver bitacora v0.2 para racional.
 
 ---
 
@@ -91,6 +91,7 @@ Tabla alineada con `shot_list.md` v0. `VO` es texto hablado (castellano).
 
 ## Historial de versiones
 
+- **v0.2** (2026-04-20, Corola) — ajuste narrativo pedido por Bea: los verbos "caminar" y "a pie" empequeñecen la tesis de Pollen. Sustituidos por neutros. VO 0:18-0:25: "Alguien ya camina esta ruta." → **"Alguien ya recorre esta ruta."** (5 palabras, igual). VO climax 0:35-0:50: "En el camino de A a B..." → **"En ruta de A a B..."** (20 palabras, -2). Cartela cierre 2:30-2:50: "Sprout: criterio que viaja a pie." → **"Sprout: criterio que viaja con quien se mueve."** Principio #7 anotado explicitamente: verbo neutro protege diseño agnostico al portador de Pollen. Total VO: 103 palabras. Racional completo en `bitacora/2026-04-20_corola-guion-v02_corola.md`.
 - **v0-post-review** (2026-04-20, Corola) — ajuste tras review Cambium en PR #41: linea 1:30-1:50 pasa de "El hardware bloquea lo que el modelo no deberia permitir." a **"El firmware rechaza lo que el modelo aun no sabe frenar."** (de pasivo+adversarial a activo+narrativa de capas, -1 palabra). Climax (0:35-0:50) mantenido tal cual por recomendacion explicita de Cambium. Linea 2:10-2:30 ("despierta con el criterio") mantenida por voto estilistico — busco resonancia con el amanecer en pantalla. Total VO: 105 palabras.
 - **v0** (2026-04-19, Corola) — reset tras reframe (`2026-04-18_reframe-narrativo-pollen_cambium.md`) y Meristem diferido (`2026-04-19_meristem-como-revision-diferida_cambium.md`). 3 min con min 1 autosuficiente, climax (b) transferencia cruzada, cierre (e) Meristem diferido, cartela 26B objetivo, VO ~106 palabras. Acepta criterios #12.
 - **v0.1** (2026-04-18, Corola) — draft descartado. Construido sobre climax caducidad y Pollen como mula.


### PR DESCRIPTION
## Summary

- `video/script.md` v0: VO castellano ~106 palabras (bajo objetivo ~180 — margen para doblaje EN).
- Alineado con `shot_list.md` v0 (PR hermano [#40](https://github.com/zigiella/sprout/pull/40)).
- **Apertura y cierre silenciosos** (sin idioma) — friccion cero para jurado anglo.
- **Frase espinal "Un modelo. Tres profundidades. Tres tiempos."** en pull-back (fin min 1).
- **Climax 0:35-0:50** denso (22 palabras) para dar soporte verbal al `rationale` visible en pantalla.
- **Cartela Meristem explicita:** `E4B MVP / 26B objetivo` — honestidad sobre trade-off (pedido Bea).
- **Datos duros en cartelas silenciosas,** nunca en VO (BdE 20-30% trigo, FAO 84%/36%, IRRIFRAME 40k, ITU 85/58). Facilita doblaje EN sin resincronizar datos.

## Obsoleto por este PR

- `video/script.md` v0.1 (descartado antes de este commit): construido sobre climax caducidad, Pollen-mula, y duracion 3 min sin autosuficiencia min 1.

## Decisiones abiertas (no bloquean merge)

- Doblaje EN de frase espinal (decision Bea). Propuesta: "One model. Three depths. Three speeds."
- Cota superior duracion: Bea dice 1+1-2; brief dice <1 min; #12 dice 3 min. v0 asume 3 min. Si Cambium baja, re-edicion del cierre preserva tripleta.
- Persona VO castellano (Bea o Corola).

## Test plan

- [ ] Lectura cruzada Cambium (coherencia narrativa)
- [ ] Lectura cruzada Xilema/Floema/Meristem (factibilidad MVP)
- [ ] Revisar linea climax (0:35-0:50) — bloque mas denso, puede pulirse
- [ ] Confirmar con Bea la tripleta final (FAO / IRRIFRAME / Sprout)
- [ ] Validar version EN para doblaje cuando Bea la genere

Refs #12. No cierra — necesita tambien el shot list v0 [#40](https://github.com/zigiella/sprout/pull/40).