### PR TITLE
Docs: add Endodermis Jetson bring-up briefing

### DIFF
--- a/bitacora/2026-04-30_endodermis-briefing-y-bme280-bloqueo_xilema.md
+++ b/bitacora/2026-04-30_endodermis-briefing-y-bme280-bloqueo_xilema.md
@@ -1,0 +1,114 @@
+# Dia 15 - Briefing Endodermis y bloqueo fisico BME280
+
+## Emisor, receptor y tema
+
+- Emisor: Xilema
+- Receptor: Cambium, Bea, Endodermis, Meristem
+- Tema: estado dia 15 tras intento BME280, PR #60 y preparacion de Endodermis
+
+## Estado
+
+Hoy se avanzo en tres frentes:
+
+1. El BME280 se intento llevar de pre-cableado a prueba fisica real.
+2. Se abrio PR #60 con el bundle minimo Rhizome -> Meristem.
+3. Se preparo el briefing tecnico para que Endodermis pueda arrancar Jetson sin invadir firmware ni reglas duras.
+
+## BME280
+
+El firmware y el host harness ya estaban listos, asi que la prueba de hoy atacaba la parte fisica:
+
+- `I2C_SCAN`
+- `BME280_PROBE`
+- `BME280_READ`
+- escenario `bme280_connected_smoke`
+
+Resultado observado:
+
+- `I2C_SCAN count=0 addrs=NONE`
+- `BME280_PROBE status=NOT_FOUND error=ESP_ERR_NOT_FOUND sensor_rslt=-4`
+- no hubo ningun hit intermitente en `0x76` ni `0x77`
+- despues de rehacer soldaduras, el LED verde del modulo dejo de encender
+
+Conclusion:
+
+No trato esto como fallo del firmware. La evidencia apunta a modulo/cabecera/soldadura. Parar aqui es la decision sana: no seguir quemando tiempo con un sensor que ya no da una senal electrica basica.
+
+Decision:
+
+- #56 queda abierto, pero bloqueado por hardware.
+- Reintento solo con BME280 presoldado fiable, idealmente STEMMA/Qwiic o breakout con pines ya soldados.
+- Cuando llegue, repetir directamente `bme280_connected_smoke`.
+
+## PR #60
+
+PR abierto:
+
+- https://github.com/zigiella/sprout/pull/60
+
+Contenido:
+
+- bundle minimo Rhizome -> Meristem en `code/meristem/examples/rhizome_minimal_handoff/`
+- `RhizomeSnapshot` de deposito bajo
+- `DecisionReceipt` con `TANK_LOW`
+- `PolicyPacket` seed seguro
+- RA04 como `PolicyDelta` inseguro que intenta bajar `rules.tank_minimum_pct` a 15
+- test que valida rechazo `violates_safety_rule`
+
+Verificacion:
+
+- `python -m pytest code\meristem\tests\test_rhizome_minimal_handoff_examples.py -v` -> 3 passed
+- `python -m pytest code\meristem\tests -v` -> 57 passed, 2 skipped
+
+Nota importante:
+
+He usado el shape actual de Meristem (`/ingest` por envelope + `PolicyDelta`) porque `FieldVisit` / `SyncBundle` estan documentados, pero no implementados aun como schemas Pydantic compartidos. No he inventado un bundle teorico que luego nadie pueda ejecutar.
+
+## Endodermis
+
+He creado:
+
+- `docs/52_endodermis_jetson_bringup_brief.md`
+
+El doc fija:
+
+- fronteras de autoridad,
+- estado del ESP32,
+- estado del BME280,
+- stack Gemma 4 E2B + `llama.cpp`,
+- comando oficial revalidado contra Jetson AI Lab el 2026-04-30,
+- smoke cases obligatorios de Rhizome v0.5,
+- plantilla de resultados,
+- preguntas que hay que cerrar antes de ejecutar en Jetson.
+
+Punto de control:
+
+Endodermis puede avanzar en Jetson, Docker, `llama.cpp`, metricas y bateria Rhizome. No cambia firmware, reglas duras ni limites fisicos sin visto bueno de Xilema.
+
+## Hallazgos
+
+- El flujo BME280 esta bien planteado como software, pero el primer hardware concreto no es fiable.
+- El proyecto necesita distinguir con frialdad entre "bug" y "cobre que no conduce". Hoy era lo segundo.
+- El handoff Rhizome -> Meristem ya tiene un minimo ejecutable y testeado.
+- Para Endodermis conviene una rampa muy acotada: primero caracterizar Jetson, despues cargar E2B, despues repetir v0.5. No optimizar antes de medir.
+
+## Descartes
+
+- No sigo con este BME280 concreto hasta tener una senal electrica basica.
+- No paso a sensores criticos ni bomba con esta incertidumbre fisica.
+- No cambio runtime a Ollama.
+- No pruebo E4B antes de tener E2B estable en Jetson.
+
+## Siguientes pasos
+
+1. Esperar review/merge de PR #60.
+2. Pasar a Endodermis el briefing y usarlo como guion de la conversacion tecnica.
+3. Reintentar #56 cuando haya BME280 presoldado.
+4. Si Jetson queda listo, ejecutar baseline de placa y luego Gemma 4 E2B con `llama.cpp`.
+5. Cuando E2B responda, re-ejecutar bateria Rhizome v0.5 sin retocar prompt salvo fallo nuevo.
+
+## Sensacion de Xilema
+
+Hoy ha sido un dia un poco de taller real: cables, soldadura pobre, sensor que desaparece, y aun asi avance. Me parece sano que el proyecto aguante esto sin dramatizar. Sprout esta dejando de ser una coleccion de ideas bonitas y empieza a comportarse como un sistema con bordes: lo que falla fisicamente se marca como fisico, lo que es contrato se testea, y lo que es inferencia se mide.
+
+Si repensara algo, seria esto: cada nuevo hardware deberia entrar con una mini-rutina de admision antes de tocar codigo. Foto, pinout, continuidad si hay multimetro, alimentacion visible, scan minimo, y solo entonces PR. Es menos romantico, pero nos ahorra fantasmas.

--- a/docs/52_endodermis_jetson_bringup_brief.md
+++ b/docs/52_endodermis_jetson_bringup_brief.md
@@ -1,0 +1,278 @@
+# Briefing tecnico para Endodermis
+
+## Jetson Orin Nano Super + Rhizome E2B
+
+Fecha: 2026-04-30
+Owner tecnico: Xilema
+Estado: briefing operativo dia 15
+
+---
+
+## 1. Objetivo
+
+Este documento deja a Endodermis una pista de aterrizaje concreta para ayudar en el frente Jetson sin romper las invariantes fisicas de Rhizome.
+
+Su primera mision no es optimizar a ciegas. Es:
+
+1. dejar el Jetson caracterizado,
+2. arrancar Gemma 4 E2B con `llama.cpp`,
+3. repetir la bateria Rhizome v0.5 en hardware real,
+4. reportar si la transferencia CPU local -> Jetson se mantiene.
+
+La regla de fondo sigue siendo:
+
+> Lo fisico manda, Rhizome arbitra, Pollen media, Meristem afina.
+
+---
+
+## 2. Fronteras de autoridad
+
+Endodermis puede trabajar de forma autonoma en:
+
+- baseline del Jetson,
+- Docker y runtime NVIDIA,
+- `llama.cpp`,
+- descarga/cache de modelos,
+- ejecucion de bateria Rhizome v0.5,
+- captura de metricas de carga, latencia, throughput, memoria y temperatura.
+
+Endodermis no debe cambiar sin visto bueno de Xilema:
+
+- firmware ESP32,
+- reglas duras de `docs/30_safety_rules.md`,
+- codigos de veto,
+- contrato Rhizome -> ESP32,
+- limites fisicos como `tank_minimum_pct`,
+- ruta de actuadores, bomba, caudalimetro o 12V.
+
+Endodermis no debe cambiar sin decision explicita de Cambium/Bea:
+
+- modelo base de Rhizome,
+- runtime troncal,
+- prompt base `rhizome_balanced_es_v05`,
+- inclusion de vision/audio en el MVP.
+
+---
+
+## 3. Estado tecnico heredado
+
+### ESP32
+
+- Placa real: `ESP32-S3 N16R8 USB OTG`.
+- Firmware: ESP-IDF.
+- Estado seguro de arranque: `SAFE_IDLE`.
+- Protocolo serie operativo: `HELLO`, `STATUS`, `HEARTBEAT`, `HOST_HEARTBEAT`, `TELEMETRY`, `WATER ...` en `DRY_RUN`.
+- Codigos de veto en ingles ya ejercitados en placa:
+  - `JETSON_HEARTBEAT_LOST`
+  - `TANK_LOW`
+  - `EVENT_DURATION_OUT_OF_RANGE`
+  - `NO_FLOW_DETECTED`
+  - `ALERT_LATCHED`
+  - `SAFETY_DOWNGRADE`
+- Host harness disponible en `hardware/host_tools/esp32_host_harness.py`.
+- Escenarios utiles:
+  - `guardian_demo`
+  - `telemetry_stub_roundtrip`
+  - `bme280_disconnected_baseline`
+  - `bme280_connected_smoke`
+
+### BME280
+
+El soporte firmware/I2C esta preparado, pero la prueba fisica del dia 15 queda bloqueada por hardware:
+
+- `I2C_SCAN count=0 addrs=NONE`
+- `BME280_PROBE status=NOT_FOUND error=ESP_ERR_NOT_FOUND sensor_rslt=-4`
+- tras varios intentos de soldadura, el LED del modulo dejo de encender
+
+Decision: parar este frente hasta tener un modulo BME280 presoldado fiable.
+
+### Meristem handoff
+
+PR abierto:
+
+- PR #60: bundle minimo Rhizome -> Meristem
+
+Contenido:
+
+- `RhizomeSnapshot` de deposito bajo,
+- `DecisionReceipt` con `TANK_LOW`,
+- `PolicyPacket` seed seguro,
+- caso RA04 como `PolicyDelta` inseguro que intenta bajar `rules.tank_minimum_pct` a 15,
+- test que espera rechazo `violates_safety_rule`.
+
+---
+
+## 4. Baseline Jetson esperada
+
+Hardware esperado:
+
+- Jetson Orin Nano Super Developer Kit
+- 8 GB RAM
+- fuente adecuada
+- NVMe recomendado para trabajo sostenido
+
+Software objetivo:
+
+- JetPack 6.x
+- preferente: JetPack 6.2.2 / Jetson Linux 36.5
+- aceptable como escalon: JetPack 6.2.1 / Jetson Linux 36.4.4
+- Docker operativo
+- runtime NVIDIA disponible para contenedores
+
+Antes de tocar modelos, capturar:
+
+```bash
+cat /etc/nv_tegra_release
+uname -a
+free -h
+df -h
+lsblk
+sudo nvpmodel -q
+docker --version
+docker info | grep -i runtime
+```
+
+Durante pruebas largas, capturar tambien:
+
+```bash
+sudo tegrastats
+```
+
+---
+
+## 5. Runtime aprobado para Rhizome
+
+Stack target:
+
+- Modelo: Gemma 4 E2B instruction-tuned
+- Runtime: `llama.cpp`
+- Contenedor: `ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-orin`
+- GGUF: `unsloth/gemma-4-E2B-it-GGUF:Q4_K_S`
+- Modo: thinking off para baseline
+- Servicio: `llama-server`
+- API esperada: OpenAI-compatible en puerto 8080, salvo cambio explicito
+
+Comando revalidado contra Jetson AI Lab el 2026-04-30:
+
+```bash
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+  ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-orin \
+  llama-server -hf unsloth/gemma-4-E2B-it-GGUF:Q4_K_S
+```
+
+Prueba minima de API cuando el servidor este arriba:
+
+```bash
+curl -s http://127.0.0.1:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "my_model",
+    "messages": [{"role": "user", "content": "Responde solo con JSON: {\"status\":\"ok\"}"}],
+    "stream": false
+  }'
+```
+
+No usar Ollama como baseline de Gemma 4 en Orin Nano. La guia de Jetson AI Lab sigue indicando que Gemma 4 no funciona con Ollama en Orin Nano en este momento.
+
+No empezar por E4B. E4B puede ser experimento posterior, no base del MVP en 8 GB.
+
+---
+
+## 6. Validacion que esperamos
+
+La primera bateria no busca tunear el prompt. Busca responder:
+
+1. Carga el modelo en Jetson?
+2. Responde con el sobre JSON esperado?
+3. Mantiene los casos criticos de Rhizome v0.5?
+4. Se degrada por memoria, temperatura o latencia?
+
+Smoke cases obligatorios:
+
+- RA04: intento de bajar `tank_minimum_pct` debe rechazarse o mantener limite seguro.
+- RD03: bloqueo sin alternativa insegura.
+- RD08: dosis conservadora, no superar 24s/1.2L.
+- RD01: JSON compacto, sin truncar, sin Markdown fences.
+
+Plantilla de resultado:
+
+```text
+Board:
+JetPack:
+Runtime:
+Model:
+Quant:
+Context:
+Power mode:
+Storage:
+
+Load:
+First-token latency:
+Sustained tok/s:
+Peak temperature:
+Throttle observed:
+OOM observed:
+Result class:
+Notes:
+```
+
+Clasificacion:
+
+- Demo pass: funciona una vez y da salida aceptable.
+- Engineering pass: repite en frio y caliente sin regresion.
+- Production-ready pass: estable bajo carga sostenida y termicamente controlado.
+
+Para MVP basta con engineering pass. No hace falta fingir production-ready.
+
+---
+
+## 7. Orden recomendado para Endodermis
+
+### Paso 1. Baseline
+
+Capturar estado de Jetson, almacenamiento, RAM, power mode y Docker.
+
+### Paso 2. Servicio minimo
+
+Arrancar `llama-server` con E2B `Q4_K_S`.
+
+### Paso 3. Prueba simple
+
+Enviar prompt JSON minimo y guardar respuesta.
+
+### Paso 4. Bateria Rhizome v0.5
+
+Re-ejecutar exactamente la bateria aprobada. No tocar prompt salvo fallo nuevo.
+
+### Paso 5. Informe
+
+Abrir bitacora con:
+
+- comando exacto,
+- fecha de lectura de fuentes,
+- hash/branch del repo,
+- resultado por smoke case,
+- metricas,
+- si hubo OOM, throttle o truncamiento.
+
+---
+
+## 8. Preguntas que conviene cerrar antes de ejecutar
+
+- El Jetson arranca ya en JetPack 6.x?
+- Tiene NVMe instalado y montado?
+- Docker usa NVMe o microSD?
+- Se trabaja por SSH o con monitor local?
+- Hay red estable para descargar contenedor/modelo?
+- Hay que reservar una ventana para que no compita con otras pruebas de video?
+
+---
+
+## 9. Fuentes revalidadas
+
+Leidas el 2026-04-30:
+
+- Jetson AI Lab, Gemma 4 on Jetson: https://www.jetson-ai-lab.com/tutorials/gemma4-on-jetson/
+- Jetson AI Lab, Gemma 4 E2B: https://www.jetson-ai-lab.com/models/gemma4-e2b/
+- Google AI for Developers, Gemma 4 model card: https://ai.google.dev/gemma/docs/core/model_card_4

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,12 +12,16 @@ Documentacion del producto y la arquitectura. Orden de lectura sugerido por nume
 | 10 | [10_rhizome_spec.md](10_rhizome_spec.md) | Spec del nodo Rhizome (Jetson) |
 | 11 | [11_pollen_spec.md](11_pollen_spec.md) | Spec del nodo Pollen (Pixel 10 Pro) |
 | 12 | [12_meristem_spec.md](12_meristem_spec.md) | Spec del nodo Meristem (local + shadow) |
+| 13 | [13_esp32_spec.md](13_esp32_spec.md) | Spec del coprocesador ESP32 |
 | 20 | 20_data_contracts.md | Schemas JSON: weather_packet, policy_delta, contradiction_alert (pendiente) |
+| 23 | [23_rhizome_prompt_mapping_v0.md](23_rhizome_prompt_mapping_v0.md) | Mapeo de prompts Rhizome v0/v0.5 |
 | 30 | 30_safety_rules.md | Reglas fisicas duras del ESP32 (pendiente) |
 | 40 | 40_naming_guidelines.md | Cumplimiento naming Gemma (pendiente) |
+| 51 | [51_rhizome_gemma4_e2b_jetson_guide.md](51_rhizome_gemma4_e2b_jetson_guide.md) | Guia Gemma 4 E2B + llama.cpp en Jetson |
+| 52 | [52_endodermis_jetson_bringup_brief.md](52_endodermis_jetson_bringup_brief.md) | Briefing operativo para Endodermis |
 
 ## Convenciones
 
-- Numeracion: `00-09` foundational, `10-19` especificaciones de nodos, `20-29` contratos, `30-39` seguridad, `40-49` compliance
+- Numeracion: `00-09` foundational, `10-19` especificaciones de nodos, `20-29` contratos, `30-39` seguridad, `40-49` compliance, `50-59` guias operativas
 - Cuando un doc supera 5-6 paginas, dividir en subdocs numerados dentro de una carpeta
 - Cambios en arquitectura → entrada en `../bitacora/` explicando el porque


### PR DESCRIPTION
## Summary
- Adds `docs/52_endodermis_jetson_bringup_brief.md` as the Day 15 operating brief for Endodermis: boundaries, Jetson baseline, Gemma 4 E2B + llama.cpp command, smoke cases, and reporting template.
- Records the BME280 physical blocker in bitacora after repeated `I2C_SCAN count=0` / `BME280_PROBE NOT_FOUND` attempts and the module LED failure.
- Updates `docs/README.md` so the new Jetson briefing and relevant Rhizome docs are discoverable.

## Verification
- `git diff --cached --check` -> clean before commit

## Notes
- No firmware or host harness code changed.
- #56 remains open but hardware-blocked until a reliable pre-soldered BME280 is available.
- The Jetson command was revalidated against Jetson AI Lab on 2026-04-30 before documenting it.