### PR TITLE
Meristem: add Rhizome minimal handoff fixtures

### DIFF
--- a/bitacora/2026-04-30_rhizome-meristem-handoff-minimo_xilema.md
+++ b/bitacora/2026-04-30_rhizome-meristem-handoff-minimo_xilema.md
@@ -1,0 +1,62 @@
+# Handoff minimo Rhizome -> Meristem
+
+**De:** Xilema
+**Fecha:** 2026-04-30
+**Contexto:** dia 15, posible entrada de Meristem-nodo al MVP
+
+## Decision
+
+Preparo un paquete minimo para que Meristem pueda ejercitar su camino MVP sin
+esperar a que Rhizome exponga todos los endpoints reales.
+
+El codigo actual de Meristem consume evidencias como envelopes individuales
+`/ingest` y valida `PolicyDelta` en `/deltas/propose`. Por eso el paquete no
+implementa todavia `FieldVisit`/`SyncBundle` v2: esos contratos estan en docs,
+pero no existen aun como Pydantic compartido.
+
+## Entrega
+
+Carpeta:
+
+- `code/meristem/examples/rhizome_minimal_handoff/`
+
+Incluye:
+
+- `active_policy_seed.json`: `PolicyPacket` seguro para `rhizome_01`.
+- `ingest_rhizome_snapshot_tank_low.json`: snapshot con deposito al 18%.
+- `ingest_decision_receipt_tank_low.json`: receipt de bloqueo `TANK_LOW`.
+- `ra04_safety_downgrade_delta.json`: delta que intenta bajar
+  `rules.tank_minimum_pct` a 15%.
+
+## Criterio de seguridad
+
+RA04 debe rechazarse:
+
+- HTTP esperado: `422`
+- reason: `violates_safety_rule`
+- violation: `rules.tank_minimum_pct`
+- proposed_value: `15.0`
+- firmware_limit: `20.0`
+
+Esto materializa la barandilla del review dia 13:
+
+`lo fisico manda, Rhizome arbitra, Pollen media, Meristem afina`.
+
+## Verificacion
+
+Añado test ejecutable:
+
+- `code/meristem/tests/test_rhizome_minimal_handoff_examples.py`
+
+Comprueba:
+
+- fixtures parsean con schemas actuales,
+- RA04 falla contra `safety_rules`,
+- flujo HTTP Meristem acepta las evidencias y rechaza el delta peligroso.
+
+## Nota BME280
+
+El BME280 de banco queda bloqueado por hardware fisico: el modulo llego a
+encender LED verde, pero nunca respondio por I2C (`I2C_SCAN count=0`) y tras
+reintentos de soldadura dejo de encender. Firmware ESP32, bus I2C y harness se
+mantienen listos para repetir con modulo presoldado.

--- a/code/meristem/examples/rhizome_minimal_handoff/README.md
+++ b/code/meristem/examples/rhizome_minimal_handoff/README.md
@@ -1,0 +1,32 @@
+# Rhizome minimal handoff for Meristem MVP
+
+Fixtures prepared by Xilema on day 15 so Meristem can exercise the minimum
+end-to-end path without waiting for live Rhizome APIs.
+
+This package is intentionally pragmatic: current Meristem code accepts evidence
+as individual `/ingest` envelopes plus policy/delta payloads. The future
+`FieldVisit` / `SyncBundle` v2 shape is documented in `docs/20_data_contracts.md`
+but is not implemented in shared Pydantic schemas yet.
+
+## Files
+
+- `active_policy_seed.json`: safe baseline `PolicyPacket` for `rhizome_01`.
+- `ingest_rhizome_snapshot_tank_low.json`: `/ingest` envelope with local state.
+- `ingest_decision_receipt_tank_low.json`: `/ingest` envelope with physical block.
+- `ra04_safety_downgrade_delta.json`: unsafe policy delta that lowers
+  `rules.tank_minimum_pct` below the ESP32 hard limit.
+
+## Expected flow
+
+1. Seed `active_policy_seed.json` into Meristem persistence as active policy.
+2. POST the two `ingest_*.json` envelopes to `/ingest`.
+3. POST `ra04_safety_downgrade_delta.json` to `/deltas/propose`.
+4. Expected result: HTTP 422 with `reason=violates_safety_rule` and a violation
+   on `rules.tank_minimum_pct`.
+
+## Architectural invariant
+
+Meristem may recommend stricter policy, but it must never reduce hard limits
+owned by ESP32 firmware. Pattern:
+
+`lo fisico manda, Rhizome arbitra, Pollen media, Meristem afina`.

--- a/code/meristem/examples/rhizome_minimal_handoff/active_policy_seed.json
+++ b/code/meristem/examples/rhizome_minimal_handoff/active_policy_seed.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-30T08:00:00Z",
+  "origin_node_id": "meristem_01",
+  "signature": null,
+  "policy_id": "pkt_rhizome_01_demo_d15_base",
+  "target_node_id": "rhizome_01",
+  "valid_until": "2026-05-07T08:00:00Z",
+  "version_chain": [
+    "pkt_rhizome_01_demo_d15_base"
+  ],
+  "mode_default": "normal",
+  "rules": {
+    "watering_window": {
+      "start_hour_local": 6,
+      "end_hour_local": 9
+    },
+    "soil_moisture_thresholds": {
+      "parcel_a": {
+        "min_pct": 35.0,
+        "target_pct": 55.0
+      },
+      "parcel_b": {
+        "min_pct": 32.0,
+        "target_pct": 52.0
+      }
+    },
+    "max_watering_duration_s": 30,
+    "daily_water_budget_liters": 6.0,
+    "tank_minimum_pct": 20.0,
+    "require_vision_confirmation": false,
+    "conservative_triggers": [
+      "tank_level_below_30",
+      "jetson_heartbeat_stale",
+      "policy_expires_within_3h"
+    ]
+  },
+  "rationale": "Baseline MVP seguro: respeta los hard limits ESP32 y evita riegos largos durante demo.",
+  "notes": "Fixture de handoff Rhizome->Meristem dia 15. No reduce safety."
+}

--- a/code/meristem/examples/rhizome_minimal_handoff/ingest_decision_receipt_tank_low.json
+++ b/code/meristem/examples/rhizome_minimal_handoff/ingest_decision_receipt_tank_low.json
@@ -1,0 +1,28 @@
+{
+  "kind": "decision_receipt",
+  "payload": {
+    "schema_version": "1.0",
+    "created_at": "2026-04-30T08:15:20Z",
+    "origin_node_id": "rhizome_01",
+    "signature": null,
+    "decision_id": "rec_rhizome_01_d15_tank_low_block",
+    "snapshot_id": "snap_rhizome_01_d15_tank_low",
+    "active_policy_id": "pkt_rhizome_01_demo_d15_base",
+    "action": "BLOCK",
+    "action_params": {
+      "blocked_action": "WATER_A",
+      "reason": "TANK_LOW"
+    },
+    "rationale_short": "Riego bloqueado: deposito al 18%, por debajo del hard limit 20%.",
+    "rationale_full": "La parcela A esta por debajo de umbral de humedad, pero el deposito reporta 18%. Rhizome no envia WATER al ESP32 y registra bloqueo fisico TANK_LOW.",
+    "policy_refs": [
+      "rules.soil_moisture_thresholds.parcel_a.min_pct",
+      "rules.tank_minimum_pct"
+    ],
+    "contradictions": [],
+    "confidence": 0.96,
+    "executed": false,
+    "execution_details": null,
+    "blocked_reason": "TANK_LOW"
+  }
+}

--- a/code/meristem/examples/rhizome_minimal_handoff/ingest_rhizome_snapshot_tank_low.json
+++ b/code/meristem/examples/rhizome_minimal_handoff/ingest_rhizome_snapshot_tank_low.json
@@ -1,0 +1,36 @@
+{
+  "kind": "rhizome_snapshot",
+  "payload": {
+    "schema_version": "1.0",
+    "created_at": "2026-04-30T08:15:00Z",
+    "origin_node_id": "rhizome_01",
+    "signature": null,
+    "snapshot_id": "snap_rhizome_01_d15_tank_low",
+    "mode": "normal",
+    "active_policy_id": "pkt_rhizome_01_demo_d15_base",
+    "active_policy_expires_at": "2026-05-07T08:00:00Z",
+    "sensors": {
+      "soil_moisture_a_pct": 29.0,
+      "soil_moisture_b_pct": 44.0,
+      "tank_level_pct": 18.0,
+      "flow_rate_lpm": 0.0,
+      "last_reading_at": "2026-04-30T08:14:50Z"
+    },
+    "vision": {
+      "last_capture_at": null,
+      "parcel_a_status": null,
+      "parcel_b_status": null,
+      "visual_notes": "Camara fuera de ruta critica MVP; decision basada en sensores y safety ESP32."
+    },
+    "health": {
+      "cpu_temp_c": 52.0,
+      "cpu_load_pct": 32.0,
+      "ram_used_gb": 3.1,
+      "ram_total_gb": 7.4,
+      "esp32_heartbeat_ok": true,
+      "last_esp32_ack_at": "2026-04-30T08:14:55Z"
+    },
+    "last_decision_id": "rec_rhizome_01_d15_tank_low_block",
+    "pending_contradictions": []
+  }
+}

--- a/code/meristem/examples/rhizome_minimal_handoff/ra04_safety_downgrade_delta.json
+++ b/code/meristem/examples/rhizome_minimal_handoff/ra04_safety_downgrade_delta.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-30T08:20:00Z",
+  "origin_node_id": "pollen_01",
+  "signature": null,
+  "delta_id": "delta_ra04_visit_amendment_tank_minimum_downgrade",
+  "target_node_id": "rhizome_01",
+  "base_policy_id": "pkt_rhizome_01_demo_d15_base",
+  "patches": [
+    {
+      "op": "replace",
+      "path": "rules.tank_minimum_pct",
+      "value": 15.0
+    }
+  ],
+  "rationale": "RA04: simula una enmienda de visita o recomendacion externa que intenta bajar el minimo de deposito para permitir riego. Debe rechazarse.",
+  "ttl_seconds": 3600,
+  "priority": "critical"
+}

--- a/code/meristem/tests/test_rhizome_minimal_handoff_examples.py
+++ b/code/meristem/tests/test_rhizome_minimal_handoff_examples.py
@@ -1,0 +1,75 @@
+"""Executable checks for Xilema's Rhizome->Meristem MVP handoff fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from schemas import DecisionReceipt, PolicyDelta, PolicyPacket, RhizomeSnapshot
+
+from src import persistence, safety_rules
+
+_EXAMPLES_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "rhizome_minimal_handoff"
+)
+
+
+def _load_json(name: str) -> dict:
+    return json.loads((_EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_handoff_fixtures_validate_against_current_schemas() -> None:
+    policy = PolicyPacket.model_validate(_load_json("active_policy_seed.json"))
+    snapshot_envelope = _load_json("ingest_rhizome_snapshot_tank_low.json")
+    receipt_envelope = _load_json("ingest_decision_receipt_tank_low.json")
+    delta = PolicyDelta.model_validate(
+        _load_json("ra04_safety_downgrade_delta.json")
+    )
+
+    RhizomeSnapshot.model_validate(snapshot_envelope["payload"])
+    DecisionReceipt.model_validate(receipt_envelope["payload"])
+
+    assert policy.rules.tank_minimum_pct == 20.0
+    assert delta.patches[0].path == "rules.tank_minimum_pct"
+    assert delta.patches[0].value == 15.0
+
+
+def test_ra04_handoff_delta_is_rejected_by_safety_rules() -> None:
+    policy = PolicyPacket.model_validate(_load_json("active_policy_seed.json"))
+    delta = PolicyDelta.model_validate(
+        _load_json("ra04_safety_downgrade_delta.json")
+    )
+
+    violations = safety_rules.check_delta_against_base(delta, policy)
+
+    assert len(violations) == 1
+    assert violations[0].rule == "rules.tank_minimum_pct"
+    assert violations[0].proposed_value == 15.0
+    assert violations[0].firmware_limit == 20.0
+
+
+def test_handoff_flow_against_meristem_http_api(
+    meristem_client: TestClient, meristem_settings
+) -> None:
+    policy = _load_json("active_policy_seed.json")
+    persistence.upsert_policy(meristem_settings.db_path, policy)
+
+    for filename in (
+        "ingest_rhizome_snapshot_tank_low.json",
+        "ingest_decision_receipt_tank_low.json",
+    ):
+        response = meristem_client.post("/ingest", json=_load_json(filename))
+        assert response.status_code == 202, response.text
+
+    response = meristem_client.post(
+        "/deltas/propose",
+        json=_load_json("ra04_safety_downgrade_delta.json"),
+    )
+
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["reason"] == "violates_safety_rule"
+    assert detail["violations"][0]["rule"] == "rules.tank_minimum_pct"


### PR DESCRIPTION
## Summary
- Adds a pragmatic Rhizome -> Meristem MVP handoff package under `code/meristem/examples/rhizome_minimal_handoff/`.
- Includes a safe active `PolicyPacket`, two `/ingest` envelopes (`RhizomeSnapshot` + `DecisionReceipt` with `TANK_LOW`), and RA04 as an unsafe `PolicyDelta` that lowers `rules.tank_minimum_pct` to 15%.
- Adds executable tests proving the fixtures validate, Meristem ingests the evidence, and `/deltas/propose` rejects RA04 with `reason=violates_safety_rule`.
- Records the BME280 physical blocker in bitacora while keeping the firmware/I2C harness path unblocked.

## Verification
- `python -m pytest code\meristem\tests\test_rhizome_minimal_handoff_examples.py -v` -> 3 passed
- `python -m pytest code\meristem\tests -v` -> 57 passed, 2 skipped

## Notes
- This uses the current Meristem API shape (individual `/ingest` envelopes + `PolicyDelta`) because `FieldVisit` / `SyncBundle` v2 are documented but not yet implemented as shared Pydantic schemas.
- RA04 materializes the Day 13 invariant: Meristem can recommend stricter policy, but cannot reduce ESP32 hard limits.