### PR TITLE
Rhizome API: document JSON envelope for decision explanations

### DIFF
--- a/bitacora/2026-04-27_rhizome-explain-json-contract_xilema.md
+++ b/bitacora/2026-04-27_rhizome-explain-json-contract_xilema.md
@@ -1,0 +1,38 @@
+# Contrato JSON para `/explain/decision/{id}`
+
+**De:** Xilema  
+**Fecha:** 2026-04-27  
+**Contexto:** coordinacion con Floema / cliente Retrofit
+
+## Decision
+
+Floema detecta un riesgo de interoperabilidad: el cliente Retrofit espera que
+`GET /explain/decision/{id}` devuelva un objeto JSON, no texto plano crudo.
+
+Contrato fijado:
+
+```json
+{
+  "explanation": "El modelo decidió..."
+}
+```
+
+## Cambio
+
+Se documenta en:
+
+- `docs/10_rhizome_spec.md`
+- `docs/20_data_contracts.md`
+
+## Implicacion
+
+Cuando implementemos la API local de Rhizome para Pollen, el endpoint debe
+responder `application/json` con campo obligatorio `explanation`.
+
+No debe devolver:
+
+- `text/plain`
+- string JSON raiz
+- texto crudo del modelo
+
+Con esto evitamos `SerializationException` en el cliente Kotlin/Retrofit.

--- a/docs/10_rhizome_spec.md
+++ b/docs/10_rhizome_spec.md
@@ -129,6 +129,26 @@ Solo entra cuando hay arbitraje o explicación.
 - `GET /outbox`
 - `GET /explain/decision/{id}`
 
+#### `GET /explain/decision/{id}`
+
+Este endpoint debe responder siempre `application/json`, no texto plano.
+
+Respuesta correcta:
+
+```json
+{
+  "explanation": "El modelo decidió bloquear el riego porque el depósito está por debajo del mínimo seguro."
+}
+```
+
+Contrato:
+
+- `explanation` es obligatorio
+- `explanation` es string
+- no devolver `text/plain`
+- no devolver el texto crudo del modelo como body raiz
+- si la decisión no existe, devolver error HTTP estructurado, no una explicación vacía
+
 ### Escritura
 - `POST /mission_patch`
 - `POST /weather_digest`

--- a/docs/20_data_contracts.md
+++ b/docs/20_data_contracts.md
@@ -144,6 +144,23 @@ Campos clave:
 - `acked_ids`
 - `bundle_kind`: `visit | return | meristem_sync`
 
+## 3.11 DecisionExplanationResponse
+Respuesta de la API local de Rhizome para `GET /explain/decision/{id}`.
+
+Campos clave:
+- `explanation`: texto breve y legible para Pollen / operador
+
+Regla de interoperabilidad:
+- la respuesta debe ser JSON object
+- no se acepta texto plano crudo
+- forma exacta mínima:
+
+```json
+{
+  "explanation": "El modelo decidió regar A porque el suelo estaba bajo el umbral y el depósito era suficiente."
+}
+```
+
 ## 4. Autoridad por contrato
 
 - `RhizomeSnapshot`: Rhizome


### PR DESCRIPTION
## Summary
- Documents that `GET /explain/decision/{id}` must return `application/json`, not raw text.
- Adds the minimal response envelope `{"explanation": "..."}` to Rhizome API spec and data contracts.
- Adds bitacora entry capturing Floema's Retrofit interoperability concern before API implementation.

## Verification
- Docs-only change; no code tests run.

## Notes
- This is intentionally split from the ESP32/BME280 firmware PR to keep review scope small.