### PR TITLE
feat(meristem): inference adapter Ollama-compatible (cloud+local+test)

### DIFF
--- a/bitacora/2026-04-21_thoughts-token-count-verificacion-pendiente_meristem.md
+++ b/bitacora/2026-04-21_thoughts-token-count-verificacion-pendiente_meristem.md
@@ -1,0 +1,138 @@
+# Semántica de `thoughts_token_count` — verificación diferida a ejecución con API key
+
+**Fecha:** 2026-04-21
+**Autor:** Meristem
+**Área:** Meristem
+**Tipo:** decisión de alcance para PR #46 + protocolo ejecutable pendiente
+**Destinatario:** Cambium (para aceptar el PR con la verificación diferida) y
+Estoma (si decide correrla como parte de research con su key Gemini)
+
+## Contexto
+
+El README del adapter deja abierta esta pregunta (sección "Semántica de
+`thoughts_token_count`"): cuando Gemini responde con `include_thoughts=true`,
+¿los `thoughts_token_count` consumen del pool de la ventana de contexto del
+modelo (como prompt + candidates), o son output-only y no descuentan?
+
+Esta respuesta **no cambia** nada del adapter que se implementa en #46. El
+contrato de headers es estable contra ambos resultados:
+
+- `Sprout-Inference-Tokens-In`  = `prompt_token_count` (siempre, agnóstico).
+- `Sprout-Inference-Thinking-Tokens` = `thoughts_token_count` explícito (siempre).
+- `Sprout-Inference-Tokens-Out` = `candidates_token_count` sin thinking (siempre).
+
+Lo que sí cambia es el **scope de #47** (sweep de ventana de contexto): si
+thoughts consume del pool, el sweep tiene que presupuestarlos contra el
+`num_ctx` nominal; si son output-only, solo cuentan prompt+candidates.
+
+## Qué se intentó en esta sesión
+
+Implementé el PR completo (11 criterios de Cambium, 88 tests verdes). Intenté
+cerrar la verificación corriendo el protocolo del README contra Gemini real.
+Blocker inmediato: **`GEMINI_API_KEY` no está disponible en el entorno de esta
+sesión**. No he visto la key en `.env` ni en `env` del shell.
+
+Alternativas consideradas:
+
+1. **Pedirle la key a Cambium para cerrar en esta sesión.** Descartado — no
+   depende de arquitectura, es verificación puntual que cualquiera puede correr
+   en 3 minutos con su key. No bloquea el PR.
+2. **Inferir la respuesta de la doc de Google.** La doc de `google-genai` dice
+   que `thoughts_token_count` es parte de `usage_metadata` junto a los otros
+   dos contadores, sin especificar si consume del pool. No es defensible
+   apostar por una interpretación sin medir.
+3. **Diferir la verificación y documentar el protocolo.** Adoptado. El PR
+   queda mergeado; la bitácora tiene el protocolo ejecutable; el resultado se
+   añade como comment aquí cuando alguien lo corra.
+
+## Protocolo ejecutable (reproducible cuando haya key)
+
+```bash
+# 1. Exportar la key.
+export GEMINI_API_KEY="AIzaSy..."
+
+# 2. Correr este script (adjunto al final) que hace una llamada controlada.
+python scripts/verify_thoughts_token_count.py
+```
+
+Script propuesto (lo adjunto aquí como referencia, no lo comiteo al repo hasta
+que se ejecute — es throwaway):
+
+```python
+# scripts/verify_thoughts_token_count.py
+import os
+from google import genai
+from google.genai import types
+
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+# Prompt pequeño, ~500 tokens. No importa el contenido — lo que importa es el
+# contador reportado.
+prompt = (
+    "Explica brevemente (<=200 palabras) por qué el ciclo del carbono "
+    "terrestre se ve afectado por microbiota del suelo. Responde en español."
+)
+
+# Forzar thinking ON con presupuesto moderado.
+config = types.GenerateContentConfig(
+    thinking_config=types.ThinkingConfig(
+        include_thoughts=True,
+        thinking_budget=2048,
+    ),
+)
+
+response = client.models.generate_content(
+    model="gemma-4-26b-a4b",  # o el id que la key tenga habilitado
+    contents=prompt,
+    config=config,
+)
+
+um = response.usage_metadata
+print("prompt_token_count     :", um.prompt_token_count)
+print("candidates_token_count :", um.candidates_token_count)
+print("thoughts_token_count   :", um.thoughts_token_count)
+print("TOTAL (si contaran los 3):",
+      um.prompt_token_count + um.candidates_token_count + um.thoughts_token_count)
+
+# Para diagnosticar si consume del pool, repetir con prompt cercano al límite
+# de la ventana y observar si una llamada con thinking OFF del mismo prompt
+# tiene cabida cuando la misma con thinking ON falla con "context length
+# exceeded".
+```
+
+## Regla de decisión cuando se ejecute
+
+Si se observa que un prompt que con `thinking=false` cabe en ventana X, con
+`thinking=true` falla por context length → **consume del pool**:
+
+1. Actualizar `src/backends/cloud.py` docstring con la nota.
+2. Abrir (o añadir a) issue #47 un item que presupueste `thoughts_token_count`
+   contra `num_ctx` al componer sweeps.
+3. Bitácora `2026-04-XX_gemini-api-thinking-budget-consume-contexto_meristem.md`
+   cerrando este documento.
+
+Si el mismo prompt cabe con ambos → **output-only**:
+
+1. Nota de una línea en README sección "Semántica de `thoughts_token_count`".
+2. Cerrar este documento con un comment resumiendo el resultado.
+3. #47 no requiere cambios.
+
+## Impacto en el PR #46
+
+**Ninguno.** El PR es mergeable tal cual. La asimetría solo afecta a:
+
+- `#47` (sweep de ventana de contexto) — scope pendiente del resultado.
+- El writeup puede perfilar mejor la métrica una vez fijado.
+
+Los 11 criterios técnicos del comment de #46 no tocan esta pregunta: se
+implementan igual para ambas ramas de la decisión.
+
+## Referencias
+
+- `code/meristem_inference_adapter/README.md` sección "Semántica de
+  `thoughts_token_count`" — describe el protocolo.
+- `bitacora/2026-04-19_thinking-mode-e4b-latencia_meristem.md` — antecedente
+  con la medición local (Ollama no desglosa, por eso `Thinking-Tokens=0` en
+  local; cloud sí desglosa y por eso esta verificación importa).
+- #46 — PR que este bitácora acompaña.
+- #47 — sweep de ventana de contexto, principal consumidor del resultado.

--- a/code/meristem_inference_adapter/.env.example
+++ b/code/meristem_inference_adapter/.env.example
@@ -1,0 +1,29 @@
+# --- Backend selection ---
+# cloud | local | test
+INFERENCE_BACKEND=test
+
+# --- Port layout ---
+# El adapter escucha SIEMPRE en :11434 (donde Meristem habla).
+# En modo local, Ollama real debe correr en :11435 (ollama serve --port 11435).
+ADAPTER_PORT=11434
+OLLAMA_UPSTREAM_HOST=http://localhost:11435
+
+# --- Cloud backend (Gemini API) ---
+# Requerido si INFERENCE_BACKEND=cloud
+GEMINI_API_KEY=
+# Modelo cloud por defecto (ver DEFAULT_MODEL_ALIASES en src/config.py)
+GEMINI_DEFAULT_MODEL=gemma-4-26b-a4b
+
+# --- Thinking budget placeholder (#44 fijara valor empirico tras A/B) ---
+MERISTEM_THINKING_BUDGET=4096
+
+# --- Pricing Gemini (EUR por 1K tokens). Configurable para que Cost-EUR no quede hardcoded. ---
+GEMINI_PRICE_IN_EUR_PER_1K=0.0
+GEMINI_PRICE_OUT_EUR_PER_1K=0.0
+GEMINI_PRICE_THINKING_EUR_PER_1K=0.0
+
+# --- Retry / backoff (429 Gemini). Defaults del comentario tecnico de #46. ---
+RETRY_MAX_ATTEMPTS=3
+RETRY_BACKOFF_MS_1=500
+RETRY_BACKOFF_MS_2=2000
+RETRY_BACKOFF_MS_3=8000

--- a/code/meristem_inference_adapter/README.md
+++ b/code/meristem_inference_adapter/README.md
@@ -1,0 +1,230 @@
+# meristem_inference_adapter/
+
+Proxy local Ollama-compatible que expone `localhost:11434` con la API de Ollama
+(`/api/chat`, `/api/generate`) y reenvia:
+
+- a Gemini API cuando `INFERENCE_BACKEND=cloud` (demo via nube con Gemma 26B MoE)
+- a Ollama real en `:11435` cuando `INFERENCE_BACKEND=local` (reverse-proxy transparente)
+- a un backend `test` con respuestas canneadas cuando `INFERENCE_BACKEND=test` (CI sin Gemini ni Ollama)
+
+Meristem (el consumidor) habla siempre a `:11434` con contrato Ollama nativo y
+no distingue el backend. El switch es del adapter.
+
+Contexto: D2/D3 de `bitacora/2026-04-20_meristem-reframe-modelo-objetivo_cambium.md`
+y los 11 criterios tecnicos convergidos en el comentario de #46.
+
+## Estado
+
+Implementado en `feat/meristem-inference-adapter-46`. Los 11 criterios técnicos
+del comentario de Cambium en #46 están cubiertos. 88 tests verdes, ninguno
+requiere Gemini ni Ollama real (contrato punto 11).
+
+Pendiente de ejecución (no bloquea merge): verificación en vivo de la
+semántica de `thoughts_token_count` contra Gemini API real — ver sección
+correspondiente abajo.
+
+## Estructura
+
+```
+meristem_inference_adapter/
+├── README.md
+├── requirements.txt
+├── pyproject.toml
+├── .env.example
+├── src/
+│   ├── __init__.py
+│   ├── main.py                # FastAPI app en :11434, /api/chat + /api/generate
+│   ├── config.py              # env vars, aliases de modelos, pricing
+│   ├── schema_flatten.py      # inline de $ref / poda de $defs (punto 1)
+│   ├── thinking_map.py        # Ollama think <-> Gemini thinking_config (punto 2)
+│   ├── reconstruct.py         # extrae partes thought=true a message.thinking (punto 3)
+│   ├── headers.py             # emite Sprout-Inference-* uniformes (punto 7)
+│   ├── retry.py               # backoff 500ms/2s/8s para 429 Gemini (punto 5)
+│   └── backends/
+│       ├── __init__.py
+│       ├── base.py            # Protocol InferenceBackend
+│       ├── local.py           # reverse-proxy transparente a :11435
+│       ├── cloud.py           # Gemini API (google-genai)
+│       └── test.py            # mock con canned responses (punto 11)
+└── tests/
+    ├── __init__.py
+    ├── conftest.py
+    ├── test_scaffold.py        # config + health + protocolo
+    ├── test_schema_flatten.py  # punto 1
+    ├── test_thinking_map.py    # punto 2
+    ├── test_reconstruct.py     # punto 3
+    ├── test_headers.py         # puntos 4 y 7
+    ├── test_retry.py           # punto 5
+    ├── test_backend_test.py    # punto 11
+    ├── test_backend_local.py   # reverse-proxy con respx
+    ├── test_backend_cloud.py   # Gemini API con genai client fake
+    ├── test_main.py            # integracion FastAPI + error handling
+    └── test_smoke_parity.py    # mismo prompt local vs cloud, headers uniformes
+```
+
+## Port layout (punto 6)
+
+| Quien | Puerto | Nota |
+|---|---|---|
+| Meristem | cliente | habla a `http://localhost:11434` |
+| adapter | `11434` | escucha SIEMPRE aqui |
+| Ollama real | `11435` | solo en modo `local`; arrancar con `ollama serve --port 11435` |
+| Gemini API | remoto | backend `cloud` |
+
+## Variables de entorno
+
+Ver `.env.example`. Claves:
+
+| Var | Default | Nota |
+|---|---|---|
+| `INFERENCE_BACKEND` | `test` | `cloud` \| `local` \| `test` |
+| `ADAPTER_PORT` | `11434` | puerto del adapter |
+| `OLLAMA_UPSTREAM_HOST` | `http://localhost:11435` | solo usado en `local` |
+| `GEMINI_API_KEY` | (vacio) | requerido si `cloud` |
+| `GEMINI_DEFAULT_MODEL` | `gemma-4-26b-a4b` | modelo cloud por defecto |
+| `MERISTEM_THINKING_BUDGET` | `4096` | placeholder, #44 lo fija empiricamente |
+| `GEMINI_PRICE_IN_EUR_PER_1K` | `0.0` | configurable, no hardcoded |
+| `GEMINI_PRICE_OUT_EUR_PER_1K` | `0.0` | |
+| `GEMINI_PRICE_THINKING_EUR_PER_1K` | `0.0` | |
+| `RETRY_MAX_ATTEMPTS` | `3` | |
+| `RETRY_BACKOFF_MS_1/2/3` | `500` / `2000` / `8000` | |
+
+## Alias de modelos (punto 9)
+
+```python
+DEFAULT_MODEL_ALIASES = {
+    "gemma4:26b-moe": "gemma-4-26b-a4b",
+    "gemma4:e4b":     "gemma-4-e4b-it",
+    "gemma4:31b":     "gemma-4-31b-it",
+}
+```
+
+Overridable por env (pendiente de definir formato exacto en implementacion).
+
+## Headers `Sprout-Inference-*` (puntos 4 y 7)
+
+Adapter emite el set completo en **ambos** modos. En modo local los campos de
+coste son `0.0`.
+
+```
+Sprout-Inference-Backend:         cloud-gemini | local-ollama | test
+Sprout-Inference-Model:           gemma-4-26b-a4b | gemma-4-e4b-it | ...
+Sprout-Inference-Tokens-In:       <int>    = prompt_token_count
+Sprout-Inference-Tokens-Out:      <int>    = candidates_token_count (sin thinking)
+Sprout-Inference-Thinking-Tokens: <int>    = thoughts_token_count (0 explicito si thinking off)
+Sprout-Inference-Duration-Ms:     <int>    = wallclock total adapter
+Sprout-Inference-Cost-EUR:        <float>  = 0.0 en local/test
+```
+
+### Nota sobre `tok/s` derivado (punto 4, docstring explicito pedido por Cambium)
+
+`eval_count` en la respuesta Ollama-format que el adapter devuelve se calcula como
+`candidates_token_count + thoughts_token_count`. Eso significa que cualquier
+`tok/s` derivado como `eval_count / eval_duration` **incluye tokens de thinking**
+cuando thinking esta activo.
+
+El numero defendible (tok/s de generacion visible al usuario) sale de los
+headers desglosados: `Sprout-Inference-Tokens-Out / Sprout-Inference-Duration-Ms`.
+
+Harness (#45), writeup y cualquier grafica comparativa DEBEN usar los headers
+desglosados, no el `eval_count` agregado.
+
+## Placeholder thinking budget (punto 2)
+
+```python
+# PLACEHOLDER — default empirico se fija en #44 tras A/B.
+# No optimizar en base a este numero.
+THINKING_BUDGET_TOKENS_PLACEHOLDER = 4096
+```
+
+Cuando #44 cierre, la constante se sustituye por el valor medido y el
+comentario referencia el run.
+
+## Semantica de `thoughts_token_count` (verificacion diferida)
+
+Pregunta abierta: cuando Gemini responde con `include_thoughts=true`, los
+`thoughts_token_count` ¿consumen del pool de la ventana de contexto (como
+`prompt_token_count + candidates_token_count`) o son output-only?
+
+La respuesta no cambia el contrato del adapter — los 3 contadores se emiten
+siempre, desglosados, en los headers `Sprout-Inference-*`. Solo afecta al
+**scope de #47** (sweep de ventana de contexto): si consumen, el sweep tiene
+que presupuestarlos contra el `num_ctx` nominal.
+
+Protocolo ejecutable + decision rule + estado actual:
+`bitacora/2026-04-21_thoughts-token-count-verificacion-pendiente_meristem.md`.
+
+TL;DR del estado: **diferido**. La verificacion queda bloqueada a disponer de
+`GEMINI_API_KEY`; es reproducible en ~3 minutos con el script documentado en la
+bitacora. No bloquea el merge de #46.
+
+## Streaming (punto 8)
+
+`stream=true` en el request se acepta pero el adapter bufferea la respuesta
+completa de Gemini/Ollama y devuelve un unico chunk Ollama-format. Streaming
+real es iteracion posterior solo si #43 lo requiere.
+
+## Coexistencia con Ollama real (punto 6)
+
+Si se quiere correr Ollama real y el adapter a la vez, Ollama debe ir a `:11435`:
+
+```bash
+OLLAMA_HOST=0.0.0.0:11435 ollama serve
+# o
+ollama serve --port 11435
+```
+
+El adapter en modo `local` reenvia transparentemente a `$OLLAMA_UPSTREAM_HOST`.
+
+## Como correr
+
+```bash
+cd code/meristem_inference_adapter
+pip install -r requirements.txt
+cp .env.example .env
+# por defecto arranca con INFERENCE_BACKEND=test (no necesita Gemini ni Ollama)
+python -m src.main
+```
+
+## Tests
+
+```bash
+cd code/meristem_inference_adapter
+python -m pytest tests -v                    # suite completa (sin Gemini ni Ollama real)
+python -m pytest -m gemini tests -v          # solo si GEMINI_API_KEY esta exportada
+python -m pytest -m ollama tests -v          # solo si hay daemon Ollama en :11435
+```
+
+CI verde sin upstreams reales gracias al backend `test` (punto 11 de Cambium) y
+a `respx` + fake `genai.Client` para los backends `local` y `cloud`. 88 tests
+cubren los 11 criterios técnicos + smoke parity local-vs-cloud via headers
+(`test_smoke_parity.py`).
+
+## Troubleshooting
+
+### 429 desde Gemini durante sweep de contexto (#47)
+
+Esperado. El adapter reintenta (3 intentos por defecto, backoff
+`500ms / 2s / 8s` configurable). Si el ultimo intento sigue dando 429, responde
+503 con `Sprout-Inference-Error: upstream_rate_limited`. Caller (harness)
+decide si descartar el punto del sweep o esperar.
+
+### Puerto `:11434` ocupado
+
+Otro Ollama corriendo. Matar ese daemon o cambiar `ADAPTER_PORT`.
+
+### `thinking` vacio con backend cloud pese a `think=true`
+
+Verificar `MERISTEM_THINKING_BUDGET` > 0 y que el modelo cloud soporte thinking
+(26B MoE si; E4B-cloud, verificar).
+
+## Referencias
+
+- `bitacora/2026-04-20_meristem-reframe-modelo-objetivo_cambium.md` (D3)
+- `bitacora/2026-04-19_thinking-mode-e4b-latencia_meristem.md`
+- `bitacora/2026-04-21_thoughts-token-count-verificacion-pendiente_meristem.md`
+- #46 (este PR) — comentarios con los 11 criterios
+- #42 (quick-win `/api/chat`) — precede
+- #44 (thinking mode A/B) — consume el adapter, fija `THINKING_BUDGET_TOKENS_PLACEHOLDER`
+- #45 (harness completo) — consume el adapter
+- #47 (sweep ventana de contexto) — consume el adapter

--- a/code/meristem_inference_adapter/pyproject.toml
+++ b/code/meristem_inference_adapter/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "sprout-meristem-inference-adapter"
+version = "0.1.0"
+description = "Proxy Ollama-compatible que reenvia a Gemini API o a Ollama real segun INFERENCE_BACKEND."
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115,<0.120",
+    "uvicorn[standard]>=0.32,<0.40",
+    "httpx>=0.27,<0.30",
+    "pydantic>=2.12,<3",
+    "jsonref>=1.1,<2",
+    "google-genai>=0.3,<2",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0,<10",
+    "pytest-asyncio>=0.24,<1",
+    "respx>=0.21,<1",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+asyncio_mode = "auto"
+markers = [
+    "gemini: test que requiere GEMINI_API_KEY real (skip automatico si no esta).",
+    "ollama: test que requiere un daemon Ollama en :11435 (skip automatico si no responde).",
+]

--- a/code/meristem_inference_adapter/requirements.txt
+++ b/code/meristem_inference_adapter/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.115,<0.120
+uvicorn[standard]>=0.32,<0.40
+httpx>=0.27,<0.30
+pydantic>=2.12,<3
+jsonref>=1.1,<2
+google-genai>=0.3,<2

--- a/code/meristem_inference_adapter/src/__init__.py
+++ b/code/meristem_inference_adapter/src/__init__.py
@@ -1,0 +1,7 @@
+"""meristem_inference_adapter — proxy Ollama-compatible.
+
+Expone :11434 con contrato Ollama y reenvia a Gemini API (cloud), Ollama real
+en :11435 (local) o a un mock con canned responses (test).
+
+Ver README.md para contratos y puntos 1-11 de los criterios tecnicos de #46.
+"""

--- a/code/meristem_inference_adapter/src/backends/__init__.py
+++ b/code/meristem_inference_adapter/src/backends/__init__.py
@@ -1,0 +1,7 @@
+"""Backends del adapter.
+
+Un backend implementa el Protocol `InferenceBackend` (ver `base.py`) y encapsula
+el reenvio al upstream (Gemini / Ollama real / mock).
+
+El selector vive en `main.py` y lee `INFERENCE_BACKEND` de Settings.
+"""

--- a/code/meristem_inference_adapter/src/backends/base.py
+++ b/code/meristem_inference_adapter/src/backends/base.py
@@ -1,0 +1,44 @@
+"""Protocolo comun a todos los backends.
+
+Un backend recibe un request Ollama-format y devuelve (respuesta Ollama-format,
+InferenceMetrics para los headers Sprout-Inference-*).
+
+El adapter (main.py) orquesta: selecciona backend segun Settings, invoca,
+envuelve la respuesta con los headers y la devuelve al caller.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from ..headers import InferenceMetrics
+
+
+@runtime_checkable
+class InferenceBackend(Protocol):
+    """Contrato minimo que cualquier backend debe cumplir.
+
+    Los metodos son asyncronos porque cloud y local hacen I/O de red; test puede
+    implementarlos como `async def` triviales.
+    """
+
+    async def chat(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        """Implementa `/api/chat`.
+
+        Args:
+            request: body del request Ollama-format (dict parseado de JSON).
+
+        Returns:
+            Tupla `(response_body, metrics)`. `response_body` es el dict que el
+            adapter serializara como JSON de respuesta. `metrics` alimenta los
+            headers Sprout-Inference-*.
+        """
+        ...
+
+    async def generate(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        """Implementa `/api/generate`. Mismo contrato que `chat`."""
+        ...

--- a/code/meristem_inference_adapter/src/backends/cloud.py
+++ b/code/meristem_inference_adapter/src/backends/cloud.py
@@ -1,0 +1,443 @@
+"""Backend `cloud` — Gemini API via `google-genai`.
+
+Compone las cinco utilidades de la task 2:
+
+1. Si el request trae `format=<schema>`, pasar por `schema_flatten` (Gemini
+   rechaza `$ref`/`$defs`).
+2. Mapear `think` con `thinking_map.map_think_to_gemini`.
+3. Ejecutar la llamada a Gemini dentro de `retry.with_retry` para 429s
+   (backoff 500ms/2s/8s, 3 intentos por defecto).
+4. Dividir `candidate.content.parts` en content + thinking con
+   `reconstruct.split_gemini_parts`.
+5. Construir respuesta Ollama-format y emitir `InferenceMetrics` con el
+   desglose real de tokens.
+
+## Traduccion Ollama → Gemini
+
+### `/api/chat`
+
+Ollama `messages: [{"role": "user"|"assistant"|"system", "content": "..."}]`
+se mapea a:
+- `role=system` → `config.system_instruction` (NO va en `contents`).
+- `role=user` → `Content(role="user", parts=[Part.from_text("...")])`.
+- `role=assistant` → `Content(role="model", parts=[Part.from_text("...")])`.
+
+### `/api/generate`
+
+Ollama `{"prompt": "...", "system": "..."?}` se mapea a un unico mensaje user
+mas un `system_instruction` opcional.
+
+### `options`
+
+- `options.temperature` → `config.temperature`
+- `options.num_predict` → `config.max_output_tokens` (si > 0).
+- `options.num_ctx` → **NO propagable a Gemini**. Gemini no expone ventana por
+  llamada; el limite efectivo lo fija el modelo. Se ignora silenciosamente con
+  un warning en log. Ver bitacora del sweep de #47.
+
+## Contadores y eval_count
+
+Ollama `eval_count` = `candidates_token_count + thoughts_token_count`. Los
+headers `Sprout-Inference-*` desglosan (ver `headers.py` punto 4).
+
+## Cost
+
+`cost_eur = (tokens_in/1000)*price_in + (tokens_out/1000)*price_out
+          + (thinking/1000)*price_thinking`.
+
+Los tres precios vienen de env (`GEMINI_PRICE_*_EUR_PER_1K`), default `0.0` —
+no se hardcodea el pricing vigente. Si el caller no configura, el header sale
+`0.000000` y el harness documenta que el coste real hay que calcularlo fuera.
+
+## thoughts_token_count: ventana o output-only
+
+Pendiente verificar empiricamente (ver task 8). El adapter emite los 3
+contadores por separado; si thoughts descuenta de la ventana total, eso afecta
+al scope del sweep de #47, no al adapter.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable
+
+from ..config import PricingConfig, RetryConfig, resolve_model
+from ..headers import InferenceMetrics
+from ..reconstruct import split_gemini_parts
+from ..retry import with_retry
+from ..schema_flatten import flatten_json_schema
+from ..thinking_map import map_think_to_gemini
+
+logger = logging.getLogger(__name__)
+
+# Importacion perezosa del SDK para que `INFERENCE_BACKEND=test` no exija
+# `google-genai` instalado.
+_GENAI_MODULE = None
+_GENAI_TYPES = None
+_GENAI_ERRORS = None
+
+
+def _load_genai() -> tuple[Any, Any, Any]:
+    """Carga google-genai on-demand. Cachea el resultado."""
+    global _GENAI_MODULE, _GENAI_TYPES, _GENAI_ERRORS
+    if _GENAI_MODULE is None:
+        from google import genai as _genai  # type: ignore[import-untyped]
+        from google.genai import errors as _errors, types as _types
+
+        _GENAI_MODULE = _genai
+        _GENAI_TYPES = _types
+        _GENAI_ERRORS = _errors
+    return _GENAI_MODULE, _GENAI_TYPES, _GENAI_ERRORS
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """Predicado para `with_retry`: True si la excepcion es un 429 de Gemini."""
+    _, _, errors_mod = _load_genai()
+    if not isinstance(exc, errors_mod.APIError):
+        return False
+    return getattr(exc, "code", None) == 429
+
+
+def _translate_chat_request(request: dict[str, Any]) -> tuple[list, str | None]:
+    """Traduce `messages` Ollama → (contents Gemini, system_instruction)."""
+    _, types, _ = _load_genai()
+    system_instruction: str | None = None
+    contents: list = []
+    for msg in request.get("messages", []):
+        role = msg.get("role")
+        content = msg.get("content", "")
+        if role == "system":
+            # Gemini permite un unico system_instruction. Si hay varios msgs
+            # system, se concatenan con un blank line entre ellos — esto es
+            # poco comun pero el contrato Ollama lo permite.
+            system_instruction = (
+                content
+                if system_instruction is None
+                else f"{system_instruction}\n\n{content}"
+            )
+            continue
+        gemini_role = "model" if role == "assistant" else "user"
+        contents.append(
+            types.Content(
+                role=gemini_role,
+                parts=[types.Part.from_text(text=content)],
+            )
+        )
+    return contents, system_instruction
+
+
+def _translate_generate_request(request: dict[str, Any]) -> tuple[list, str | None]:
+    """Traduce `prompt` Ollama → (contents Gemini, system_instruction)."""
+    _, types, _ = _load_genai()
+    prompt = request.get("prompt", "")
+    system_instruction = request.get("system") or None
+    contents = [
+        types.Content(role="user", parts=[types.Part.from_text(text=prompt)])
+    ]
+    return contents, system_instruction
+
+
+def _build_config(
+    request: dict[str, Any],
+    *,
+    thinking_budget: int,
+    system_instruction: str | None,
+) -> Any:
+    """Construye GenerateContentConfig desde options + format + think."""
+    _, types, _ = _load_genai()
+    options = request.get("options") or {}
+
+    kwargs: dict[str, Any] = {}
+    if system_instruction is not None:
+        kwargs["system_instruction"] = system_instruction
+
+    # temperature
+    if "temperature" in options:
+        kwargs["temperature"] = float(options["temperature"])
+    # num_predict → max_output_tokens
+    if "num_predict" in options:
+        n = int(options["num_predict"])
+        if n > 0:
+            kwargs["max_output_tokens"] = n
+    # num_ctx: Gemini no lo soporta por llamada.
+    if "num_ctx" in options:
+        logger.info(
+            "cloud: num_ctx=%s ignorado (Gemini no expone ventana por llamada).",
+            options["num_ctx"],
+        )
+
+    # format=<schema>: estructura JSON-structured-output.
+    fmt = request.get("format")
+    if isinstance(fmt, dict):
+        flat = flatten_json_schema(fmt)
+        kwargs["response_mime_type"] = "application/json"
+        kwargs["response_schema"] = flat
+    elif fmt == "json":
+        # Ollama permite `format: "json"` sin schema. Gemini necesita
+        # response_mime_type; lo fijamos igual sin schema.
+        kwargs["response_mime_type"] = "application/json"
+
+    # thinking
+    think_flag = request.get("think")
+    thinking_cfg = map_think_to_gemini(
+        think=think_flag, budget_when_on=thinking_budget
+    )
+    kwargs["thinking_config"] = types.ThinkingConfig(
+        include_thoughts=thinking_cfg.include_thoughts,
+        thinking_budget=thinking_cfg.thinking_budget,
+    )
+
+    return types.GenerateContentConfig(**kwargs)
+
+
+def _compute_cost(
+    *,
+    tokens_in: int,
+    tokens_out: int,
+    thinking_tokens: int,
+    pricing: PricingConfig,
+) -> float:
+    return (
+        (tokens_in / 1000.0) * pricing.in_eur_per_1k
+        + (tokens_out / 1000.0) * pricing.out_eur_per_1k
+        + (thinking_tokens / 1000.0) * pricing.thinking_eur_per_1k
+    )
+
+
+class CloudBackend:
+    """Backend Gemini API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        default_model: str,
+        model_aliases: dict[str, str],
+        thinking_budget: int,
+        retry: RetryConfig,
+        pricing: PricingConfig,
+        client_factory: Callable[[str], Any] | None = None,
+    ) -> None:
+        """Construye el backend cloud.
+
+        Args:
+            api_key: GEMINI_API_KEY.
+            default_model: id de modelo Gemini a usar si el caller no manda uno.
+            model_aliases: dict `{"gemma4:26b-moe": "gemma-4-26b-a4b", ...}`.
+            thinking_budget: presupuesto de thinking cuando `think=true`.
+            retry: politica de reintentos para 429s.
+            pricing: pricing por 1K tokens para los 3 tipos de contador.
+            client_factory: callable que recibe `api_key` y devuelve un cliente
+                al estilo `genai.Client` (con `.aio.models.generate_content`).
+                Inyectable para tests.
+        """
+        self._api_key = api_key
+        self._default_model = default_model
+        self._aliases = dict(model_aliases)
+        self._thinking_budget = thinking_budget
+        self._retry = retry
+        self._pricing = pricing
+        self._client_factory = client_factory
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            if self._client_factory is not None:
+                self._client = self._client_factory(self._api_key)
+            else:
+                genai, _, _ = _load_genai()
+                self._client = genai.Client(api_key=self._api_key)
+        return self._client
+
+    def _resolve_model(self, request: dict[str, Any]) -> str:
+        tag = request.get("model") or self._default_model
+        return resolve_model(tag, self._aliases)
+
+    async def _call_gemini(
+        self, *, model_id: str, contents: list, config: Any
+    ) -> Any:
+        client = self._get_client()
+
+        async def _op() -> Any:
+            return await client.aio.models.generate_content(
+                model=model_id, contents=contents, config=config
+            )
+
+        return await with_retry(
+            _op,
+            max_attempts=self._retry.max_attempts,
+            backoff_ms=self._retry.backoff_ms,
+            is_rate_limit=_is_rate_limit_error,
+        )
+
+    def _build_metrics_and_body_common(
+        self,
+        *,
+        response: Any,
+        request_model_tag: str,
+        duration_ns: int,
+    ) -> tuple[str, str, int, int, int, int]:
+        """Extrae campos comunes de la respuesta Gemini.
+
+        Returns:
+            (content, thinking, tokens_in, tokens_out, thinking_tokens, duration_ms)
+        """
+        candidates = getattr(response, "candidates", None) or []
+        if not candidates:
+            raise RuntimeError(
+                "Gemini respondio sin candidates — posible filtro de seguridad."
+            )
+        parts = getattr(candidates[0].content, "parts", None) or []
+        split = split_gemini_parts(parts)
+
+        usage = getattr(response, "usage_metadata", None)
+        tokens_in = int(getattr(usage, "prompt_token_count", 0) or 0)
+        tokens_out = int(getattr(usage, "candidates_token_count", 0) or 0)
+        thinking_tokens = int(getattr(usage, "thoughts_token_count", 0) or 0)
+        duration_ms = max(duration_ns // 1_000_000, 1)
+
+        return (
+            split.content,
+            split.thinking,
+            tokens_in,
+            tokens_out,
+            thinking_tokens,
+            duration_ms,
+        )
+
+    def _split_duration_ns(
+        self, total_ns: int, tokens_in: int, tokens_out_plus_thinking: int
+    ) -> tuple[int, int]:
+        """Proporcional a tokens; mitad-mitad si ambos son 0."""
+        total = tokens_in + tokens_out_plus_thinking
+        if total == 0:
+            half = total_ns // 2
+            return half, total_ns - half
+        prompt_ns = (total_ns * tokens_in) // total
+        return prompt_ns, total_ns - prompt_ns
+
+    async def chat(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        request_model_tag = request.get("model", self._default_model)
+        model_id = self._resolve_model(request)
+        contents, system_instruction = _translate_chat_request(request)
+        config = _build_config(
+            request,
+            thinking_budget=self._thinking_budget,
+            system_instruction=system_instruction,
+        )
+
+        t0 = time.perf_counter_ns()
+        response = await self._call_gemini(
+            model_id=model_id, contents=contents, config=config
+        )
+        t1 = time.perf_counter_ns()
+        total_ns = max(t1 - t0, 1_000)
+
+        content, thinking, tokens_in, tokens_out, thinking_tokens, duration_ms = (
+            self._build_metrics_and_body_common(
+                response=response,
+                request_model_tag=request_model_tag,
+                duration_ns=total_ns,
+            )
+        )
+
+        prompt_ns, eval_ns = self._split_duration_ns(
+            total_ns, tokens_in, tokens_out + thinking_tokens
+        )
+
+        body = {
+            "model": request_model_tag,  # preservamos el tag que el caller envio
+            "created_at": "1970-01-01T00:00:00Z",  # deterministico
+            "message": {
+                "role": "assistant",
+                "content": content,
+                "thinking": thinking,
+            },
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": tokens_in,
+            # Contrato Ollama: eval_count incluye thinking.
+            "eval_count": tokens_out + thinking_tokens,
+            "prompt_eval_duration": prompt_ns,
+            "eval_duration": eval_ns,
+            "total_duration": total_ns,
+        }
+        metrics = InferenceMetrics(
+            backend="cloud-gemini",
+            model=request_model_tag,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,  # SIN thinking
+            thinking_tokens=thinking_tokens,
+            duration_ms=duration_ms,
+            cost_eur=_compute_cost(
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                thinking_tokens=thinking_tokens,
+                pricing=self._pricing,
+            ),
+        )
+        return body, metrics
+
+    async def generate(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        request_model_tag = request.get("model", self._default_model)
+        model_id = self._resolve_model(request)
+        contents, system_instruction = _translate_generate_request(request)
+        config = _build_config(
+            request,
+            thinking_budget=self._thinking_budget,
+            system_instruction=system_instruction,
+        )
+
+        t0 = time.perf_counter_ns()
+        response = await self._call_gemini(
+            model_id=model_id, contents=contents, config=config
+        )
+        t1 = time.perf_counter_ns()
+        total_ns = max(t1 - t0, 1_000)
+
+        content, thinking, tokens_in, tokens_out, thinking_tokens, duration_ms = (
+            self._build_metrics_and_body_common(
+                response=response,
+                request_model_tag=request_model_tag,
+                duration_ns=total_ns,
+            )
+        )
+
+        prompt_ns, eval_ns = self._split_duration_ns(
+            total_ns, tokens_in, tokens_out + thinking_tokens
+        )
+
+        body = {
+            "model": request_model_tag,
+            "created_at": "1970-01-01T00:00:00Z",
+            # /api/generate usa `response` en vez de `message`.
+            "response": content,
+            "thinking": thinking,
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": tokens_in,
+            "eval_count": tokens_out + thinking_tokens,
+            "prompt_eval_duration": prompt_ns,
+            "eval_duration": eval_ns,
+            "total_duration": total_ns,
+        }
+        metrics = InferenceMetrics(
+            backend="cloud-gemini",
+            model=request_model_tag,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            thinking_tokens=thinking_tokens,
+            duration_ms=duration_ms,
+            cost_eur=_compute_cost(
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                thinking_tokens=thinking_tokens,
+                pricing=self._pricing,
+            ),
+        )
+        return body, metrics

--- a/code/meristem_inference_adapter/src/backends/local.py
+++ b/code/meristem_inference_adapter/src/backends/local.py
@@ -1,0 +1,136 @@
+"""Backend `local` — reverse-proxy transparente a Ollama real en :11435 (punto 6).
+
+Meristem habla a :11434 (el adapter). Ollama real corre en :11435
+(`ollama serve --port 11435`). El adapter reenvia sin modificar request ni
+response, solo extrae contadores nativos para emitir los headers
+`Sprout-Inference-*`.
+
+## Contadores
+
+Ollama devuelve en la respuesta:
+- `prompt_eval_count` (tokens del prompt)
+- `eval_count` (tokens generados; INCLUYE thinking si think=true)
+- `prompt_eval_duration` y `eval_duration` (en ns)
+
+Nota importante (punto 7): en local, `Sprout-Inference-Thinking-Tokens` se
+emite como `0` porque Ollama no desglosa thinking de generacion en los
+contadores — el campo `message.thinking` llega como texto, no como contador
+separado. Consecuencia: `Sprout-Inference-Tokens-Out` en local equivale a
+`eval_count` tal cual (incluye thinking).
+
+Esto significa que la paridad local vs cloud NO es exacta en el header
+`Tokens-Out` cuando thinking esta activo. El caller debe saberlo via
+`Sprout-Inference-Backend`: en `cloud-gemini` el desglose es real, en
+`local-ollama` `Thinking-Tokens=0` y `Tokens-Out` puede incluir thinking.
+
+El harness #45 documenta esta asimetria al comparar.
+
+## Streaming (punto 8)
+
+Si el caller envia `stream=true`, el adapter lo fuerza a `false` hacia el
+upstream. Ollama devuelve un unico JSON y el adapter lo relay tal cual.
+Streaming real es iteracion posterior solo si #43 lo requiere.
+
+## Errores
+
+Fallos de conexion (Ollama upstream caido) se propagan como `httpx.HTTPError`.
+`main.py` no los captura; FastAPI devuelve 500. Es el comportamiento deseado:
+en local mode un upstream muerto es un bug del dev, no un escenario operativo.
+"""
+
+from __future__ import annotations
+
+import copy
+import time
+from typing import Any
+
+import httpx
+
+from ..headers import InferenceMetrics
+
+
+class LocalBackend:
+    """Reverse-proxy a Ollama real en `:11435` (o lo que diga `upstream_host`)."""
+
+    def __init__(
+        self,
+        upstream_host: str,
+        *,
+        timeout_s: float = 600.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Construye el backend.
+
+        Args:
+            upstream_host: URL base de Ollama real. Ej. `http://localhost:11435`.
+            timeout_s: timeout total de la llamada. 600s por defecto porque
+                generaciones largas con 26B pueden pasar de 2 minutos en CPU.
+            client: `httpx.AsyncClient` inyectable para tests (respx).
+        """
+        self._upstream_host = upstream_host.rstrip("/")
+        self._timeout = httpx.Timeout(timeout_s)
+        self._external_client = client
+
+    def _client(self) -> httpx.AsyncClient:
+        if self._external_client is not None:
+            return self._external_client
+        return httpx.AsyncClient(
+            base_url=self._upstream_host, timeout=self._timeout
+        )
+
+    async def _forward(
+        self, path: str, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        # Forzamos stream=false al upstream: el adapter siempre devuelve un
+        # unico JSON (punto 8). El caller puede mandar stream=true y recibira
+        # el chunk completo en la respuesta sintetica.
+        body = copy.deepcopy(request)
+        body["stream"] = False
+
+        t0 = time.perf_counter_ns()
+        if self._external_client is not None:
+            client = self._external_client
+            owns_client = False
+        else:
+            client = httpx.AsyncClient(
+                base_url=self._upstream_host, timeout=self._timeout
+            )
+            owns_client = True
+        try:
+            response = await client.post(path, json=body)
+            response.raise_for_status()
+            data = response.json()
+        finally:
+            if owns_client:
+                await client.aclose()
+        t1 = time.perf_counter_ns()
+
+        # Contadores nativos de Ollama. Todos opcionales: si el upstream no los
+        # devuelve (ej. error parcial), se asumen 0.
+        tokens_in = int(data.get("prompt_eval_count") or 0)
+        tokens_out = int(data.get("eval_count") or 0)
+        model = str(data.get("model") or request.get("model") or "")
+        duration_ms = max((t1 - t0) // 1_000_000, 1)
+
+        metrics = InferenceMetrics(
+            backend="local-ollama",
+            model=model,
+            tokens_in=tokens_in,
+            # En local no podemos desglosar thinking; Tokens-Out incluye
+            # thinking si think=true. Thinking-Tokens=0 explicito por contrato.
+            tokens_out=tokens_out,
+            thinking_tokens=0,
+            duration_ms=duration_ms,
+            cost_eur=0.0,
+        )
+        return data, metrics
+
+    async def chat(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        return await self._forward("/api/chat", request)
+
+    async def generate(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        return await self._forward("/api/generate", request)

--- a/code/meristem_inference_adapter/src/backends/test.py
+++ b/code/meristem_inference_adapter/src/backends/test.py
@@ -1,0 +1,217 @@
+"""Backend `test` — mock con canned responses (punto 11 de Cambium).
+
+Obligatorio en el primer PR para desacoplar el CI de Gemini y de Ollama real.
+No hace I/O de red. Devuelve respuestas fijas con contadores plausibles y
+duraciones sintetizadas desde `time.perf_counter_ns()`.
+
+## Como funciona
+
+- El backend se inicializa con un dict `{selector: CannedResponse}`. Si no se
+  pasa ninguno, usa `DEFAULT_CANNED` que incluye tres fixtures basicos.
+- El request puede seleccionar un fixture explicitamente via
+  `options["test_fixture"] = "<selector>"`. Si no lo hace, se usa `"default"`.
+- Si el selector pedido no existe, el backend levanta `KeyError` para que la
+  mala configuracion del test sea ruidosa.
+
+## Por que canned en vez de generado
+
+El caller de este backend es el CI y los tests unitarios, no un usuario. La
+gracia es tener respuestas bit-a-bit estables — si el formato cambiara y el
+caller parseara mal, lo queremos detectar sin depender de LLMs no-deterministas.
+
+## Inspeccion desde tests
+
+El backend guarda el ultimo request recibido en `last_chat_request` y
+`last_generate_request` para que los tests puedan hacer assertions sobre que
+se envio (utiles en parity tests y en unit tests de `main.py`).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..headers import InferenceMetrics
+
+
+@dataclass(frozen=True)
+class CannedResponse:
+    """Una respuesta fija para el backend test.
+
+    Se dimensiona como lo que Gemini/Ollama devolverian: content, thinking
+    opcional, y contadores de tokens (in/out/thinking). Los contadores se
+    exponen tal cual en los headers y en el body Ollama-format.
+    """
+
+    model: str
+    content: str
+    thinking: str = ""
+    tokens_in: int = 0
+    tokens_out: int = 0
+    thinking_tokens: int = 0
+
+
+DEFAULT_CANNED: dict[str, CannedResponse] = {
+    "default": CannedResponse(
+        model="gemma-4-26b-a4b",
+        content="ok",
+        thinking="",
+        tokens_in=10,
+        tokens_out=2,
+        thinking_tokens=0,
+    ),
+    "with_thinking": CannedResponse(
+        model="gemma-4-26b-a4b",
+        content="respuesta final",
+        thinking="razonando sobre el problema y llegando a una conclusion",
+        tokens_in=20,
+        tokens_out=5,
+        thinking_tokens=15,
+    ),
+    "empty": CannedResponse(
+        model="gemma-4-26b-a4b",
+        content="",
+        thinking="",
+        tokens_in=0,
+        tokens_out=0,
+        thinking_tokens=0,
+    ),
+}
+
+
+def _pick_selector(request: dict[str, Any]) -> str:
+    options = request.get("options") or {}
+    selector = options.get("test_fixture")
+    return selector if isinstance(selector, str) and selector else "default"
+
+
+def _split_duration_ns(total_ns: int, tokens_in: int, tokens_out: int) -> tuple[int, int]:
+    """Reparte `total_ns` entre prompt_eval y eval proporcional a tokens.
+
+    Sin tokens (tokens_in==tokens_out==0), devuelve mitad-mitad para evitar 0
+    en algun campo (que podria disparar divisions por cero en el caller).
+    """
+    total = tokens_in + tokens_out
+    if total == 0:
+        half = total_ns // 2
+        return half, total_ns - half
+    prompt_ns = (total_ns * tokens_in) // total
+    return prompt_ns, total_ns - prompt_ns
+
+
+class TestBackend:
+    """Mock con respuestas predefinidas por selector.
+
+    Implementa el Protocol `InferenceBackend` (chat + generate) sin I/O de red.
+    Emite headers `Sprout-Inference-*` con `backend="test"` y `cost_eur=0.0`.
+    """
+
+    # El prefijo `Test` en el nombre hace que pytest intente recolectar esta
+    # clase como test class. No es un test class. Renombrarla a `MockBackend`
+    # perderia la simetria con `INFERENCE_BACKEND=test` (Cambium, punto 11).
+    # `__test__ = False` es el opt-out documentado de pytest.
+    __test__ = False
+
+    def __init__(self, canned: dict[str, CannedResponse] | None = None) -> None:
+        self._canned: dict[str, CannedResponse] = (
+            dict(canned) if canned is not None else dict(DEFAULT_CANNED)
+        )
+        if "default" not in self._canned:
+            raise ValueError(
+                "canned debe contener al menos la clave 'default' "
+                "(fallback cuando el request no especifica test_fixture)."
+            )
+        self.last_chat_request: dict[str, Any] | None = None
+        self.last_generate_request: dict[str, Any] | None = None
+
+    def _resolve(self, request: dict[str, Any]) -> CannedResponse:
+        selector = _pick_selector(request)
+        if selector not in self._canned:
+            raise KeyError(
+                f"canned selector {selector!r} no definido. "
+                f"Disponibles: {sorted(self._canned.keys())}"
+            )
+        return self._canned[selector]
+
+    async def chat(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        self.last_chat_request = request
+        t0 = time.perf_counter_ns()
+        canned = self._resolve(request)
+        # El backend test no hace I/O real; el perf_counter aqui solo mide
+        # overhead de dispatch. Eso esta bien: queremos duraciones pequenas
+        # pero no-cero para que el caller pueda calcular tok/s sin dividir
+        # por cero en pruebas.
+        t1 = time.perf_counter_ns()
+        total_ns = max(t1 - t0, 1_000)  # suelo de 1 microsegundo
+        prompt_ns, eval_ns = _split_duration_ns(
+            total_ns, canned.tokens_in, canned.tokens_out + canned.thinking_tokens
+        )
+        model = request.get("model", canned.model)
+        body = {
+            "model": model,
+            "created_at": "1970-01-01T00:00:00Z",  # deterministico
+            "message": {
+                "role": "assistant",
+                "content": canned.content,
+                "thinking": canned.thinking,
+            },
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": canned.tokens_in,
+            # Ojo: eval_count incluye thinking, por contrato Ollama. El desglose
+            # defendible va por headers (ver headers.py docstring, punto 4).
+            "eval_count": canned.tokens_out + canned.thinking_tokens,
+            "prompt_eval_duration": prompt_ns,
+            "eval_duration": eval_ns,
+            "total_duration": total_ns,
+        }
+        metrics = InferenceMetrics(
+            backend="test",
+            model=model,
+            tokens_in=canned.tokens_in,
+            tokens_out=canned.tokens_out,
+            thinking_tokens=canned.thinking_tokens,
+            duration_ms=max(total_ns // 1_000_000, 1),
+            cost_eur=0.0,
+        )
+        return body, metrics
+
+    async def generate(
+        self, request: dict[str, Any]
+    ) -> tuple[dict[str, Any], InferenceMetrics]:
+        self.last_generate_request = request
+        t0 = time.perf_counter_ns()
+        canned = self._resolve(request)
+        t1 = time.perf_counter_ns()
+        total_ns = max(t1 - t0, 1_000)
+        prompt_ns, eval_ns = _split_duration_ns(
+            total_ns, canned.tokens_in, canned.tokens_out + canned.thinking_tokens
+        )
+        model = request.get("model", canned.model)
+        body = {
+            "model": model,
+            "created_at": "1970-01-01T00:00:00Z",
+            # /api/generate usa `response` en vez de `message`.
+            "response": canned.content,
+            "thinking": canned.thinking,
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": canned.tokens_in,
+            "eval_count": canned.tokens_out + canned.thinking_tokens,
+            "prompt_eval_duration": prompt_ns,
+            "eval_duration": eval_ns,
+            "total_duration": total_ns,
+        }
+        metrics = InferenceMetrics(
+            backend="test",
+            model=model,
+            tokens_in=canned.tokens_in,
+            tokens_out=canned.tokens_out,
+            thinking_tokens=canned.thinking_tokens,
+            duration_ms=max(total_ns // 1_000_000, 1),
+            cost_eur=0.0,
+        )
+        return body, metrics

--- a/code/meristem_inference_adapter/src/config.py
+++ b/code/meristem_inference_adapter/src/config.py
@@ -1,0 +1,120 @@
+"""Configuracion del adapter.
+
+Env vars + alias de modelos + pricing placeholders. No depende de FastAPI ni de
+httpx; se puede importar en tests sin levantar el server.
+
+PLACEHOLDER para el thinking budget se resuelve en #44 tras A/B.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Literal
+
+BackendMode = Literal["cloud", "local", "test"]
+
+
+# -----------------------------------------------------------------------------
+# Placeholder — #44 fija el valor empirico tras A/B.
+# No optimizar en base a este numero.
+# -----------------------------------------------------------------------------
+THINKING_BUDGET_TOKENS_PLACEHOLDER = 4096
+
+
+# -----------------------------------------------------------------------------
+# Alias de modelos (punto 9). Overridable por env via MODEL_ALIAS_<tag>=<cloud_id>
+# (formato exacto a confirmar en implementacion).
+# -----------------------------------------------------------------------------
+DEFAULT_MODEL_ALIASES: dict[str, str] = {
+    "gemma4:26b-moe": "gemma-4-26b-a4b",
+    "gemma4:e4b": "gemma-4-e4b-it",
+    "gemma4:31b": "gemma-4-31b-it",
+}
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    max_attempts: int
+    backoff_ms: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class PricingConfig:
+    in_eur_per_1k: float
+    out_eur_per_1k: float
+    thinking_eur_per_1k: float
+
+
+@dataclass(frozen=True)
+class Settings:
+    backend: BackendMode
+    adapter_port: int
+    ollama_upstream_host: str
+    gemini_api_key: str | None
+    gemini_default_model: str
+    thinking_budget: int
+    pricing: PricingConfig
+    retry: RetryConfig
+    model_aliases: dict[str, str] = field(default_factory=dict)
+
+
+def _get_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return int(raw)
+
+
+def _get_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return float(raw)
+
+
+def _get_backend(default: BackendMode = "test") -> BackendMode:
+    raw = (os.environ.get("INFERENCE_BACKEND") or default).strip().lower()
+    if raw not in ("cloud", "local", "test"):
+        raise ValueError(
+            f"INFERENCE_BACKEND invalido: {raw!r}. Valores validos: cloud | local | test"
+        )
+    return raw  # type: ignore[return-value]
+
+
+def load_settings() -> Settings:
+    """Construye Settings desde el entorno actual. Scaffold: stub sin validacion completa."""
+    return Settings(
+        backend=_get_backend(),
+        adapter_port=_get_int("ADAPTER_PORT", 11434),
+        ollama_upstream_host=os.environ.get(
+            "OLLAMA_UPSTREAM_HOST", "http://localhost:11435"
+        ),
+        gemini_api_key=os.environ.get("GEMINI_API_KEY") or None,
+        gemini_default_model=os.environ.get("GEMINI_DEFAULT_MODEL", "gemma-4-26b-a4b"),
+        thinking_budget=_get_int(
+            "MERISTEM_THINKING_BUDGET", THINKING_BUDGET_TOKENS_PLACEHOLDER
+        ),
+        pricing=PricingConfig(
+            in_eur_per_1k=_get_float("GEMINI_PRICE_IN_EUR_PER_1K", 0.0),
+            out_eur_per_1k=_get_float("GEMINI_PRICE_OUT_EUR_PER_1K", 0.0),
+            thinking_eur_per_1k=_get_float("GEMINI_PRICE_THINKING_EUR_PER_1K", 0.0),
+        ),
+        retry=RetryConfig(
+            max_attempts=_get_int("RETRY_MAX_ATTEMPTS", 3),
+            backoff_ms=(
+                _get_int("RETRY_BACKOFF_MS_1", 500),
+                _get_int("RETRY_BACKOFF_MS_2", 2000),
+                _get_int("RETRY_BACKOFF_MS_3", 8000),
+            ),
+        ),
+        model_aliases=dict(DEFAULT_MODEL_ALIASES),
+    )
+
+
+def resolve_model(tag: str, aliases: dict[str, str]) -> str:
+    """Mapea un tag tipo `gemma4:26b-moe` al id del backend cloud.
+
+    Si el tag no esta en el dict, se devuelve tal cual (permite pasar ids nativos).
+    """
+    return aliases.get(tag, tag)

--- a/code/meristem_inference_adapter/src/headers.py
+++ b/code/meristem_inference_adapter/src/headers.py
@@ -1,0 +1,103 @@
+"""Emision uniforme de headers `Sprout-Inference-*` (puntos 4 y 7 de #46).
+
+Caller (`policy_engine`) lee estos headers y persiste sin branchear por backend.
+En modo local/test los campos de coste son `0.0`.
+
+Semantica exacta (punto 7, fijada en el comentario tecnico de #46):
+
+    Sprout-Inference-Backend:         cloud-gemini | local-ollama | test
+    Sprout-Inference-Model:           gemma-4-26b-a4b | gemma-4-e4b-it | ...
+    Sprout-Inference-Tokens-In:       = prompt_token_count
+    Sprout-Inference-Tokens-Out:      = candidates_token_count (SIN thinking)
+    Sprout-Inference-Thinking-Tokens: = thoughts_token_count (0 explicito si off)
+    Sprout-Inference-Duration-Ms:     = wallclock total adapter
+    Sprout-Inference-Cost-EUR:        = 0.0 en local/test
+
+PUNTO 4 — docstring explicito pedido por Cambium:
+El `eval_count` que el adapter devuelve en la respuesta Ollama-format se
+calcula como `candidates_token_count + thoughts_token_count`. Cualquier `tok/s`
+derivado como `eval_count / eval_duration` **incluye tokens de thinking**. El
+numero defendible sale de los headers desglosados: `Tokens-Out / Duration-Ms`.
+Harness (#45) y writeup DEBEN usar los desglosados.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+BackendLabel = Literal["cloud-gemini", "local-ollama", "test"]
+
+HEADER_BACKEND = "Sprout-Inference-Backend"
+HEADER_MODEL = "Sprout-Inference-Model"
+HEADER_TOKENS_IN = "Sprout-Inference-Tokens-In"
+HEADER_TOKENS_OUT = "Sprout-Inference-Tokens-Out"
+HEADER_THINKING_TOKENS = "Sprout-Inference-Thinking-Tokens"
+HEADER_DURATION_MS = "Sprout-Inference-Duration-Ms"
+HEADER_COST_EUR = "Sprout-Inference-Cost-EUR"
+HEADER_ERROR = "Sprout-Inference-Error"
+
+ALL_METRIC_HEADERS = (
+    HEADER_BACKEND,
+    HEADER_MODEL,
+    HEADER_TOKENS_IN,
+    HEADER_TOKENS_OUT,
+    HEADER_THINKING_TOKENS,
+    HEADER_DURATION_MS,
+    HEADER_COST_EUR,
+)
+
+
+@dataclass(frozen=True)
+class InferenceMetrics:
+    """Contadores uniformes que el backend devuelve al adapter.
+
+    Todos los campos son obligatorios, explicitos. `thinking_tokens=0` cuando
+    thinking esta off (no omitir el header). `cost_eur=0.0` en local/test.
+    """
+
+    backend: BackendLabel
+    model: str
+    tokens_in: int
+    tokens_out: int  # SIN thinking
+    thinking_tokens: int  # 0 explicito si thinking off
+    duration_ms: int
+    cost_eur: float  # 0.0 en local/test
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("tokens_in", self.tokens_in),
+            ("tokens_out", self.tokens_out),
+            ("thinking_tokens", self.thinking_tokens),
+            ("duration_ms", self.duration_ms),
+        ):
+            if value < 0:
+                raise ValueError(f"{name} no puede ser negativo: {value}")
+        if self.cost_eur < 0.0:
+            raise ValueError(f"cost_eur no puede ser negativo: {self.cost_eur}")
+
+
+def build_sprout_headers(metrics: InferenceMetrics) -> dict[str, str]:
+    """Construye el dict de headers `Sprout-Inference-*` para la respuesta HTTP.
+
+    Todos los valores son str (requisito de FastAPI `Response.headers`). El
+    caller convierte de vuelta a int/float si necesita.
+
+    Args:
+        metrics: metricas uniformes del backend.
+
+    Returns:
+        Dict con las 7 claves `Sprout-Inference-*`. Nunca omite claves.
+    """
+    return {
+        HEADER_BACKEND: metrics.backend,
+        HEADER_MODEL: metrics.model,
+        HEADER_TOKENS_IN: str(metrics.tokens_in),
+        HEADER_TOKENS_OUT: str(metrics.tokens_out),
+        HEADER_THINKING_TOKENS: str(metrics.thinking_tokens),
+        HEADER_DURATION_MS: str(metrics.duration_ms),
+        # cost_eur con 6 decimales para no perder precision en costes bajos
+        # (una decision Meristem cuesta ~centimos). Formato decimal fijo para
+        # que el parsing del caller sea estable.
+        HEADER_COST_EUR: f"{metrics.cost_eur:.6f}",
+    }

--- a/code/meristem_inference_adapter/src/main.py
+++ b/code/meristem_inference_adapter/src/main.py
@@ -1,0 +1,188 @@
+"""FastAPI app del adapter.
+
+Expone `/api/chat` y `/api/generate` en `:11434` (por defecto) con contrato
+Ollama-nativo. Selecciona backend segun `INFERENCE_BACKEND` y delega.
+
+Manejo de errores (punto 5 de #46): `UpstreamRateLimited` se traduce a 503 con
+el header `Sprout-Inference-Error: upstream_rate_limited`. El caller (harness,
+policy_engine) decide si descartar el punto o esperar.
+
+Streaming (punto 8): `stream=true` se acepta pero el adapter bufferea la
+respuesta completa y devuelve un unico chunk. Streaming real es iteracion
+posterior solo si #43 lo requiere.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+
+from .backends.base import InferenceBackend
+from .config import Settings, load_settings
+from .headers import (
+    HEADER_BACKEND,
+    HEADER_ERROR,
+    HEADER_MODEL,
+    build_sprout_headers,
+)
+from .retry import UpstreamRateLimited
+
+logger = logging.getLogger(__name__)
+
+
+def _build_backend(settings: Settings) -> InferenceBackend:
+    """Selecciona el backend segun `settings.backend`.
+
+    Import local de cada backend para que `INFERENCE_BACKEND=test` no exija
+    `google-genai` ni el upstream de Ollama.
+    """
+    if settings.backend == "cloud":
+        from .backends.cloud import CloudBackend
+
+        if not settings.gemini_api_key:
+            raise RuntimeError(
+                "INFERENCE_BACKEND=cloud pero GEMINI_API_KEY no esta definida."
+            )
+        return CloudBackend(
+            api_key=settings.gemini_api_key,
+            default_model=settings.gemini_default_model,
+            model_aliases=settings.model_aliases,
+            thinking_budget=settings.thinking_budget,
+            retry=settings.retry,
+            pricing=settings.pricing,
+        )
+    if settings.backend == "local":
+        from .backends.local import LocalBackend
+
+        return LocalBackend(upstream_host=settings.ollama_upstream_host)
+    # backend == "test"
+    from .backends.test import TestBackend
+
+    return TestBackend()
+
+
+def _json_dumps(obj: Any) -> str:
+    # Helper separado para que los tests puedan stubbearlo si quisieran validar
+    # que las duraciones se emiten como int, no float.
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def _rate_limit_response(body: dict[str, Any], backend_label: str) -> Response:
+    """Construye la respuesta 503 cuando el upstream agoto los reintentos."""
+    # Preservamos backend/model del request para que el caller pueda correlar
+    # el error con el punto del sweep que lo provoco, pero no emitimos
+    # contadores (no hubo llamada exitosa).
+    model = body.get("model", "")
+    headers = {
+        HEADER_BACKEND: backend_label,
+        HEADER_MODEL: model,
+        HEADER_ERROR: "upstream_rate_limited",
+    }
+    payload = {
+        "error": "upstream_rate_limited",
+        "detail": "Upstream agoto los reintentos tras los backoffs configurados.",
+    }
+    return Response(
+        content=_json_dumps(payload),
+        media_type="application/json",
+        status_code=503,
+        headers=headers,
+    )
+
+
+def _backend_label(settings: Settings) -> str:
+    mapping = {
+        "cloud": "cloud-gemini",
+        "local": "local-ollama",
+        "test": "test",
+    }
+    return mapping[settings.backend]
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Construye la FastAPI app. Factory permite inyectar settings en tests."""
+    settings = settings or load_settings()
+    backend = _build_backend(settings)
+    label = _backend_label(settings)
+
+    app = FastAPI(
+        title="meristem_inference_adapter",
+        version="0.1.0",
+        description=(
+            "Proxy Ollama-compatible. Backend: "
+            f"{settings.backend}. Ver README.md."
+        ),
+    )
+    app.state.settings = settings
+    app.state.backend = backend
+    app.state.backend_label = label
+
+    @app.get("/health")
+    async def health() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "backend": settings.backend,
+            "adapter_port": settings.adapter_port,
+            "version": "0.1.0",
+        }
+
+    @app.post("/api/chat")
+    async def chat(request: Request) -> Response:
+        body = await request.json()
+        # Leemos backend_label en cada request (no en closure) para que los
+        # tests puedan inyectar un backend distinto via state monkey-patch.
+        current_label = request.app.state.backend_label
+        current_backend = request.app.state.backend
+        try:
+            response_body, metrics = await current_backend.chat(body)
+        except UpstreamRateLimited as exc:
+            logger.warning("chat rate-limited: %s", exc)
+            return _rate_limit_response(body, current_label)
+        headers = build_sprout_headers(metrics)
+        return Response(
+            content=_json_dumps(response_body),
+            media_type="application/json",
+            headers=headers,
+        )
+
+    @app.post("/api/generate")
+    async def generate(request: Request) -> Response:
+        body = await request.json()
+        current_label = request.app.state.backend_label
+        current_backend = request.app.state.backend
+        try:
+            response_body, metrics = await current_backend.generate(body)
+        except UpstreamRateLimited as exc:
+            logger.warning("generate rate-limited: %s", exc)
+            return _rate_limit_response(body, current_label)
+        headers = build_sprout_headers(metrics)
+        return Response(
+            content=_json_dumps(response_body),
+            media_type="application/json",
+            headers=headers,
+        )
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    """Entrypoint CLI. `python -m src.main` levanta uvicorn."""
+    import uvicorn
+
+    settings = load_settings()
+    uvicorn.run(
+        "src.main:app",
+        host="0.0.0.0",
+        port=settings.adapter_port,
+        reload=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/code/meristem_inference_adapter/src/reconstruct.py
+++ b/code/meristem_inference_adapter/src/reconstruct.py
@@ -1,0 +1,68 @@
+"""Reconstruccion de `message.thinking` desde la respuesta de Gemini (punto 3 de #46).
+
+Gemini intercala partes con `thought=True` dentro de `content.parts`. Ollama
+expone el thinking en un campo separado `message.thinking`.
+
+Este modulo extrae las partes `thought=True`, las concatena en orden, y
+devuelve ambos strings (content sin thinking, thinking solo).
+
+Sin esto, rompe el patron documentado en
+`2026-04-19_thinking-mode-e4b-latencia_meristem.md` y los smoke tests del dia 5
+fallan.
+
+Nota: la lista `parts` puede venir como:
+- dicts (`{"text": "...", "thought": True}`) — dict sin `thought` → asumimos False.
+- objetos google-genai (atributos `.text` / `.thought`).
+
+El helper soporta ambos para no atar este modulo a `google-genai` (los tests
+unitarios usan dicts).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SplitMessage:
+    """Resultado de dividir una respuesta Gemini en content + thinking."""
+
+    content: str
+    thinking: str
+
+
+def _get(part: Any, key: str, default: Any = None) -> Any:
+    if isinstance(part, dict):
+        return part.get(key, default)
+    return getattr(part, key, default)
+
+
+def split_gemini_parts(parts: list[Any]) -> SplitMessage:
+    """Divide la lista `content.parts` de Gemini en content y thinking.
+
+    Args:
+        parts: lista de `Part` tal como la expone `google-genai`, o lista de
+            dicts con claves `text` (str) y `thought` (bool, opcional).
+
+    Returns:
+        SplitMessage con ambos campos concatenados en orden de aparicion. Si no
+        hay partes thought, `thinking == ""`. Si no hay partes no-thought,
+        `content == ""`.
+    """
+    content_buf: list[str] = []
+    thinking_buf: list[str] = []
+
+    for part in parts:
+        text = _get(part, "text")
+        if not text:
+            # Saltar partes sin texto (ej. function calls, imagenes). No entran
+            # ni en content ni en thinking.
+            continue
+        is_thought = bool(_get(part, "thought", False))
+        (thinking_buf if is_thought else content_buf).append(text)
+
+    return SplitMessage(
+        content="".join(content_buf),
+        thinking="".join(thinking_buf),
+    )

--- a/code/meristem_inference_adapter/src/retry.py
+++ b/code/meristem_inference_adapter/src/retry.py
@@ -1,0 +1,87 @@
+"""Retry con backoff para 429 de Gemini (punto 5 de #46).
+
+Obligatorio desde el primer PR, no iteracion posterior. Default: 3 reintentos
+con backoff `500ms / 2s / 8s`. Si el ultimo intento falla, `UpstreamRateLimited`
+se propaga y el adapter responde 503 al caller con header
+`Sprout-Inference-Error: upstream_rate_limited`.
+
+Sin esto, una rafaga del sweep de #47 o una demo en vivo explota por rate
+limit del plan Gemini.
+
+Nota: excepciones que NO son rate-limit (ej. 400 por request malformado) se
+propagan sin reintento. Solo el predicado `is_rate_limit` decide que cuenta.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+class UpstreamRateLimited(Exception):
+    """Se agotaron los reintentos frente a 429 del upstream."""
+
+    def __init__(self, attempts: int, last_error: BaseException) -> None:
+        super().__init__(
+            f"upstream rate-limited tras {attempts} intento(s); "
+            f"ultima causa: {type(last_error).__name__}: {last_error}"
+        )
+        self.attempts = attempts
+        self.last_error = last_error
+
+
+async def with_retry(
+    op: Callable[[], Awaitable[T]],
+    *,
+    max_attempts: int,
+    backoff_ms: tuple[int, ...],
+    is_rate_limit: Callable[[BaseException], bool],
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> T:
+    """Ejecuta `op` con reintentos frente a errores considerados rate-limit.
+
+    Args:
+        op: coroutine sin argumentos que realiza la llamada upstream.
+        max_attempts: numero total de intentos (incluye el primero). Minimo 1.
+        backoff_ms: duracion de espera ANTES de los reintentos 2, 3, ...
+            Debe tener longitud >= `max_attempts - 1`. Si es mas larga, las
+            posiciones extra se ignoran.
+        is_rate_limit: predicado que decide si una excepcion cuenta como 429.
+            Todo lo demas se propaga sin retry.
+        sleep: inyectable para tests (por defecto `asyncio.sleep`).
+
+    Returns:
+        El resultado de `op` si algun intento tuvo exito.
+
+    Raises:
+        UpstreamRateLimited: si todos los intentos fallaron con rate-limit.
+        BaseException: cualquier excepcion no-rate-limit se propaga sin retry.
+        ValueError: si la configuracion es invalida.
+    """
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts debe ser >= 1, recibido {max_attempts}")
+    if len(backoff_ms) < max_attempts - 1:
+        raise ValueError(
+            f"backoff_ms debe tener al menos {max_attempts - 1} valores "
+            f"para max_attempts={max_attempts}, recibido {len(backoff_ms)}"
+        )
+
+    last_error: BaseException | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await op()
+        except BaseException as exc:  # noqa: BLE001 — predicado decide
+            if not is_rate_limit(exc):
+                raise
+            last_error = exc
+            if attempt >= max_attempts:
+                break
+            # Esperar backoff_ms[attempt-1] antes del siguiente intento.
+            wait_s = backoff_ms[attempt - 1] / 1000.0
+            await sleep(wait_s)
+
+    # Si llegamos aqui, todos los intentos fueron rate-limit.
+    assert last_error is not None  # invariante: entramos en except al menos 1 vez
+    raise UpstreamRateLimited(attempts=max_attempts, last_error=last_error)

--- a/code/meristem_inference_adapter/src/schema_flatten.py
+++ b/code/meristem_inference_adapter/src/schema_flatten.py
@@ -1,0 +1,91 @@
+"""Flattening de JSON Schema para Gemini `response_schema` (punto 1 de #46).
+
+Gemini API rechaza `$ref` y `$defs`. Pydantic v2 los genera por defecto para
+tipos anidados (ej. `PolicyPacket.model_json_schema()` referencia
+`SoilMoistureThresholds`, `WateringWindow`, etc. via `$ref`).
+
+Estrategia:
+1. `jsonref.replace_refs(schema, proxies=False)` → inline de refs como dicts planos.
+2. Serializar/deserializar JSON para desactivar cualquier objeto lazy residual.
+3. Podar `$defs` y `definitions` del nivel raiz.
+4. Verificar recursivamente que no queda ningun `$ref` en el resultado.
+
+Verificado sobre `PolicyPacket.model_json_schema()` (5 definiciones, 6 refs).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+import jsonref
+
+
+class SchemaFlattenError(ValueError):
+    """Error al aplanar un JSON Schema (refs circulares, etc.)."""
+
+
+def flatten_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Devuelve el schema con `$ref`/`$defs` resueltos inline.
+
+    Args:
+        schema: JSON Schema tal cual lo emite pydantic v2.
+
+    Returns:
+        Schema equivalente sin `$ref` ni `$defs`. No muta el input.
+
+    Raises:
+        SchemaFlattenError: si tras aplanar quedan `$ref` (ref no resuelta,
+            probable ciclo).
+    """
+    # Deep-copy defensivo — no mutar el input del caller.
+    src = copy.deepcopy(schema)
+
+    # jsonref.replace_refs con proxies=False devuelve dicts/listas planos donde
+    # fuera posible, pero puede dejar proxies lazy en contextos anidados. El
+    # round-trip json.dumps/loads normaliza a estructuras puras.
+    #
+    # Si el schema contiene un ciclo (A -> B -> A), jsonref lo materializa como
+    # estructura Python auto-referencial y json.dumps lanza
+    # `ValueError: Circular reference detected`. Convertimos a SchemaFlattenError
+    # para dar al caller un error tipado en vez de un ValueError generico.
+    resolved = jsonref.replace_refs(src, proxies=False)
+    try:
+        normalized = json.loads(json.dumps(resolved))
+    except ValueError as exc:
+        raise SchemaFlattenError(
+            f"flatten fallo al normalizar el schema: {exc}. "
+            "Probable ciclo entre definiciones."
+        ) from exc
+
+    # Poda de contenedores de definiciones en el nivel raiz. Draft-07 usa
+    # `definitions`; 2020-12 usa `$defs`. Pydantic v2 emite `$defs`.
+    normalized.pop("$defs", None)
+    normalized.pop("definitions", None)
+
+    remaining = _find_ref_path(normalized)
+    if remaining is not None:
+        raise SchemaFlattenError(
+            f"flatten incompleto: `$ref` residual en path {remaining!r}. "
+            "Probable ciclo o ref externa no resoluble."
+        )
+
+    return normalized
+
+
+def _find_ref_path(node: Any, path: tuple[str, ...] = ()) -> tuple[str, ...] | None:
+    """Busca recursivamente el primer `$ref` residual. Devuelve su path o None."""
+    if isinstance(node, dict):
+        if "$ref" in node:
+            return path + ("$ref",)
+        for key, value in node.items():
+            found = _find_ref_path(value, path + (key,))
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            found = _find_ref_path(item, path + (f"[{i}]",))
+            if found is not None:
+                return found
+    return None

--- a/code/meristem_inference_adapter/src/thinking_map.py
+++ b/code/meristem_inference_adapter/src/thinking_map.py
@@ -1,0 +1,52 @@
+"""Mapeo del parametro `think` entre Ollama y Gemini (punto 2 de #46).
+
+Ollama: `think: true | false`, binario, budget libre.
+Gemini: `thinking_config={include_thoughts: bool, thinking_budget: int}`, explicito.
+
+Reglas acordadas en el comentario tecnico de #46:
+
+- `think=true`  desde caller → `include_thoughts=True`  + `thinking_budget=<budget_when_on>`
+- `think=false` o ausente    → `include_thoughts=False` + `thinking_budget=0`
+  (desactivado explicito, no default del modelo)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GeminiThinkingConfig:
+    include_thoughts: bool
+    thinking_budget: int
+
+
+def map_think_to_gemini(
+    think: bool | None,
+    budget_when_on: int,
+) -> GeminiThinkingConfig:
+    """Traduce el flag `think` de Ollama al `thinking_config` de Gemini.
+
+    Args:
+        think: valor del campo `think` del request Ollama. `None` se trata como
+            `False` (ausencia = desactivado explicito, no default del modelo).
+        budget_when_on: presupuesto de thinking a aplicar cuando `think=True`.
+            Viene de `Settings.thinking_budget` (env `MERISTEM_THINKING_BUDGET`).
+
+    Returns:
+        GeminiThinkingConfig listo para pasar a `google-genai`.
+
+    Raises:
+        ValueError: si `think=True` pero `budget_when_on <= 0`.
+    """
+    if think:
+        if budget_when_on <= 0:
+            raise ValueError(
+                f"think=True pero budget_when_on={budget_when_on}. "
+                "Si se quiere desactivar thinking, pasar think=False."
+            )
+        return GeminiThinkingConfig(
+            include_thoughts=True,
+            thinking_budget=budget_when_on,
+        )
+    return GeminiThinkingConfig(include_thoughts=False, thinking_budget=0)

--- a/code/meristem_inference_adapter/tests/conftest.py
+++ b/code/meristem_inference_adapter/tests/conftest.py
@@ -1,0 +1,75 @@
+"""Config de pytest para meristem_inference_adapter.
+
+Anade la raiz del paquete al sys.path (para `from src... import ...`) y
+`code/shared` (para reusar los schemas canonicos en tests de flatten).
+
+Fixtures compartidos:
+- `adapter_settings()`  → `Settings` con backend=test, valores deterministicos.
+- `adapter_app()`       → `FastAPI` construida sobre esos settings.
+- `adapter_client()`    → `TestClient` sobre la app.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_THIS = Path(__file__).resolve()
+_ADAPTER_ROOT = _THIS.parents[1]
+_CODE_ROOT = _ADAPTER_ROOT.parent
+_SHARED = _CODE_ROOT / "shared"
+
+for path in (_ADAPTER_ROOT, _SHARED):
+    path_str = str(path)
+    if path.exists() and path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+# Imports que dependen de sys.path se hacen dentro de las fixtures para que
+# `collect` no falle si uno de los modulos aun no existe durante el scaffold.
+
+
+def _make_settings():
+    from src.config import (
+        DEFAULT_MODEL_ALIASES,
+        PricingConfig,
+        RetryConfig,
+        Settings,
+    )
+
+    return Settings(
+        backend="test",
+        adapter_port=11434,
+        ollama_upstream_host="http://localhost:11435",
+        gemini_api_key=None,
+        gemini_default_model="gemma-4-26b-a4b",
+        thinking_budget=4096,
+        pricing=PricingConfig(
+            in_eur_per_1k=0.0,
+            out_eur_per_1k=0.0,
+            thinking_eur_per_1k=0.0,
+        ),
+        retry=RetryConfig(max_attempts=3, backoff_ms=(500, 2000, 8000)),
+        model_aliases=dict(DEFAULT_MODEL_ALIASES),
+    )
+
+
+@pytest.fixture
+def adapter_settings():
+    return _make_settings()
+
+
+@pytest.fixture
+def adapter_app(adapter_settings):
+    from src.main import create_app
+
+    return create_app(adapter_settings)
+
+
+@pytest.fixture
+def adapter_client(adapter_app):
+    from fastapi.testclient import TestClient
+
+    with TestClient(adapter_app) as client:
+        yield client

--- a/code/meristem_inference_adapter/tests/test_backend_cloud.py
+++ b/code/meristem_inference_adapter/tests/test_backend_cloud.py
@@ -1,0 +1,510 @@
+"""Tests del backend `cloud` (Gemini API).
+
+Usamos un `client_factory` inyectado que devuelve un cliente fake con la misma
+shape que `genai.Client`: un atributo `.aio.models.generate_content` async.
+Los tipos `types.Content`, `types.Part`, `types.GenerateContentConfig` SI son
+los reales (no queremos divergencia con la API de produccion).
+
+Cubre, en orden de riesgo tecnico del comentario de #46:
+
+- Punto 1: si request trae `format={schema}`, se pasa por flatten antes de ir
+  a Gemini como `response_schema`. El config capturado no contiene `$ref`.
+- Punto 2: `think=true` pone `thinking_config.include_thoughts=True` y
+  `thinking_budget=<budget>`; `think=false` pone `include_thoughts=False` y
+  `thinking_budget=0`.
+- Punto 3: partes `thought=True` se separan en `message.thinking`;
+  `message.content` solo lleva lo no-thought.
+- Punto 4: `eval_count == candidates_token_count + thoughts_token_count`.
+  Headers desglosan.
+- Punto 5: 2x 429 + exito al 3er intento → respuesta normal. 3x 429 →
+  UpstreamRateLimited.
+- Punto 9: `gemma4:26b-moe` del caller se resuelve a `gemma-4-26b-a4b` en la
+  llamada a Gemini, pero el body devuelto conserva el tag original.
+- system role del caller se extrae a `system_instruction` y NO va en contents.
+- `options.num_ctx` se ignora (no propagable a Gemini).
+- Cost calculado desde pricing.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from google.genai import errors as genai_errors
+
+from src.backends.cloud import CloudBackend
+from src.config import PricingConfig, RetryConfig
+from src.retry import UpstreamRateLimited
+
+
+# ---------------------------------------------------------------------------
+# Helpers: fake client y respuesta
+# ---------------------------------------------------------------------------
+
+
+def _fake_response(
+    *,
+    parts_specs: list[tuple[str, bool]],  # [(text, is_thought), ...]
+    prompt_tokens: int = 10,
+    candidates_tokens: int = 5,
+    thoughts_tokens: int = 0,
+) -> SimpleNamespace:
+    parts = [SimpleNamespace(text=t, thought=th) for t, th in parts_specs]
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=parts))],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=prompt_tokens,
+            candidates_token_count=candidates_tokens,
+            thoughts_token_count=thoughts_tokens,
+        ),
+    )
+
+
+class _FakeGenaiClient:
+    """Minima shape de `genai.Client` para tests.
+
+    Registra los argumentos de cada llamada en `self.calls` y deja que el test
+    defina la respuesta (o excepcion) con `set_response` / `set_error_sequence`.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._response: Any = None
+        self._error_sequence: list[BaseException] = []
+        self._final_response_after_errors: Any = None
+        self.aio = SimpleNamespace(
+            models=SimpleNamespace(generate_content=self._generate_content)
+        )
+
+    def set_response(self, response: Any) -> None:
+        self._response = response
+
+    def set_error_sequence(
+        self, errors: list[BaseException], final_response: Any
+    ) -> None:
+        self._error_sequence = list(errors)
+        self._final_response_after_errors = final_response
+
+    async def _generate_content(
+        self, *, model: str, contents: Any, config: Any
+    ) -> Any:
+        self.calls.append({"model": model, "contents": contents, "config": config})
+        if self._error_sequence:
+            exc = self._error_sequence.pop(0)
+            raise exc
+        if self._final_response_after_errors is not None:
+            resp = self._final_response_after_errors
+            self._final_response_after_errors = None
+            return resp
+        if self._response is None:
+            raise AssertionError("test no fijo response")
+        return self._response
+
+
+def _make_backend(
+    *,
+    client: _FakeGenaiClient,
+    pricing: PricingConfig | None = None,
+    retry: RetryConfig | None = None,
+    thinking_budget: int = 4096,
+    aliases: dict[str, str] | None = None,
+) -> CloudBackend:
+    return CloudBackend(
+        api_key="fake-key",
+        default_model="gemma-4-26b-a4b",
+        model_aliases=aliases or {"gemma4:26b-moe": "gemma-4-26b-a4b"},
+        thinking_budget=thinking_budget,
+        retry=retry or RetryConfig(max_attempts=3, backoff_ms=(1, 1, 1)),
+        pricing=pricing or PricingConfig(0.0, 0.0, 0.0),
+        client_factory=lambda api_key: client,
+    )
+
+
+def _make_429() -> genai_errors.APIError:
+    # Construye un APIError con code=429 sin tocar response/details reales.
+    exc = genai_errors.APIError.__new__(genai_errors.APIError)
+    exc.code = 429
+    exc.status = "RESOURCE_EXHAUSTED"
+    exc.message = "rate limited"
+    exc.details = {}
+    exc.response = None
+    BaseException.__init__(exc, "429 RESOURCE_EXHAUSTED")
+    return exc
+
+
+# ---------------------------------------------------------------------------
+# Chat basico + headers + alias
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_basico_devuelve_body_ollama_y_metrics():
+    client = _FakeGenaiClient()
+    client.set_response(
+        _fake_response(
+            parts_specs=[("hola desde Gemini", False)],
+            prompt_tokens=42,
+            candidates_tokens=17,
+            thoughts_tokens=0,
+        )
+    )
+    backend = _make_backend(client=client)
+    body, metrics = await backend.chat(
+        {
+            "model": "gemma4:26b-moe",
+            "messages": [{"role": "user", "content": "hola"}],
+        }
+    )
+    # Body shape
+    assert body["message"]["role"] == "assistant"
+    assert body["message"]["content"] == "hola desde Gemini"
+    assert body["message"]["thinking"] == ""
+    assert body["done"] is True
+    assert body["prompt_eval_count"] == 42
+    assert body["eval_count"] == 17  # sin thinking → == candidates
+    assert body["model"] == "gemma4:26b-moe"  # tag original preservado
+    # Metrics
+    assert metrics.backend == "cloud-gemini"
+    assert metrics.model == "gemma4:26b-moe"
+    assert metrics.tokens_in == 42
+    assert metrics.tokens_out == 17
+    assert metrics.thinking_tokens == 0
+    assert metrics.duration_ms >= 1
+
+
+async def test_alias_gemma4_26b_moe_se_resuelve_al_id_gemini():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat({"model": "gemma4:26b-moe", "messages": []})
+    assert len(client.calls) == 1
+    # El id que llega a Gemini es el resuelto, no el alias Ollama.
+    assert client.calls[0]["model"] == "gemma-4-26b-a4b"
+
+
+async def test_tag_sin_alias_se_pasa_tal_cual():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat({"model": "gemma-4-e4b-it", "messages": []})
+    assert client.calls[0]["model"] == "gemma-4-e4b-it"
+
+
+async def test_sin_model_usa_default():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    body, metrics = await backend.chat({"messages": []})
+    assert body["model"] == "gemma-4-26b-a4b"
+    assert metrics.model == "gemma-4-26b-a4b"
+
+
+# ---------------------------------------------------------------------------
+# Punto 3: thinking parts → message.thinking
+# ---------------------------------------------------------------------------
+
+
+async def test_thinking_parts_se_separan_en_message_thinking():
+    client = _FakeGenaiClient()
+    client.set_response(
+        _fake_response(
+            parts_specs=[
+                ("razonamiento interno. ", True),
+                ("respuesta visible ", False),
+                ("mas razonamiento. ", True),
+                ("final.", False),
+            ],
+            prompt_tokens=100,
+            candidates_tokens=20,
+            thoughts_tokens=50,
+        )
+    )
+    backend = _make_backend(client=client)
+    body, metrics = await backend.chat(
+        {"model": "gemma4:26b-moe", "messages": [], "think": True}
+    )
+    assert body["message"]["content"] == "respuesta visible final."
+    assert body["message"]["thinking"] == "razonamiento interno. mas razonamiento. "
+    # Punto 4: eval_count = candidates + thoughts = 20 + 50 = 70
+    assert body["eval_count"] == 70
+    # Headers desglosan
+    assert metrics.tokens_out == 20
+    assert metrics.thinking_tokens == 50
+
+
+# ---------------------------------------------------------------------------
+# Punto 2: thinking map
+# ---------------------------------------------------------------------------
+
+
+async def test_think_true_configura_thinking_include_thoughts_y_budget():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client, thinking_budget=4096)
+    await backend.chat(
+        {"model": "gemma4:26b-moe", "messages": [], "think": True}
+    )
+    cfg = client.calls[0]["config"]
+    assert cfg.thinking_config.include_thoughts is True
+    assert cfg.thinking_config.thinking_budget == 4096
+
+
+async def test_think_false_desactiva_con_budget_cero():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat(
+        {"model": "gemma4:26b-moe", "messages": [], "think": False}
+    )
+    cfg = client.calls[0]["config"]
+    assert cfg.thinking_config.include_thoughts is False
+    assert cfg.thinking_config.thinking_budget == 0
+
+
+async def test_think_ausente_tratado_como_false():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat({"model": "gemma4:26b-moe", "messages": []})
+    cfg = client.calls[0]["config"]
+    assert cfg.thinking_config.include_thoughts is False
+    assert cfg.thinking_config.thinking_budget == 0
+
+
+# ---------------------------------------------------------------------------
+# Punto 1: flatten de schema
+# ---------------------------------------------------------------------------
+
+
+async def test_format_schema_se_aplana_antes_de_enviar_a_gemini():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[('{"a": 1}', False)]))
+    backend = _make_backend(client=client)
+
+    schema_con_refs = {
+        "$defs": {"Foo": {"type": "string"}},
+        "type": "object",
+        "properties": {"foo": {"$ref": "#/$defs/Foo"}},
+    }
+    await backend.chat(
+        {"model": "gemma4:26b-moe", "messages": [], "format": schema_con_refs}
+    )
+    cfg = client.calls[0]["config"]
+    # response_mime_type fijado
+    assert cfg.response_mime_type == "application/json"
+    # response_schema aplanado: no hay $ref ni $defs
+    flat = cfg.response_schema
+    import json as _json
+
+    serialized = _json.dumps(flat)
+    assert "$ref" not in serialized
+    assert "$defs" not in serialized
+    # Y `foo` expandido in-place.
+    assert flat["properties"]["foo"] == {"type": "string"}
+
+
+async def test_format_json_string_sin_schema():
+    # Ollama permite `format: "json"` sin schema; mapeamos solo el mime-type.
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("{}", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat(
+        {"model": "gemma4:26b-moe", "messages": [], "format": "json"}
+    )
+    cfg = client.calls[0]["config"]
+    assert cfg.response_mime_type == "application/json"
+    assert cfg.response_schema is None  # no schema explicito
+
+
+# ---------------------------------------------------------------------------
+# options: temperature, num_predict, num_ctx
+# ---------------------------------------------------------------------------
+
+
+async def test_options_temperature_y_num_predict_se_propagan():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat(
+        {
+            "model": "gemma4:26b-moe",
+            "messages": [],
+            "options": {"temperature": 0.3, "num_predict": 256},
+        }
+    )
+    cfg = client.calls[0]["config"]
+    assert cfg.temperature == 0.3
+    assert cfg.max_output_tokens == 256
+
+
+async def test_options_num_ctx_se_ignora_en_cloud(caplog):
+    # Gemini no tiene equivalente directo. Verificamos que NO se propaga y que
+    # se loguea un info para trazabilidad.
+    import logging
+
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    with caplog.at_level(logging.INFO, logger="src.backends.cloud"):
+        await backend.chat(
+            {
+                "model": "gemma4:26b-moe",
+                "messages": [],
+                "options": {"num_ctx": 65536},
+            }
+        )
+    # Config no lleva atributo derivado de num_ctx.
+    cfg = client.calls[0]["config"]
+    assert not hasattr(cfg, "num_ctx")
+    # Log registrado.
+    assert any("num_ctx" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# system role → system_instruction (no va en contents)
+# ---------------------------------------------------------------------------
+
+
+async def test_role_system_se_extrae_a_system_instruction():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat(
+        {
+            "model": "gemma4:26b-moe",
+            "messages": [
+                {"role": "system", "content": "Se breve y preciso."},
+                {"role": "user", "content": "hola"},
+            ],
+        }
+    )
+    call = client.calls[0]
+    cfg = call["config"]
+    assert cfg.system_instruction == "Se breve y preciso."
+    # contents solo lleva el mensaje user (1 item).
+    assert len(call["contents"]) == 1
+    assert call["contents"][0].role == "user"
+
+
+async def test_role_assistant_se_mapea_a_model():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("x", False)]))
+    backend = _make_backend(client=client)
+    await backend.chat(
+        {
+            "model": "gemma4:26b-moe",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "follow up"},
+            ],
+        }
+    )
+    contents = client.calls[0]["contents"]
+    assert [c.role for c in contents] == ["user", "model", "user"]
+
+
+# ---------------------------------------------------------------------------
+# Punto 5: retry 429
+# ---------------------------------------------------------------------------
+
+
+async def test_dos_429_luego_exito_devuelve_respuesta_normal():
+    client = _FakeGenaiClient()
+    client.set_error_sequence(
+        errors=[_make_429(), _make_429()],
+        final_response=_fake_response(
+            parts_specs=[("recuperado", False)],
+            prompt_tokens=3,
+            candidates_tokens=1,
+        ),
+    )
+    backend = _make_backend(
+        client=client,
+        retry=RetryConfig(max_attempts=3, backoff_ms=(1, 1, 1)),
+    )
+    body, metrics = await backend.chat(
+        {"model": "gemma4:26b-moe", "messages": []}
+    )
+    assert body["message"]["content"] == "recuperado"
+    # 3 llamadas al upstream: 2 que fallaron + 1 que tuvo exito.
+    assert len(client.calls) == 3
+
+
+async def test_tres_429_levanta_upstream_rate_limited():
+    client = _FakeGenaiClient()
+    client.set_error_sequence(
+        errors=[_make_429(), _make_429(), _make_429()],
+        final_response=None,
+    )
+    backend = _make_backend(
+        client=client,
+        retry=RetryConfig(max_attempts=3, backoff_ms=(1, 1, 1)),
+    )
+    with pytest.raises(UpstreamRateLimited) as ei:
+        await backend.chat({"model": "gemma4:26b-moe", "messages": []})
+    assert ei.value.attempts == 3
+    assert len(client.calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# Cost
+# ---------------------------------------------------------------------------
+
+
+async def test_cost_calculado_desde_pricing():
+    client = _FakeGenaiClient()
+    client.set_response(
+        _fake_response(
+            parts_specs=[("x", False)],
+            prompt_tokens=1000,
+            candidates_tokens=500,
+            thoughts_tokens=200,
+        )
+    )
+    pricing = PricingConfig(
+        in_eur_per_1k=0.10,  # 0.10 EUR/1K in
+        out_eur_per_1k=0.40,  # 0.40 EUR/1K out
+        thinking_eur_per_1k=0.20,  # 0.20 EUR/1K thinking
+    )
+    backend = _make_backend(client=client, pricing=pricing)
+    _, metrics = await backend.chat({"model": "gemma4:26b-moe", "messages": []})
+    # 1000/1000 * 0.10 + 500/1000 * 0.40 + 200/1000 * 0.20
+    # = 0.10 + 0.20 + 0.04 = 0.34
+    assert metrics.cost_eur == pytest.approx(0.34)
+
+
+# ---------------------------------------------------------------------------
+# /api/generate
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_usa_response_y_unico_mensaje_user():
+    client = _FakeGenaiClient()
+    client.set_response(_fake_response(parts_specs=[("salida", False)]))
+    backend = _make_backend(client=client)
+    body, _ = await backend.generate(
+        {"model": "gemma4:e4b", "prompt": "hola", "system": "Se conciso."}
+    )
+    # Shape
+    assert "response" in body
+    assert "message" not in body
+    assert body["response"] == "salida"
+    # Contents: 1 mensaje user; system_instruction aparte.
+    call = client.calls[0]
+    assert len(call["contents"]) == 1
+    assert call["contents"][0].role == "user"
+    assert call["config"].system_instruction == "Se conciso."
+
+
+# ---------------------------------------------------------------------------
+# Robustez: respuesta sin candidates
+# ---------------------------------------------------------------------------
+
+
+async def test_respuesta_sin_candidates_levanta_runtime_error():
+    client = _FakeGenaiClient()
+    client.set_response(SimpleNamespace(candidates=[], usage_metadata=None))
+    backend = _make_backend(client=client)
+    with pytest.raises(RuntimeError, match="sin candidates"):
+        await backend.chat({"model": "gemma4:26b-moe", "messages": []})

--- a/code/meristem_inference_adapter/tests/test_backend_local.py
+++ b/code/meristem_inference_adapter/tests/test_backend_local.py
@@ -1,0 +1,224 @@
+"""Tests del backend `local` — reverse-proxy a Ollama en :11435 (punto 6).
+
+Usamos respx para interceptar httpx a nivel de transport; no se necesita un
+Ollama real en CI.
+
+Cubre:
+- POST /api/chat y /api/generate se forwardean al upstream con body preservado.
+- `stream=true` en el request se fuerza a `false` al upstream (punto 8).
+- Contadores nativos de Ollama (`prompt_eval_count`, `eval_count`) se mapean
+  a `Tokens-In` / `Tokens-Out`.
+- `Thinking-Tokens` siempre `0` en local (nota del punto 7: Ollama no desglosa).
+- `Cost-EUR` siempre `0.0`.
+- Backend label = `local-ollama`.
+- Model del response se usa; fallback al del request si Ollama no lo devuelve.
+- httpx error 5xx del upstream se propaga (FastAPI devolvera 500).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from src.backends.local import LocalBackend
+
+
+UPSTREAM = "http://localhost:11435"
+
+
+def _ollama_chat_response(
+    *,
+    model: str = "gemma4:e4b",
+    content: str = "ok",
+    thinking: str | None = None,
+    prompt_eval_count: int = 10,
+    eval_count: int = 5,
+) -> dict:
+    message: dict = {"role": "assistant", "content": content}
+    if thinking is not None:
+        message["thinking"] = thinking
+    return {
+        "model": model,
+        "created_at": "2026-04-21T12:00:00Z",
+        "message": message,
+        "done": True,
+        "done_reason": "stop",
+        "total_duration": 123_456_789,
+        "load_duration": 1_234,
+        "prompt_eval_count": prompt_eval_count,
+        "prompt_eval_duration": 10_000_000,
+        "eval_count": eval_count,
+        "eval_duration": 100_000_000,
+    }
+
+
+def _ollama_generate_response(**kwargs) -> dict:
+    data = _ollama_chat_response(**kwargs)
+    # /api/generate tiene `response` en vez de `message`
+    message = data.pop("message")
+    data["response"] = message["content"]
+    if "thinking" in message:
+        data["thinking"] = message["thinking"]
+    return data
+
+
+@respx.mock
+async def test_chat_forwardea_y_extrae_contadores():
+    route = respx.post(f"{UPSTREAM}/api/chat").mock(
+        return_value=httpx.Response(200, json=_ollama_chat_response(
+            prompt_eval_count=42, eval_count=17
+        ))
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    body, metrics = await backend.chat(
+        {"model": "gemma4:e4b", "messages": [{"role": "user", "content": "hi"}]}
+    )
+    assert route.called
+    # Body se relaya tal cual.
+    assert body["message"]["content"] == "ok"
+    assert body["done"] is True
+    assert body["eval_count"] == 17
+    # Metrics mapean Ollama → headers.
+    assert metrics.backend == "local-ollama"
+    assert metrics.tokens_in == 42
+    assert metrics.tokens_out == 17  # incluye thinking si hubiera
+    assert metrics.thinking_tokens == 0  # siempre 0 en local
+    assert metrics.cost_eur == 0.0
+    assert metrics.duration_ms >= 1
+    assert metrics.model == "gemma4:e4b"
+
+
+@respx.mock
+async def test_generate_forwardea():
+    route = respx.post(f"{UPSTREAM}/api/generate").mock(
+        return_value=httpx.Response(200, json=_ollama_generate_response(
+            content="salida", prompt_eval_count=5, eval_count=3
+        ))
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    body, metrics = await backend.generate(
+        {"model": "gemma4:e4b", "prompt": "hola"}
+    )
+    assert route.called
+    assert body["response"] == "salida"
+    assert metrics.tokens_in == 5
+    assert metrics.tokens_out == 3
+
+
+@respx.mock
+async def test_stream_true_se_fuerza_a_false_al_upstream():
+    # Capturamos el body enviado al upstream y verificamos stream=False.
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        import json as _json
+
+        captured["body"] = _json.loads(request.content)
+        return httpx.Response(200, json=_ollama_chat_response())
+
+    respx.post(f"{UPSTREAM}/api/chat").mock(side_effect=_handler)
+
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    await backend.chat(
+        {"model": "gemma4:e4b", "messages": [], "stream": True}
+    )
+
+    assert captured["body"]["stream"] is False, (
+        "adapter debe forzar stream=false al upstream (punto 8)"
+    )
+    # Campos no-stream se preservan.
+    assert captured["body"]["model"] == "gemma4:e4b"
+
+
+@respx.mock
+async def test_request_original_no_se_muta():
+    respx.post(f"{UPSTREAM}/api/chat").mock(
+        return_value=httpx.Response(200, json=_ollama_chat_response())
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    original = {"model": "gemma4:e4b", "messages": [], "stream": True}
+    snapshot = dict(original)
+    await backend.chat(original)
+    # El caller debe seguir viendo su request tal cual; solo el body enviado
+    # al upstream fue modificado.
+    assert original == snapshot
+
+
+@respx.mock
+async def test_thinking_tokens_siempre_cero_en_local():
+    # Aunque la respuesta traiga message.thinking con texto, Thinking-Tokens=0.
+    respx.post(f"{UPSTREAM}/api/chat").mock(
+        return_value=httpx.Response(
+            200,
+            json=_ollama_chat_response(
+                content="respuesta",
+                thinking="razonando intensamente",
+                prompt_eval_count=10,
+                eval_count=50,  # incluye thinking segun contrato Ollama
+            ),
+        )
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    body, metrics = await backend.chat(
+        {"model": "gemma4:e4b", "messages": [], "think": True}
+    )
+    assert body["message"]["thinking"] == "razonando intensamente"
+    # El texto se preserva en el body, pero el header es 0 porque Ollama no
+    # desglosa. Eso es el compromiso documentado.
+    assert metrics.thinking_tokens == 0
+    assert metrics.tokens_out == 50  # incluye thinking; documentado
+
+
+@respx.mock
+async def test_model_del_response_se_usa_si_presente():
+    respx.post(f"{UPSTREAM}/api/chat").mock(
+        return_value=httpx.Response(
+            200, json=_ollama_chat_response(model="gemma4:e4b")
+        )
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    _, metrics = await backend.chat({"model": "alias-que-ollama-normaliza"})
+    assert metrics.model == "gemma4:e4b"
+
+
+@respx.mock
+async def test_model_fallback_al_request_si_response_no_lo_trae():
+    data = _ollama_chat_response()
+    del data["model"]
+    respx.post(f"{UPSTREAM}/api/chat").mock(
+        return_value=httpx.Response(200, json=data)
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    _, metrics = await backend.chat({"model": "gemma4:26b-moe"})
+    assert metrics.model == "gemma4:26b-moe"
+
+
+@respx.mock
+async def test_upstream_5xx_se_propaga():
+    respx.post(f"{UPSTREAM}/api/chat").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    with pytest.raises(httpx.HTTPStatusError):
+        await backend.chat({"model": "x", "messages": []})
+
+
+@respx.mock
+async def test_contadores_ausentes_caen_a_cero():
+    # Si por algun motivo el upstream omite los contadores (caso degenerado),
+    # no queremos crashear — caemos a 0 y el header emite "0" explicito.
+    respx.post(f"{UPSTREAM}/api/chat").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "x",
+                "message": {"role": "assistant", "content": "hola"},
+                "done": True,
+            },
+        )
+    )
+    backend = LocalBackend(upstream_host=UPSTREAM)
+    _, metrics = await backend.chat({"model": "x", "messages": []})
+    assert metrics.tokens_in == 0
+    assert metrics.tokens_out == 0

--- a/code/meristem_inference_adapter/tests/test_backend_test.py
+++ b/code/meristem_inference_adapter/tests/test_backend_test.py
@@ -1,0 +1,151 @@
+"""Tests del backend `test` (punto 11 de Cambium).
+
+Verifica:
+- Implementa el Protocol InferenceBackend (runtime check).
+- chat() y generate() devuelven respuesta Ollama-shaped + InferenceMetrics.
+- Selector `options.test_fixture` pica el canned correcto; default si no se pasa.
+- Selector desconocido levanta KeyError (ruidoso, no silente).
+- El modelo del request sobreescribe el del canned (pasa tal cual).
+- eval_count incluye thinking (contrato Ollama); headers los separan.
+- last_chat_request / last_generate_request se guardan para inspeccion.
+- Canned custom sin 'default' rechazado en init.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.backends.base import InferenceBackend
+from src.backends.test import (
+    DEFAULT_CANNED,
+    CannedResponse,
+    TestBackend,
+)
+
+
+def test_implementa_protocol():
+    backend = TestBackend()
+    assert isinstance(backend, InferenceBackend)
+
+
+async def test_chat_shape_ollama_default():
+    backend = TestBackend()
+    body, metrics = await backend.chat({"model": "gemma4:26b-moe", "messages": []})
+    # Shape /api/chat
+    assert body["done"] is True
+    assert body["message"]["role"] == "assistant"
+    assert body["message"]["content"] == "ok"
+    assert body["message"]["thinking"] == ""
+    # Contadores
+    assert body["prompt_eval_count"] == 10
+    assert body["eval_count"] == 2  # tokens_out + thinking_tokens = 2 + 0
+    assert body["prompt_eval_duration"] > 0
+    assert body["eval_duration"] > 0
+    # Model se propaga desde el request, no del canned
+    assert body["model"] == "gemma4:26b-moe"
+
+
+async def test_generate_shape_ollama_default():
+    backend = TestBackend()
+    body, metrics = await backend.generate(
+        {"model": "gemma4:e4b", "prompt": "hola"}
+    )
+    # Shape /api/generate (response en vez de message)
+    assert "response" in body
+    assert body["response"] == "ok"
+    assert "message" not in body  # sanity: no mezcla shapes
+    assert body["thinking"] == ""
+    assert body["model"] == "gemma4:e4b"
+
+
+async def test_chat_with_thinking_fixture():
+    backend = TestBackend()
+    body, metrics = await backend.chat(
+        {
+            "model": "gemma-4-26b-a4b",
+            "messages": [],
+            "options": {"test_fixture": "with_thinking"},
+        }
+    )
+    assert body["message"]["content"] == "respuesta final"
+    assert body["message"]["thinking"].startswith("razonando")
+    # eval_count = tokens_out (5) + thinking_tokens (15) = 20
+    assert body["eval_count"] == 20
+    # Headers separan: tokens_out=5, thinking_tokens=15, tokens_in=20
+    assert metrics.tokens_out == 5
+    assert metrics.thinking_tokens == 15
+    assert metrics.tokens_in == 20
+
+
+async def test_selector_desconocido_levanta_keyerror():
+    backend = TestBackend()
+    with pytest.raises(KeyError, match="no_existe"):
+        await backend.chat(
+            {"model": "foo", "options": {"test_fixture": "no_existe"}}
+        )
+
+
+async def test_canned_custom_sin_default_rechazado():
+    with pytest.raises(ValueError, match="default"):
+        TestBackend(
+            canned={"custom": CannedResponse(model="x", content="y")}
+        )
+
+
+async def test_canned_custom_acepta_si_tiene_default():
+    custom = {
+        "default": CannedResponse(model="x", content="y", tokens_in=1, tokens_out=1),
+        "my_fixture": CannedResponse(
+            model="x", content="custom!", tokens_in=3, tokens_out=4
+        ),
+    }
+    backend = TestBackend(canned=custom)
+    body, _ = await backend.chat(
+        {"model": "x", "options": {"test_fixture": "my_fixture"}}
+    )
+    assert body["message"]["content"] == "custom!"
+    assert body["eval_count"] == 4
+
+
+async def test_metrics_backend_es_test_y_cost_cero():
+    backend = TestBackend()
+    _, metrics = await backend.chat({"model": "foo"})
+    assert metrics.backend == "test"
+    assert metrics.cost_eur == 0.0
+    assert metrics.duration_ms >= 1  # suelo
+
+
+async def test_last_request_se_guarda():
+    backend = TestBackend()
+    req = {"model": "foo", "messages": [{"role": "user", "content": "hi"}]}
+    await backend.chat(req)
+    assert backend.last_chat_request is req
+    # generate aun no invocado
+    assert backend.last_generate_request is None
+
+    gen_req = {"model": "bar", "prompt": "g"}
+    await backend.generate(gen_req)
+    assert backend.last_generate_request is gen_req
+
+
+async def test_eval_count_incluye_thinking_contrato_ollama():
+    # Punto 4: eval_count = tokens_out + thinking_tokens. Los headers los separan.
+    backend = TestBackend()
+    body, metrics = await backend.chat(
+        {"model": "m", "options": {"test_fixture": "with_thinking"}}
+    )
+    assert body["eval_count"] == metrics.tokens_out + metrics.thinking_tokens
+
+
+async def test_empty_fixture_no_divide_por_cero():
+    # tokens_in=0 y tokens_out=0: el splitter no debe dividir por cero.
+    backend = TestBackend()
+    body, metrics = await backend.chat(
+        {"model": "m", "options": {"test_fixture": "empty"}}
+    )
+    assert body["prompt_eval_duration"] >= 0
+    assert body["eval_duration"] >= 0
+    assert (
+        body["prompt_eval_duration"] + body["eval_duration"]
+        == body["total_duration"]
+    )

--- a/code/meristem_inference_adapter/tests/test_headers.py
+++ b/code/meristem_inference_adapter/tests/test_headers.py
@@ -1,0 +1,85 @@
+"""Tests de `headers.build_sprout_headers` — puntos 4 y 7 de #46.
+
+Verifica:
+- 7 claves emitidas siempre (nunca se omite una).
+- `thinking_tokens=0` se serializa como `"0"` explicito.
+- `cost_eur=0.0` formateado con 6 decimales consistentes.
+- Valores negativos rechazados (invariante del dataclass).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.headers import (
+    ALL_METRIC_HEADERS,
+    HEADER_COST_EUR,
+    HEADER_THINKING_TOKENS,
+    HEADER_TOKENS_OUT,
+    InferenceMetrics,
+    build_sprout_headers,
+)
+
+
+def _make(**overrides) -> InferenceMetrics:
+    defaults = dict(
+        backend="cloud-gemini",
+        model="gemma-4-26b-a4b",
+        tokens_in=100,
+        tokens_out=50,
+        thinking_tokens=20,
+        duration_ms=1234,
+        cost_eur=0.001234,
+    )
+    defaults.update(overrides)
+    return InferenceMetrics(**defaults)
+
+
+def test_emite_las_siete_claves_siempre():
+    metrics = _make()
+    headers = build_sprout_headers(metrics)
+    for key in ALL_METRIC_HEADERS:
+        assert key in headers, f"header {key} ausente"
+    assert len(headers) == len(ALL_METRIC_HEADERS)
+
+
+def test_todos_los_valores_son_str():
+    headers = build_sprout_headers(_make())
+    for k, v in headers.items():
+        assert isinstance(v, str), f"{k} no es str: {type(v).__name__}"
+
+
+def test_thinking_off_emite_cero_explicito():
+    # Punto 7: "Emitir 0 explicitamente cuando thinking esta off (no omitir el header)"
+    headers = build_sprout_headers(_make(thinking_tokens=0))
+    assert headers[HEADER_THINKING_TOKENS] == "0"
+
+
+def test_tokens_out_no_incluye_thinking():
+    # Sanity: el valor que ponemos en `tokens_out` es el que emite, sin sumar
+    # thinking (la suma se hace solo en `eval_count` del body Ollama-format).
+    headers = build_sprout_headers(_make(tokens_out=50, thinking_tokens=20))
+    assert headers[HEADER_TOKENS_OUT] == "50"
+
+
+def test_cost_eur_formato_6_decimales():
+    headers = build_sprout_headers(_make(cost_eur=0.001234))
+    assert headers[HEADER_COST_EUR] == "0.001234"
+
+
+def test_cost_eur_cero_en_local_test():
+    headers = build_sprout_headers(_make(backend="local-ollama", cost_eur=0.0))
+    assert headers[HEADER_COST_EUR] == "0.000000"
+
+
+def test_contadores_negativos_rechazados():
+    with pytest.raises(ValueError, match="tokens_in"):
+        _make(tokens_in=-1)
+    with pytest.raises(ValueError, match="tokens_out"):
+        _make(tokens_out=-1)
+    with pytest.raises(ValueError, match="thinking_tokens"):
+        _make(thinking_tokens=-1)
+    with pytest.raises(ValueError, match="duration_ms"):
+        _make(duration_ms=-1)
+    with pytest.raises(ValueError, match="cost_eur"):
+        _make(cost_eur=-0.01)

--- a/code/meristem_inference_adapter/tests/test_main.py
+++ b/code/meristem_inference_adapter/tests/test_main.py
@@ -1,0 +1,250 @@
+"""Integration tests de main.py (/api/chat, /api/generate) con el backend test.
+
+Cubre:
+- Header `Sprout-Inference-*` completo en la respuesta HTTP (las 7 claves).
+- Body Ollama-shaped (`message` en chat, `response` en generate).
+- Seleccion de fixture via `options.test_fixture`.
+- Traduccion de `UpstreamRateLimited` a 503 con `Sprout-Inference-Error`.
+- /health expone el backend configurado.
+- Coexistencia del adapter con `ollama serve` (port layout punto 6) validada
+  a nivel de contrato — no se arranca ollama real en CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.backends.test import CannedResponse, TestBackend
+from src.config import (
+    DEFAULT_MODEL_ALIASES,
+    PricingConfig,
+    RetryConfig,
+    Settings,
+)
+from src.headers import (
+    HEADER_BACKEND,
+    HEADER_COST_EUR,
+    HEADER_DURATION_MS,
+    HEADER_ERROR,
+    HEADER_MODEL,
+    HEADER_THINKING_TOKENS,
+    HEADER_TOKENS_IN,
+    HEADER_TOKENS_OUT,
+)
+from src.main import create_app
+from src.retry import UpstreamRateLimited
+
+
+def _make_test_settings() -> Settings:
+    return Settings(
+        backend="test",
+        adapter_port=11434,
+        ollama_upstream_host="http://localhost:11435",
+        gemini_api_key=None,
+        gemini_default_model="gemma-4-26b-a4b",
+        thinking_budget=4096,
+        pricing=PricingConfig(0.0, 0.0, 0.0),
+        retry=RetryConfig(max_attempts=3, backoff_ms=(500, 2000, 8000)),
+        model_aliases=dict(DEFAULT_MODEL_ALIASES),
+    )
+
+
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+
+def test_health_reporta_backend():
+    app = create_app(_make_test_settings())
+    with TestClient(app) as client:
+        r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["backend"] == "test"
+    assert body["adapter_port"] == 11434
+
+
+# ---------------------------------------------------------------------------
+# /api/chat
+# ---------------------------------------------------------------------------
+
+
+def test_chat_body_ollama_shape_y_headers_completos():
+    app = create_app(_make_test_settings())
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/chat",
+            json={
+                "model": "gemma4:26b-moe",
+                "messages": [{"role": "user", "content": "hola"}],
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    # Body Ollama-shape: /api/chat devuelve `message`.
+    assert body["message"]["role"] == "assistant"
+    assert "content" in body["message"]
+    assert "thinking" in body["message"]
+    assert body["done"] is True
+    assert body["prompt_eval_count"] >= 0
+    assert body["eval_count"] >= 0
+    # Headers Sprout-Inference-*: las 7 claves presentes.
+    assert r.headers[HEADER_BACKEND] == "test"
+    assert r.headers[HEADER_MODEL] == "gemma4:26b-moe"
+    assert int(r.headers[HEADER_TOKENS_IN]) >= 0
+    assert int(r.headers[HEADER_TOKENS_OUT]) >= 0
+    assert int(r.headers[HEADER_THINKING_TOKENS]) >= 0
+    assert int(r.headers[HEADER_DURATION_MS]) >= 1
+    assert float(r.headers[HEADER_COST_EUR]) == 0.0
+
+
+def test_chat_selecciona_fixture_via_options():
+    app = create_app(_make_test_settings())
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/chat",
+            json={
+                "model": "gemma4:26b-moe",
+                "messages": [],
+                "options": {"test_fixture": "with_thinking"},
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["message"]["content"] == "respuesta final"
+    assert body["message"]["thinking"].startswith("razonando")
+    # Headers deben reflejar el canned `with_thinking`: tokens_out=5, thinking=15.
+    assert r.headers[HEADER_TOKENS_OUT] == "5"
+    assert r.headers[HEADER_THINKING_TOKENS] == "15"
+
+
+def test_chat_thinking_cero_se_emite_explicito():
+    # Punto 7: thinking_tokens=0 explicito, no header ausente.
+    app = create_app(_make_test_settings())
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/chat",
+            json={"model": "x", "messages": []},  # canned default → thinking=0
+        )
+    assert HEADER_THINKING_TOKENS in r.headers
+    assert r.headers[HEADER_THINKING_TOKENS] == "0"
+
+
+# ---------------------------------------------------------------------------
+# /api/generate
+# ---------------------------------------------------------------------------
+
+
+def test_generate_body_shape_y_headers():
+    app = create_app(_make_test_settings())
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/generate",
+            json={"model": "gemma4:e4b", "prompt": "hola"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    # /api/generate usa `response`, no `message`.
+    assert "response" in body
+    assert "message" not in body
+    assert body["done"] is True
+    # Headers idem que chat.
+    assert r.headers[HEADER_BACKEND] == "test"
+    assert r.headers[HEADER_MODEL] == "gemma4:e4b"
+
+
+# ---------------------------------------------------------------------------
+# Error: UpstreamRateLimited → 503 + Sprout-Inference-Error
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysRateLimitBackend:
+    """Backend que siempre levanta UpstreamRateLimited. Para test del handler."""
+
+    __test__ = False
+
+    async def chat(self, request):
+        raise UpstreamRateLimited(attempts=3, last_error=RuntimeError("429"))
+
+    async def generate(self, request):
+        raise UpstreamRateLimited(attempts=3, last_error=RuntimeError("429"))
+
+
+def _make_app_with_backend(backend, label: str = "cloud-gemini"):
+    # Construye app con un backend inyectado via monkey-patch del state.
+    settings = _make_test_settings()
+    app = create_app(settings)
+    app.state.backend = backend
+    app.state.backend_label = label
+    return app
+
+
+def test_chat_rate_limit_devuelve_503_con_header_de_error():
+    app = _make_app_with_backend(_AlwaysRateLimitBackend(), label="cloud-gemini")
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/chat",
+            json={"model": "gemma4:26b-moe", "messages": []},
+        )
+    assert r.status_code == 503
+    assert r.headers[HEADER_ERROR] == "upstream_rate_limited"
+    # Preservamos backend/model para que el caller pueda correlar el error.
+    assert r.headers[HEADER_BACKEND] == "cloud-gemini"
+    assert r.headers[HEADER_MODEL] == "gemma4:26b-moe"
+    # Pero NO emitimos contadores (no hubo llamada exitosa).
+    assert HEADER_TOKENS_IN not in r.headers
+    assert HEADER_TOKENS_OUT not in r.headers
+
+
+def test_generate_rate_limit_devuelve_503_con_header_de_error():
+    app = _make_app_with_backend(_AlwaysRateLimitBackend())
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/generate",
+            json={"model": "gemma4:e4b", "prompt": "x"},
+        )
+    assert r.status_code == 503
+    assert r.headers[HEADER_ERROR] == "upstream_rate_limited"
+
+
+# ---------------------------------------------------------------------------
+# Custom canned: permite inyectar fixtures desde tests.
+# ---------------------------------------------------------------------------
+
+
+def test_custom_canned_se_propaga_a_la_app():
+    custom = {
+        "default": CannedResponse(
+            model="gemma-4-26b-a4b",
+            content="canned!",
+            tokens_in=7,
+            tokens_out=3,
+            thinking_tokens=0,
+        ),
+    }
+    backend = TestBackend(canned=custom)
+    app = _make_app_with_backend(backend, label="test")
+    with TestClient(app) as client:
+        r = client.post("/api/chat", json={"model": "m", "messages": []})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["message"]["content"] == "canned!"
+    assert r.headers[HEADER_TOKENS_IN] == "7"
+    assert r.headers[HEADER_TOKENS_OUT] == "3"
+
+
+# ---------------------------------------------------------------------------
+# Contrato: /api/chat y /api/generate devuelven Content-Type application/json
+# ---------------------------------------------------------------------------
+
+
+def test_content_type_json_en_ambos_endpoints():
+    app = create_app(_make_test_settings())
+    with TestClient(app) as client:
+        for path, payload in (
+            ("/api/chat", {"model": "m", "messages": []}),
+            ("/api/generate", {"model": "m", "prompt": "x"}),
+        ):
+            r = client.post(path, json=payload)
+            assert r.headers["content-type"].startswith("application/json"), path

--- a/code/meristem_inference_adapter/tests/test_reconstruct.py
+++ b/code/meristem_inference_adapter/tests/test_reconstruct.py
@@ -1,0 +1,73 @@
+"""Tests de `reconstruct.split_gemini_parts` — punto 3 de #46.
+
+Cubre el caso critico del comentario tecnico: partes `thought=True` y
+`thought=False` intercaladas.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.reconstruct import SplitMessage, split_gemini_parts
+
+
+def test_partes_intercaladas_dict():
+    parts = [
+        {"text": "Let me think. ", "thought": True},
+        {"text": "The answer is ", "thought": False},
+        {"text": "Actually wait. ", "thought": True},
+        {"text": "42.", "thought": False},
+    ]
+    out = split_gemini_parts(parts)
+    assert out.content == "The answer is 42."
+    assert out.thinking == "Let me think. Actually wait. "
+
+
+def test_solo_content_sin_thinking():
+    parts = [{"text": "hola", "thought": False}]
+    out = split_gemini_parts(parts)
+    assert out == SplitMessage(content="hola", thinking="")
+
+
+def test_solo_thinking_sin_content():
+    parts = [{"text": "pensando", "thought": True}]
+    out = split_gemini_parts(parts)
+    assert out == SplitMessage(content="", thinking="pensando")
+
+
+def test_thought_ausente_es_false():
+    # Una parte sin el campo `thought` se trata como content normal.
+    parts = [{"text": "hola"}]
+    out = split_gemini_parts(parts)
+    assert out.content == "hola"
+    assert out.thinking == ""
+
+
+def test_parts_como_objetos_con_atributos():
+    # google-genai devuelve objetos con .text / .thought, no dicts.
+    parts = [
+        SimpleNamespace(text="think ", thought=True),
+        SimpleNamespace(text="answer", thought=False),
+    ]
+    out = split_gemini_parts(parts)
+    assert out.content == "answer"
+    assert out.thinking == "think "
+
+
+def test_partes_sin_texto_se_saltan():
+    # Function calls / imagenes sin .text no entran en ninguna cadena.
+    parts = [
+        {"text": "hello", "thought": False},
+        {"function_call": {"name": "fn"}},  # sin text
+        {"text": None, "thought": False},
+        {"text": "", "thought": False},
+        {"text": " world", "thought": False},
+    ]
+    out = split_gemini_parts(parts)
+    assert out.content == "hello world"
+    assert out.thinking == ""
+
+
+def test_lista_vacia():
+    out = split_gemini_parts([])
+    assert out == SplitMessage(content="", thinking="")

--- a/code/meristem_inference_adapter/tests/test_retry.py
+++ b/code/meristem_inference_adapter/tests/test_retry.py
@@ -1,0 +1,180 @@
+"""Tests de `retry.with_retry` — punto 5 de #46.
+
+Verifica:
+- Exito en 1er intento no espera ni reintenta.
+- Rate-limit en primeros intentos + exito final → devuelve resultado.
+- Agotar intentos → UpstreamRateLimited.
+- Excepcion no-rate-limit se propaga sin retry.
+- Sleep inyectable: verifica la secuencia exacta de waits.
+- Config invalida rechazada.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.retry import UpstreamRateLimited, with_retry
+
+
+class _FakeRateLimit(Exception):
+    pass
+
+
+class _FakeServerError(Exception):
+    pass
+
+
+def _is_rl(exc: BaseException) -> bool:
+    return isinstance(exc, _FakeRateLimit)
+
+
+async def _always_ok():
+    return "ok"
+
+
+def _make_flaky(fail_times: int, then: str = "ok"):
+    """Op que falla con _FakeRateLimit `fail_times` veces, luego devuelve `then`."""
+    state = {"n": 0}
+
+    async def op():
+        state["n"] += 1
+        if state["n"] <= fail_times:
+            raise _FakeRateLimit(f"attempt {state['n']}")
+        return then
+
+    return op, state
+
+
+class _SleepRecorder:
+    def __init__(self) -> None:
+        self.waits: list[float] = []
+
+    async def __call__(self, seconds: float) -> None:
+        self.waits.append(seconds)
+
+
+@pytest.mark.asyncio
+async def test_exito_primer_intento_no_espera():
+    sleep = _SleepRecorder()
+    result = await with_retry(
+        _always_ok,
+        max_attempts=3,
+        backoff_ms=(500, 2000),
+        is_rate_limit=_is_rl,
+        sleep=sleep,
+    )
+    assert result == "ok"
+    assert sleep.waits == []
+
+
+@pytest.mark.asyncio
+async def test_reintentos_con_backoff_exacto():
+    op, state = _make_flaky(fail_times=2, then="final")
+    sleep = _SleepRecorder()
+    result = await with_retry(
+        op,
+        max_attempts=3,
+        backoff_ms=(500, 2000),
+        is_rate_limit=_is_rl,
+        sleep=sleep,
+    )
+    assert result == "final"
+    assert state["n"] == 3
+    # Espero 500ms antes del 2o intento, 2000ms antes del 3er intento.
+    assert sleep.waits == [0.5, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_agotar_intentos_levanta_upstream_rate_limited():
+    op, state = _make_flaky(fail_times=10)  # nunca tiene exito
+    sleep = _SleepRecorder()
+    with pytest.raises(UpstreamRateLimited) as ei:
+        await with_retry(
+            op,
+            max_attempts=3,
+            backoff_ms=(500, 2000, 8000),
+            is_rate_limit=_is_rl,
+            sleep=sleep,
+        )
+    assert ei.value.attempts == 3
+    assert isinstance(ei.value.last_error, _FakeRateLimit)
+    assert state["n"] == 3
+    # 3 intentos ⇒ 2 esperas entre ellos. El backoff[2]=8000 no se consume.
+    assert sleep.waits == [0.5, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_default_de_46_tres_intentos_500_2000_8000():
+    # Valores del comentario tecnico de #46.
+    op, state = _make_flaky(fail_times=99)
+    sleep = _SleepRecorder()
+    with pytest.raises(UpstreamRateLimited):
+        await with_retry(
+            op,
+            max_attempts=3,
+            backoff_ms=(500, 2000, 8000),
+            is_rate_limit=_is_rl,
+            sleep=sleep,
+        )
+    assert state["n"] == 3
+    assert sleep.waits == [0.5, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_no_rate_limit_se_propaga_sin_retry():
+    state = {"n": 0}
+
+    async def op():
+        state["n"] += 1
+        raise _FakeServerError("boom")
+
+    sleep = _SleepRecorder()
+    with pytest.raises(_FakeServerError):
+        await with_retry(
+            op,
+            max_attempts=3,
+            backoff_ms=(500, 2000),
+            is_rate_limit=_is_rl,
+            sleep=sleep,
+        )
+    assert state["n"] == 1  # solo 1 intento
+    assert sleep.waits == []
+
+
+@pytest.mark.asyncio
+async def test_max_attempts_cero_rechazado():
+    with pytest.raises(ValueError, match="max_attempts"):
+        await with_retry(
+            _always_ok,
+            max_attempts=0,
+            backoff_ms=(),
+            is_rate_limit=_is_rl,
+        )
+
+
+@pytest.mark.asyncio
+async def test_backoff_demasiado_corto_rechazado():
+    with pytest.raises(ValueError, match="backoff_ms"):
+        await with_retry(
+            _always_ok,
+            max_attempts=3,
+            backoff_ms=(500,),  # deberia tener al menos 2
+            is_rate_limit=_is_rl,
+        )
+
+
+@pytest.mark.asyncio
+async def test_max_attempts_uno_sin_reintentos():
+    op, state = _make_flaky(fail_times=99)
+    sleep = _SleepRecorder()
+    with pytest.raises(UpstreamRateLimited) as ei:
+        await with_retry(
+            op,
+            max_attempts=1,
+            backoff_ms=(),
+            is_rate_limit=_is_rl,
+            sleep=sleep,
+        )
+    assert ei.value.attempts == 1
+    assert state["n"] == 1
+    assert sleep.waits == []

--- a/code/meristem_inference_adapter/tests/test_scaffold.py
+++ b/code/meristem_inference_adapter/tests/test_scaffold.py
@@ -1,0 +1,71 @@
+"""Tests minimos de scaffold.
+
+No tocan logica real (los stubs levantan NotImplementedError). Solo verifican:
+
+- que el paquete es importable
+- que Settings carga con defaults y backend=test
+- que /health responde en la app construida
+
+Tests de logica vienen en las siguientes tandas (tasks 2-7).
+"""
+
+from __future__ import annotations
+
+
+def test_config_loads_with_defaults(monkeypatch):
+    # limpiar env para que coja defaults
+    for k in (
+        "INFERENCE_BACKEND",
+        "ADAPTER_PORT",
+        "MERISTEM_THINKING_BUDGET",
+        "GEMINI_API_KEY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+    from src.config import load_settings
+
+    settings = load_settings()
+    assert settings.backend == "test"
+    assert settings.adapter_port == 11434
+    assert settings.thinking_budget == 4096
+    assert settings.gemini_api_key is None
+    assert settings.retry.max_attempts == 3
+    assert settings.retry.backoff_ms == (500, 2000, 8000)
+    assert settings.model_aliases["gemma4:26b-moe"] == "gemma-4-26b-a4b"
+
+
+def test_config_rejects_invalid_backend(monkeypatch):
+    monkeypatch.setenv("INFERENCE_BACKEND", "bogus")
+
+    from src.config import load_settings
+
+    import pytest
+
+    with pytest.raises(ValueError, match="INFERENCE_BACKEND invalido"):
+        load_settings()
+
+
+def test_resolve_model_fallback():
+    from src.config import resolve_model
+
+    aliases = {"gemma4:26b-moe": "gemma-4-26b-a4b"}
+    assert resolve_model("gemma4:26b-moe", aliases) == "gemma-4-26b-a4b"
+    # tag no aliased se devuelve tal cual
+    assert resolve_model("unknown:model", aliases) == "unknown:model"
+
+
+def test_health_endpoint(adapter_client):
+    r = adapter_client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["backend"] == "test"
+    assert body["adapter_port"] == 11434
+
+
+def test_backend_is_test_protocol_compatible(adapter_app):
+    from src.backends.base import InferenceBackend
+
+    backend = adapter_app.state.backend
+    # runtime_checkable Protocol: verifica que existen chat() y generate()
+    assert isinstance(backend, InferenceBackend)

--- a/code/meristem_inference_adapter/tests/test_schema_flatten.py
+++ b/code/meristem_inference_adapter/tests/test_schema_flatten.py
@@ -1,0 +1,126 @@
+"""Tests de `schema_flatten` — punto 1 de #46.
+
+Verificaciones:
+- Schema simple sin refs se devuelve equivalente (no muta, no falla).
+- Input no se muta (el deep-copy defensivo funciona).
+- PolicyPacket.model_json_schema() (pydantic v2 real) queda sin $ref ni $defs.
+- Un ref circular deberia disparar SchemaFlattenError (caso defensivo).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+import pytest
+
+from src.schema_flatten import SchemaFlattenError, flatten_json_schema
+
+
+def _json_equal(a: Any, b: Any) -> bool:
+    return json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+def _has_ref_or_defs(obj: Any) -> bool:
+    s = json.dumps(obj)
+    return '"$ref"' in s or '"$defs"' in s or '"definitions"' in s
+
+
+def test_flatten_schema_sin_refs_es_equivalente():
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+        "required": ["name"],
+    }
+    out = flatten_json_schema(schema)
+    assert _json_equal(out, schema)
+
+
+def test_flatten_no_muta_input():
+    schema = {
+        "$defs": {"Foo": {"type": "string"}},
+        "type": "object",
+        "properties": {"foo": {"$ref": "#/$defs/Foo"}},
+    }
+    original = copy.deepcopy(schema)
+    _ = flatten_json_schema(schema)
+    assert _json_equal(schema, original), "el input original fue mutado"
+
+
+def test_flatten_inline_ref_basico():
+    schema = {
+        "$defs": {"Foo": {"type": "string", "minLength": 1}},
+        "type": "object",
+        "properties": {"foo": {"$ref": "#/$defs/Foo"}},
+        "required": ["foo"],
+    }
+    out = flatten_json_schema(schema)
+    assert "$defs" not in out
+    assert out["properties"]["foo"] == {"type": "string", "minLength": 1}
+    assert not _has_ref_or_defs(out)
+
+
+def test_flatten_legacy_definitions_tambien_se_eliminan():
+    # draft-07 usa `definitions` en vez de `$defs`. jsonref los resuelve igual.
+    schema = {
+        "definitions": {"Foo": {"type": "string"}},
+        "type": "object",
+        "properties": {"foo": {"$ref": "#/definitions/Foo"}},
+    }
+    out = flatten_json_schema(schema)
+    assert "definitions" not in out
+    assert out["properties"]["foo"] == {"type": "string"}
+
+
+def test_flatten_policy_packet_real():
+    """El test critico del punto 1 del comentario de #46."""
+    # Import tardio para que los tests que no necesitan shared sigan corriendo
+    # si el path no estuviera configurado.
+    from schemas.policy_packet import PolicyPacket
+
+    raw = PolicyPacket.model_json_schema()
+    # Pre-condicion: el schema original tiene refs (si no, este test no valida nada).
+    assert "$defs" in raw, "PolicyPacket deberia generar $defs en pydantic v2"
+    assert _has_ref_or_defs(raw)
+
+    flat = flatten_json_schema(raw)
+
+    assert not _has_ref_or_defs(flat), (
+        "PolicyPacket aplanado conserva $ref o $defs — Gemini rechazaria este schema"
+    )
+    # Sanity estructural: el objeto aplanado sigue siendo un schema de tipo objeto
+    # con las propiedades principales.
+    assert flat["type"] == "object"
+    assert "properties" in flat
+    assert "rules" in flat["properties"]
+    # Y `rules` expandido internamente, no como {"$ref": "..."}
+    rules = flat["properties"]["rules"]
+    assert "properties" in rules
+    assert "soil_moisture_thresholds" in rules["properties"]
+
+
+def test_flatten_ref_circular_levanta_error():
+    # $ref circular: A -> B -> A. jsonref con proxies=False puede dejar el
+    # segundo nivel sin resolver porque detecta el ciclo.
+    schema: dict[str, Any] = {
+        "$defs": {
+            "A": {"type": "object", "properties": {"next": {"$ref": "#/$defs/B"}}},
+            "B": {"type": "object", "properties": {"next": {"$ref": "#/$defs/A"}}},
+        },
+        "type": "object",
+        "properties": {"root": {"$ref": "#/$defs/A"}},
+    }
+    # Esto podria completarse sin error (jsonref repite la estructura hasta una
+    # profundidad) o disparar SchemaFlattenError. Ambos son aceptables; el test
+    # fija que NO producimos un dict con `$ref` sin avisar.
+    try:
+        out = flatten_json_schema(schema)
+    except SchemaFlattenError:
+        return  # ok, ciclo detectado
+    assert not _has_ref_or_defs(out), (
+        "schema con ciclo aplanado silenciosamente conservo refs residuales"
+    )

--- a/code/meristem_inference_adapter/tests/test_smoke_parity.py
+++ b/code/meristem_inference_adapter/tests/test_smoke_parity.py
@@ -1,0 +1,307 @@
+"""Smoke parity test: mismo /api/chat contra local y cloud, headers uniformes.
+
+Valida el contrato agnostico de backend de #46: el caller ve la misma shape
+de headers y body sin branchear. Los numeros difieren (cada upstream reporta
+sus propios contadores), pero:
+
+- Las 7 claves `Sprout-Inference-*` estan presentes en ambos.
+- Body es Ollama-shape (`message.content`, `done: true`).
+- `Sprout-Inference-Backend` identifica el upstream (local-ollama vs cloud-gemini).
+- `Sprout-Inference-Model` refleja el tag del caller, no el id interno de Gemini.
+
+Asimetria documentada (punto 7): con `think=true`, local emite
+`Thinking-Tokens=0` porque Ollama no desglosa, mientras cloud reporta el
+`thoughts_token_count` real. Test dedicado lo fija como contrato.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import respx
+from fastapi.testclient import TestClient
+
+from src.backends.cloud import CloudBackend
+from src.backends.local import LocalBackend
+from src.config import (
+    DEFAULT_MODEL_ALIASES,
+    PricingConfig,
+    RetryConfig,
+    Settings,
+)
+from src.headers import (
+    ALL_METRIC_HEADERS,
+    HEADER_BACKEND,
+    HEADER_COST_EUR,
+    HEADER_DURATION_MS,
+    HEADER_MODEL,
+    HEADER_THINKING_TOKENS,
+    HEADER_TOKENS_IN,
+    HEADER_TOKENS_OUT,
+)
+from src.main import create_app
+
+
+UPSTREAM_OLLAMA = "http://localhost:11435"
+
+
+# ---------------------------------------------------------------------------
+# Helpers: settings base, instalador de backend, respuesta Ollama/Gemini canned.
+# ---------------------------------------------------------------------------
+
+
+def _base_settings() -> Settings:
+    # backend="test" para que create_app no intente instanciar cloud/local con
+    # credenciales reales; luego monkey-patch `app.state.backend` con la pieza
+    # que queremos ejercitar.
+    return Settings(
+        backend="test",
+        adapter_port=11434,
+        ollama_upstream_host=UPSTREAM_OLLAMA,
+        gemini_api_key="fake",
+        gemini_default_model="gemma-4-26b-a4b",
+        thinking_budget=4096,
+        pricing=PricingConfig(0.0, 0.0, 0.0),
+        retry=RetryConfig(max_attempts=3, backoff_ms=(1, 1, 1)),
+        model_aliases=dict(DEFAULT_MODEL_ALIASES),
+    )
+
+
+def _install_backend(app, backend: Any, label: str) -> None:
+    app.state.backend = backend
+    app.state.backend_label = label
+
+
+def _ollama_canned(
+    *,
+    content: str = "hola desde ollama",
+    thinking: str | None = None,
+    prompt_eval_count: int = 42,
+    eval_count: int = 17,
+) -> dict:
+    message: dict = {"role": "assistant", "content": content}
+    if thinking is not None:
+        message["thinking"] = thinking
+    return {
+        "model": "gemma4:26b-moe",
+        "created_at": "2026-04-21T12:00:00Z",
+        "message": message,
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": prompt_eval_count,
+        "prompt_eval_duration": 10_000_000,
+        "eval_count": eval_count,
+        "eval_duration": 100_000_000,
+    }
+
+
+class _FakeGenai:
+    """Shape minima de `genai.Client` para inyectar via `client_factory`."""
+
+    def __init__(self, response: Any) -> None:
+        self._response = response
+        self.aio = SimpleNamespace(
+            models=SimpleNamespace(generate_content=self._gen)
+        )
+
+    async def _gen(self, *, model, contents, config):  # noqa: ARG002
+        return self._response
+
+
+def _gemini_canned(
+    *,
+    content_parts: list[tuple[str, bool]],
+    prompt_tokens: int = 42,
+    candidates_tokens: int = 17,
+    thoughts_tokens: int = 0,
+) -> SimpleNamespace:
+    parts = [SimpleNamespace(text=t, thought=th) for t, th in content_parts]
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=parts))],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=prompt_tokens,
+            candidates_token_count=candidates_tokens,
+            thoughts_token_count=thoughts_tokens,
+        ),
+    )
+
+
+def _make_cloud_backend(fake_client: _FakeGenai) -> CloudBackend:
+    return CloudBackend(
+        api_key="fake",
+        default_model="gemma-4-26b-a4b",
+        model_aliases={"gemma4:26b-moe": "gemma-4-26b-a4b"},
+        thinking_budget=4096,
+        retry=RetryConfig(max_attempts=3, backoff_ms=(1, 1, 1)),
+        pricing=PricingConfig(0.0, 0.0, 0.0),
+        client_factory=lambda _api_key: fake_client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parity de shape: headers y body igual forma aunque upstreams distintos.
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_smoke_parity_headers_y_body_shape_uniformes_entre_local_y_cloud():
+    # Mismo request para ambos backends.
+    payload = {
+        "model": "gemma4:26b-moe",
+        "messages": [{"role": "user", "content": "hola"}],
+    }
+
+    # --- local (respx intercepta httpx a :11435) ---
+    respx.post(f"{UPSTREAM_OLLAMA}/api/chat").mock(
+        return_value=httpx.Response(
+            200,
+            json=_ollama_canned(prompt_eval_count=42, eval_count=17),
+        )
+    )
+    app_local = create_app(_base_settings())
+    _install_backend(
+        app_local, LocalBackend(upstream_host=UPSTREAM_OLLAMA), "local-ollama"
+    )
+    with TestClient(app_local) as c:
+        r_local = c.post("/api/chat", json=payload)
+
+    # --- cloud (fake genai client) ---
+    fake_client = _FakeGenai(
+        _gemini_canned(
+            content_parts=[("hola desde gemini", False)],
+            prompt_tokens=42,
+            candidates_tokens=17,
+            thoughts_tokens=0,
+        )
+    )
+    app_cloud = create_app(_base_settings())
+    _install_backend(app_cloud, _make_cloud_backend(fake_client), "cloud-gemini")
+    with TestClient(app_cloud) as c:
+        r_cloud = c.post("/api/chat", json=payload)
+
+    # --- parity assertions ---
+    # Status uniforme.
+    assert r_local.status_code == 200
+    assert r_cloud.status_code == 200
+
+    # Body shape Ollama-compatible en ambos.
+    for resp in (r_local, r_cloud):
+        b = resp.json()
+        assert "message" in b, "ambos backends deben devolver `message`"
+        assert b["message"]["role"] == "assistant"
+        assert "content" in b["message"]
+        assert b["done"] is True
+
+    # Las 7 claves Sprout-Inference-* presentes en ambos.
+    for h in ALL_METRIC_HEADERS:
+        assert h in r_local.headers, f"local missing {h}"
+        assert h in r_cloud.headers, f"cloud missing {h}"
+
+    # Backend label diferencia los upstreams.
+    assert r_local.headers[HEADER_BACKEND] == "local-ollama"
+    assert r_cloud.headers[HEADER_BACKEND] == "cloud-gemini"
+
+    # Model label refleja el tag del caller en AMBOS. Para cloud, el backend
+    # resuelve el alias a `gemma-4-26b-a4b` para la llamada a Gemini pero
+    # preserva el tag original en el body/headers (punto 9 de #46).
+    assert r_local.headers[HEADER_MODEL] == "gemma4:26b-moe"
+    assert r_cloud.headers[HEADER_MODEL] == "gemma4:26b-moe"
+
+    # Contadores numericos: los upstreams stubeados reportaron el mismo valor,
+    # asi que el header tambien. El test clave es que AMBOS emitieron un
+    # numero parseable en la misma clave.
+    assert r_local.headers[HEADER_TOKENS_IN] == "42"
+    assert r_cloud.headers[HEADER_TOKENS_IN] == "42"
+    assert r_local.headers[HEADER_TOKENS_OUT] == "17"
+    assert r_cloud.headers[HEADER_TOKENS_OUT] == "17"
+    # Thinking-Tokens=0 en ambos: local por contrato (punto 7), cloud porque
+    # el request no pidio think y el upstream reporto thoughts_token_count=0.
+    assert r_local.headers[HEADER_THINKING_TOKENS] == "0"
+    assert r_cloud.headers[HEADER_THINKING_TOKENS] == "0"
+    # Cost: pricing=0 en ambos → "0.000000" uniforme (6 decimales).
+    assert r_local.headers[HEADER_COST_EUR] == "0.000000"
+    assert r_cloud.headers[HEADER_COST_EUR] == "0.000000"
+    # Duration-Ms: int>=1, mismo formato.
+    assert int(r_local.headers[HEADER_DURATION_MS]) >= 1
+    assert int(r_cloud.headers[HEADER_DURATION_MS]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Asimetria documentada (punto 7): thinking en local vs cloud.
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_smoke_parity_asimetria_thinking_local_siempre_cero_cloud_desglosa():
+    """Con `think=true`, local emite Thinking-Tokens=0 (Ollama no desglosa) y
+    Tokens-Out incluye thinking; cloud reporta Thinking-Tokens real y
+    Tokens-Out sin thinking. Esto NO es parity — es el compromiso documentado
+    que el harness (#45) debe saber via `Sprout-Inference-Backend`.
+    """
+    payload = {
+        "model": "gemma4:26b-moe",
+        "messages": [{"role": "user", "content": "hola"}],
+        "think": True,
+    }
+
+    # Local: eval_count=50 incluye thinking segun contrato Ollama; el texto de
+    # razonamiento llega en `message.thinking`.
+    respx.post(f"{UPSTREAM_OLLAMA}/api/chat").mock(
+        return_value=httpx.Response(
+            200,
+            json=_ollama_canned(
+                content="respuesta",
+                thinking="razonando",
+                prompt_eval_count=10,
+                eval_count=50,
+            ),
+        )
+    )
+    app_local = create_app(_base_settings())
+    _install_backend(
+        app_local, LocalBackend(upstream_host=UPSTREAM_OLLAMA), "local-ollama"
+    )
+    with TestClient(app_local) as c:
+        r_local = c.post("/api/chat", json=payload)
+
+    # Cloud: thoughts_token_count=30 explicito; candidates=20.
+    fake_client = _FakeGenai(
+        _gemini_canned(
+            content_parts=[
+                ("razonando", True),
+                ("respuesta", False),
+            ],
+            prompt_tokens=10,
+            candidates_tokens=20,
+            thoughts_tokens=30,
+        )
+    )
+    app_cloud = create_app(_base_settings())
+    _install_backend(app_cloud, _make_cloud_backend(fake_client), "cloud-gemini")
+    with TestClient(app_cloud) as c:
+        r_cloud = c.post("/api/chat", json=payload)
+
+    # Asimetria en HEADERS:
+    # - local: Thinking-Tokens=0 (no desglosa), Tokens-Out=50 (incluye thinking).
+    assert r_local.headers[HEADER_THINKING_TOKENS] == "0"
+    assert r_local.headers[HEADER_TOKENS_OUT] == "50"
+    # - cloud: desglose real.
+    assert r_cloud.headers[HEADER_THINKING_TOKENS] == "30"
+    assert r_cloud.headers[HEADER_TOKENS_OUT] == "20"
+
+    # Tokens-In si es paritario (ambos upstreams reportan prompt tokens).
+    assert r_local.headers[HEADER_TOKENS_IN] == "10"
+    assert r_cloud.headers[HEADER_TOKENS_IN] == "10"
+
+    # BODY: ambos preservan `message.thinking` como texto visible al caller.
+    # Esta paridad si se mantiene — la asimetria vive solo en los contadores.
+    assert r_local.json()["message"]["thinking"] == "razonando"
+    assert r_cloud.json()["message"]["thinking"] == "razonando"
+
+    # Y el `eval_count` del body ollama-shape sigue siendo la suma en ambos:
+    # local: eval_count nativo Ollama = 50 (incluye thinking).
+    # cloud: adapter compone eval_count = candidates + thoughts = 20+30 = 50.
+    assert r_local.json()["eval_count"] == 50
+    assert r_cloud.json()["eval_count"] == 50

--- a/code/meristem_inference_adapter/tests/test_thinking_map.py
+++ b/code/meristem_inference_adapter/tests/test_thinking_map.py
@@ -1,0 +1,36 @@
+"""Tests de `thinking_map` — punto 2 de #46."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.thinking_map import GeminiThinkingConfig, map_think_to_gemini
+
+
+def test_think_true_activa_con_budget():
+    cfg = map_think_to_gemini(think=True, budget_when_on=4096)
+    assert cfg == GeminiThinkingConfig(include_thoughts=True, thinking_budget=4096)
+
+
+def test_think_false_desactiva_explicito():
+    cfg = map_think_to_gemini(think=False, budget_when_on=4096)
+    assert cfg == GeminiThinkingConfig(include_thoughts=False, thinking_budget=0)
+
+
+def test_think_none_tratado_como_false():
+    # Ausencia de `think` en el request Ollama no debe significar "default del
+    # modelo"; debe significar "off explicito".
+    cfg = map_think_to_gemini(think=None, budget_when_on=4096)
+    assert cfg == GeminiThinkingConfig(include_thoughts=False, thinking_budget=0)
+
+
+def test_think_true_con_budget_cero_levanta():
+    # Si el caller pide thinking=True pero el budget es 0, mejor fallar ruidoso
+    # que mandar "activa thinking con 0 tokens" (que ya es off).
+    with pytest.raises(ValueError, match="budget_when_on=0"):
+        map_think_to_gemini(think=True, budget_when_on=0)
+
+
+def test_think_true_con_budget_negativo_levanta():
+    with pytest.raises(ValueError):
+        map_think_to_gemini(think=True, budget_when_on=-1)


### PR DESCRIPTION
Closes #46.

## Summary

Adapter FastAPI en `:11434` con contrato Ollama-nativo (`/api/chat`,
`/api/generate`). Switchea por env `INFERENCE_BACKEND`:

- `cloud` — Gemini API via `google-genai`, Gemma 26B MoE.
- `local` — reverse-proxy transparente a Ollama real en `:11435`.
- `test`  — mock canneado; CI no depende de Gemini ni Ollama (punto 11).

Meristem (el consumidor) siempre habla a `:11434` sin distinguir el backend.

## Checklist — 11 criterios tecnicos del comment de Cambium en #46

- [x] **1. Schema flatten.** `jsonref.replace_refs(proxies=False)` + JSON round-trip + poda de `$defs`/`definitions`. `SchemaFlattenError` tipado para ciclos.
- [x] **2. Thinking map.** Ollama `think:bool` -> Gemini `thinking_config(include_thoughts, thinking_budget)`. `think=True` + `budget<=0` rechazado.
- [x] **3. Reconstruct.** Split de parts Gemini por `thought=true|false` en `message.thinking` / `message.content`. Soporta dicts y objetos.
- [x] **4. eval_count = candidates + thoughts.** Docstring explicito en `headers.py`. El `tok/s` defendible es `Tokens-Out / Duration-Ms`, no `eval_count / eval_duration`.
- [x] **5. Retry 429.** Backoff `500ms / 2s / 8s` configurable; tras agotar -> `UpstreamRateLimited` -> adapter responde 503 con `Sprout-Inference-Error: upstream_rate_limited`.
- [x] **6. Port layout.** Adapter `:11434`, Ollama real `:11435`, coexistencia documentada.
- [x] **7. Headers `Sprout-Inference-*` uniformes.** 7 claves siempre presentes; `Thinking-Tokens=0` explicito si off. Asimetria local (Ollama no desglosa thinking) documentada y cubierta por test dedicado.
- [x] **8. Streaming.** `stream=true` aceptado pero forzado a `false` al upstream; respuesta en un solo JSON sintetico. Streaming real diferido a #43 si lo requiere.
- [x] **9. Model aliases.** `gemma4:26b-moe` -> `gemma-4-26b-a4b` para la llamada a Gemini; tag original preservado en body + headers.
- [x] **10. Cost configurable.** `GEMINI_PRICE_IN/OUT/THINKING_EUR_PER_1K` via env; `0.0` en local/test; formato `%.6f` en el header.
- [x] **11. Test backend obligatorio.** `CannedResponse` + selector `options.test_fixture`; `__test__ = False` para evitar colision con pytest.

## Contratos fijados (ver README)

- 7 headers `Sprout-Inference-*` (Backend, Model, Tokens-In, Tokens-Out, Thinking-Tokens, Duration-Ms, Cost-EUR) emitidos siempre en modo `cloud`/`local`/`test`.
- Body Ollama-shape uniforme (`message.content` + `done`) para los 3 backends.
- `gemma4:26b-moe` alias resuelto internamente a `gemma-4-26b-a4b` sin que el caller lo vea.

## Tests

88 verdes, sin Gemini ni Ollama real:

- `respx` intercepta `httpx.AsyncClient` para `local`.
- `genai.Client` fake via `client_factory` inyectable para `cloud`.
- `test_smoke_parity.py` corre el mismo prompt contra local (stub Ollama) y cloud (stub Gemini) y verifica que las 7 claves `Sprout-Inference-*` + shape del body son uniformes; test dedicado documenta la asimetria de thinking en local.

```bash
cd code/meristem_inference_adapter
pip install -r requirements.txt
python -m pytest tests -v
```

## Verificacion diferida (no bloquea merge)

Semantica de `thoughts_token_count` contra Gemini API real (descuenta del pool de ventana o es output-only). El contrato del adapter es agnostico al resultado — solo cambia el scope de #47 (sweep de ventana de contexto). Protocolo ejecutable + regla de decision en `bitacora/2026-04-21_thoughts-token-count-verificacion-pendiente_meristem.md`. Bloqueado por falta de `GEMINI_API_KEY` en esta sesion; ~3 min de trabajo cuando se ejecute.

## Test plan

- [x] `pytest tests -v` verde en local (Windows/Python 3.13).
- [ ] Review de Cambium contra los 11 puntos.
- [ ] Verificacion en vivo de `thoughts_token_count` (cuando se disponga de key; issue o comment en la bitacora citada).
- [ ] Smoke E2E contra Ollama real con `ollama serve --port 11435` (manual; Bea en portatil).
- [ ] Smoke E2E contra Gemini API (requiere key).

## Referencias

- Comment tecnico de Cambium en #46 con los 11 criterios.
- `bitacora/2026-04-20_meristem-reframe-modelo-objetivo_cambium.md` (D3).
- `bitacora/2026-04-19_thinking-mode-e4b-latencia_meristem.md`.
- `bitacora/2026-04-21_thoughts-token-count-verificacion-pendiente_meristem.md`.
- Consumidores: #44 (thinking A/B), #45 (harness), #47 (context sweep).