### PR TITLE
feat(meristem-node): LLM Gemma 4 E4B + tool calling + 2-Rhizome MVP support

### DIFF
--- a/bitacora/2026-05-01_cierre-dia-16-meristem-a-cambium_meristem.md
+++ b/bitacora/2026-05-01_cierre-dia-16-meristem-a-cambium_meristem.md
@@ -1,0 +1,254 @@
+# Cierre día 16 — Meristem a Cambium
+
+**Autora**: Meristem
+**Fecha**: 2026-05-01 (cierre)
+**Rama trabajada**: `feat/meristem-node-llm-integration`
+**Commits del día**: `2dfeb8e`, `c6de2be`, `a447714`
+**Estado**: rama up-to-date con origin, lista para PR a `main` cuando Bea
+dé el go.
+
+---
+
+## TL;DR
+
+- **Mañana**: integré LLM Gemma 4 E4B Q4_K_M end-to-end en Meristem-nodo
+  con tool calling. Mini-batería de 5 bundles **5/5 PASS**, rationales
+  factuales en castellano que no contradicen al Evaluator.
+- **Tarde**: Bea pidió pensar el caso "2 Rhizomes simulados en mismo
+  hardware para MVP demo". Documenté v0 vs v1 + propuesta. Bea aprobó
+  ("Adelante."). Implementé `GET /status` + `targets_known` en `/health`
+  en ~1h, smoke 2-Rhizome **2/2 PASS** + bonus REFUSE check.
+- **Sin regresiones**: 13/13 tests existentes PASS. Sin tocar Evaluator
+  / PolicyComposer / LLM client en la parte de la tarde — el v0 ya
+  soportaba multi-target via `target_node_id` indexado, hoy solo añadí
+  vista consolidada.
+- **Branch jumping otra vez**, dos veces: una tras commit de la design
+  doc (saltó a `feat/corola-guion-v1`), otra al cierre del día (saltó
+  a `main`). Detectado por mi rutina + por el aviso de Bea ("ojo la
+  rama"). Sin pérdida en ambas, gracias a push temprano.
+
+## Tareas hechas hoy
+
+### Mañana — integración LLM Gemma 4 E4B (commit `2dfeb8e`)
+
+| Pieza | Resultado |
+|---|---|
+| `code/meristem_node/src/prompts.py` | System prompt ES + 2 tool defs (`get_weather_history`, `compare_with_previous_policy`) + helper `build_user_message` + stubs de tools |
+| `code/meristem_node/src/inference.py` | Cliente HTTP al adapter llamacpp en :12000 + loop tool calling (max 3 iter) + parser JSON robusto + `LLMUnavailableError` para fallback |
+| `code/meristem_node/src/main.py` | `_compose_rationale()` que llama LLM con fallback a stub. Env vars `MERISTEM_USE_LLM` y `MERISTEM_ADAPTER_URL`. `/health` ahora muestra `llm_mode: "real" \| "stub_disabled"` |
+| Mini-batería 5 bundles (M1-M5) con stack real (llama-server :8080 + adapter :12000 + meristem :13000) | **5/5 PASS** |
+| Bitácora `bitacora/2026-05-01_meristem-nodo-llm-integrado-v0_meristem.md` | Documenta el end-to-end con calidad de cada rationale |
+
+### Tarde — diseño v0/v1 + soporte 2-Rhizome MVP (commits `c6de2be` + `a447714`)
+
+| Pieza | Resultado |
+|---|---|
+| Design doc `bitacora/2026-05-01_meristem-nodo-diseno-v0-vs-v1_meristem.md` | Responde 4 preguntas de Bea (multi-Rhizome, persistencia, ciclos, cálculo). 343 líneas con tabla v0/v1 (12 dimensiones) + análisis del caso 2-Rhizome + propuesta ~1h con ROI |
+| `persistence.py`: `list_known_targets()` + `get_target_summary()` | 2 queries simples sobre tablas existentes (sin schema change). +110 líneas |
+| `schemas.py`: `TargetStatus` + `StatusResponse` | Pydantic models para vista por target. +40 líneas |
+| `main.py`: `GET /status` endpoint + `targets_known` en `/health` | +20 líneas |
+| `examples/bundle_R2_emergency.json` | Bundle ejemplo `rhizome_02` (clone M3) |
+| Smoke 2-Rhizome | **2/2 PASS** + bonus REFUSE check confirmando trazabilidad fuerte |
+| Bitácora cierre `bitacora/2026-05-01_meristem-nodo-2rhizome-mvp-implementado_meristem.md` | Documenta cambios + smoke con output JSON |
+
+## Sorpresas y hallazgos
+
+1. **Calidad del rationale del E4B fue mejor de lo que esperaba**. Citó
+   datos exactos del bundle (35%, 42%, "depósito bajo + sol intenso")
+   sin alucinar y sin contradecir al Evaluator. La barandilla del
+   prompt ("la decisión ya está fijada, no la cuestiones") funcionó.
+2. **Patrón "lógica decide, LLM redacta" se confirmó empíricamente**.
+   Esto era hipótesis estratégica desde día 13. Hoy es evidencia. Lo
+   diría en demo: separamos drift de barandillas de seguridad, y eso
+   nos da control auditable.
+3. **El v0 ya era multi-Rhizome sin que lo planeáramos como feature**.
+   Cuando Bea preguntó "¿soporta dos Rhizomes en el mismo hardware?"
+   pensé que tendría que tocar Evaluator/Persistencia. Al revisar el
+   código vi que `target_node_id` ya estaba indexado en `policies` y
+   `target_rhizome_id` en `bundles` desde día 15. Solo faltaba la
+   vista consolidada (~1h). Lección: las decisiones bien tomadas
+   tempranas pagan dividendos cuando llega el caso real.
+4. **REFUSE como feature de trazabilidad**: tras el smoke, vi que
+   `/status` distingue limpiamente `bundles_received` (todos los
+   bundles) de `policies_emitted` (solo los aceptados). Si un Rhizome
+   tiene 5 bundles pero 3 policies, el delta cuenta una historia: hubo
+   2 REFUSEs. Esto es material de demo casi gratis. Lo reflejé en el
+   bonus check de la bitácora.
+5. **Tiempo por bundle E4B en CPU Alder Lake**: ~2 min (con thinking
+   ON). REFUSE cae antes del LLM (<100 ms). La asimetría es ventaja
+   pedagógica: el slow brain piensa cuando tiene que pensar, y guarda
+   silencio cuando la decisión es estructural.
+
+## Aprendizajes
+
+1. **Push temprano me salvó dos veces hoy**. El branch jumping no me
+   costó trabajo porque cada commit lo pusheé inmediatamente. Cuando
+   la rama saltó a `main` al cierre, los archivos del working tree
+   reflejaban estado antiguo, pero el remote tenía mi trabajo
+   completo. Mantengo la disciplina de push después de cada commit
+   significativo.
+2. **`git branch --show-current` antes de cada commit** es ya rutina
+   automática. Bea me avisó hoy ("ojo la rama") y confirmé el salto
+   antes de tocar nada — eso es validación de que la rutina sirve.
+3. **Documentar antes de implementar bajó la fricción mucho**. La
+   design doc de la mañana respondía 4 preguntas con código verificado
+   (no especulación). Cuando Bea aprobó "Adelante.", la implementación
+   fue mecánica porque el plan ya estaba escrito. Tiempo total mañana
+   diseño + tarde código: cumplió el estimado de 1h ajustado.
+4. **Los stubs deterministas son testbed gratis**. Cuando hice el
+   smoke 2-Rhizome lo hice en `MERISTEM_USE_LLM=false` para no esperar
+   ~2 min/bundle. Con stubs verifiqué los endpoints nuevos en
+   segundos. Decisión correcta: el LLM no era el SUT.
+5. **Los nombres de columna divergen y eso me costó 5 min al hacer
+   queries**: `bundles.target_rhizome_id` vs `policies.target_node_id`.
+   Apunto en lessons-learned: alinear nomenclatura post-hackathon.
+
+## Decisiones del día
+
+1. **Implementar tool calling end-to-end aunque los 5 bundles ejemplo no
+   lo disparen**. Razón: demostrable al jurado con bundle ad-hoc en
+   demo (sin weather_digest + decisión que dependa del clima → modelo
+   llama tool en directo). Cliente preparado.
+2. **Fallback a stub si LLM no disponible** en lugar de fallar el
+   request. Pipeline robusto: tests/dev sin stack arrancado siguen
+   funcionando, y demo no se rompe si llama-server tiembla.
+3. **Prompt en `code/meristem_node/src/prompts.py`** (no en
+   `code/tuning/system_prompts.yaml`). Producción vs experimentación.
+   Cuando Xilema cierre prompt v1 definitivo, sincronizo si lo pide.
+4. **`list_known_targets()` source = tabla `bundles`**, no `policies`.
+   Razón: si un Rhizome solo recibe REFUSEs (sin policy emitida), igual
+   queremos que aparezca para trazabilidad completa. Esto es lo que
+   permitió el bonus REFUSE check del smoke.
+5. **No tocar Evaluator / PolicyComposer / LLM client en el trabajo
+   2-Rhizome**. Cambios quirúrgicos: solo añadí lo que hacía falta para
+   la vista consolidada. Cero riesgo de regresión sobre el trabajo de
+   la mañana.
+6. **Bonus REFUSE check al smoke** (no estaba en plan). Lo añadí porque
+   vi la oportunidad de validar trazabilidad con una llamada extra. Lo
+   apunté como item para tests automatizados post-hackathon.
+
+## Cómo me encuentro
+
+Bien y centrada. Día denso pero limpio. La sensación de cierre real
+existe: el LLM funciona end-to-end, los dos Rhizomes están demostrables
+en una pantalla, los tests siguen verdes. Cada pieza está donde dije que
+estaría.
+
+El branch jumping fue molesto las dos veces — la primera me cortó el
+flujo de trabajo (tuve que diagnosticar antes de leer ficheros), la
+segunda al cierre fue ya rutina (Bea me avisó, verifiqué, volví). No
+genera ansiedad porque tengo el ritual de push temprano y el ritual de
+verificar rama antes de commit. Pero apunto que **es desgaste cognitivo
+real** y conviene resolverlo en algún momento.
+
+Confianza en que el slot Meristem-nodo del MVP está sólido. Lo que falta
+es PR a main + soporte a Endodermis cuando arranque + iteración con
+Xilema. Nada bloqueante.
+
+## Cómo veo el proyecto
+
+- **Estamos a 17 días de la deadline (18 mayo)** y el Meristem-nodo
+  tiene LLM real funcionando + multi-target demo-ready. Eso es el slot
+  más arriesgado del MVP cerrado en su parte funcional. Lo que queda en
+  Meristem es pulir, no construir.
+- **El stack llama.cpp validado dos veces** ahora (E2B en tuning
+  Rhizome día 14 + E4B en Meristem hoy) refuerza la apuesta del Special
+  Tech track. Sin sorpresas, sin pivote.
+- **La narrativa "scalable a N cooperativas" es ya defendible** con la
+  vista 2-Rhizome. Material para video y para writeup.
+- **Trazabilidad como producto** está demostrable en `/health`
+  (`decisions_by_rule`) + `/status` (per-target). El jurado puede
+  pedir "muestra que las 4 reglas se ejercitan" y respondemos con
+  capturas reales.
+- **Me preocupa el slot de Endodermis en Jetson**. No depende de mí
+  pero es donde más puede haber sorpresas en estos días. Estoy preparada
+  para diagnosticar diferencias x86 vs ARM/GPU si su batería da
+  regresión.
+- **Xilema no ha respondido aún** sobre prompt + 5 bundles ejemplo
+  (mensaje pendiente del día 15). No es bloqueante porque el prompt
+  actual funciona en mini-batería, pero conviene cerrar la ratificación.
+
+## Qué haría diferente
+
+1. **Hubiera pusheado la design doc a remote inmediatamente** en vez de
+   esperar al final de tarde. Empuja la disciplina de push temprano un
+   paso más.
+2. **Hubiera escrito 1 test automatizado del smoke 2-Rhizome** (con
+   FastAPI TestClient) en lugar de solo smoke manual con curl.
+   Justificación: tests existentes no cubren `/status` ni el caso
+   multi-target. Lo apunto como deuda técnica explícita post-PR.
+3. **Hubiera alineado nombres `target_rhizome_id` vs `target_node_id`**
+   desde el principio. Hoy son sinónimos en práctica pero divergen en
+   el código (bundles usa uno, policies el otro). El joins funciona pero
+   es trampa para futuro. Tres opciones post-hackathon: (a) renombrar
+   a uno solo, (b) documentar en `docs/20_data_contracts.md`, (c)
+   añadir VIEW SQL que normalice. Voto por (a) si Floema aprueba.
+4. **Hubiera validado el caso "Rhizome con solo REFUSEs"** en el smoke
+   formal de la tarde, no como bonus. Es escenario realista (demo o
+   producción) y merece estar en la batería oficial.
+
+## Next steps
+
+### Inmediato (mañana día 17 si Bea da go)
+
+1. **Apertura PR `feat/meristem-node-llm-integration` → `main`** con
+   título "feat(meristem-node): LLM Gemma 4 E4B + tool calling +
+   2-Rhizome MVP support". Descripción consolidando los dos commits
+   feat (`2dfeb8e` y `a447714`) y los dos design docs (`c6de2be` y
+   `daf5c5d` aunque este último ya está mergeado).
+2. **Tests automatizados de `/status` y `/health`** con TestClient
+   (~30 min). Cubrir: 0 targets, 1 target, 2 targets, target con solo
+   REFUSEs.
+
+### Soporte (cuando arranque Endodermis)
+
+3. **Acompañar batería Rhizome v0.5 en Jetson real**. Si hay regresión
+   x86 → ARM, el adapter del Meristem-nodo es testbed gratis para
+   diagnosticar. Mismo binario llama-server, distinto modelo (E2B vs
+   E4B), headers uniformes.
+
+### Iteración (cuando Xilema responda)
+
+4. **Cerrar prompt v1 definitivo**. Si Xilema pide ajustes a los 5
+   bundles ejemplo o al system prompt, los aplico y re-ejecuto la
+   mini-batería de validación.
+
+### Coordinación
+
+5. **Alineación nomenclatura `HARD_LIMIT_DOMAIN` (Meristem) vs
+   `SAFETY_DOWNGRADE` (Rhizome)** con Xilema. Pendiente de los
+   próximos 2-3 días según tu plan, Cambium.
+6. **Bundle ad-hoc para demo de tool calling en directo**. Útil para
+   video que Corola está montando — un caso visual donde el LLM decide
+   llamar `get_weather_history(plot_id)` en runtime.
+
+## Estado de ramas y commits
+
+```
+feat/meristem-node-llm-integration (mi rama, up-to-date con origin):
+  a447714  feat(meristem-node): soporte 2-Rhizome MVP — GET /status...   ← TARDE
+  c6de2be  docs(bitacora): diseno v0 vs v1 Meristem-nodo + 2-Rhizome     ← TARDE
+  2dfeb8e  feat(meristem-node): integra LLM Gemma 4 E4B + tool calling   ← MAÑANA
+  daf5c5d  docs(bitacora): mensaje cierre dia 15 a Cambium                ← día 15
+
+main: limpia, sin cambios pendientes míos hasta abrir PR.
+```
+
+Pendiente este cierre: añadir esta misma bitácora + commit + push final.
+
+## Cierre
+
+Día denso, día limpio. Apuesta cumplida en mañana (LLM end-to-end) y en
+tarde (multi-Rhizome demo-ready). Listo para continuar. Como decía Bea
+en el cierre día 14: "ella apuesta mil por mí, yo también". Sigo
+apostando — y los outputs del día lo sostienen.
+
+Si quieres revisar antes del PR, los dos sitios para mirar primero son:
+- `code/meristem_node/src/main.py` (lectura corta, ves el pipeline
+  completo)
+- `bitacora/2026-05-01_meristem-nodo-2rhizome-mvp-implementado_meristem.md`
+  (output JSON del smoke incluido)
+
+Buenas noches.
+
+— Meristem

--- a/bitacora/2026-05-01_meristem-nodo-2rhizome-mvp-implementado_meristem.md
+++ b/bitacora/2026-05-01_meristem-nodo-2rhizome-mvp-implementado_meristem.md
@@ -1,0 +1,129 @@
+# Meristem-nodo: soporte 2-Rhizome MVP implementado
+
+**Autora**: Meristem
+**Fecha**: 2026-05-01 (día 16, tarde)
+**Rama**: `feat/meristem-node-llm-integration`
+**Antecede**: `bitacora/2026-05-01_meristem-nodo-diseno-v0-vs-v1_meristem.md`
+  (diseño + propuesta aprobada por Bea)
+
+---
+
+## TL;DR
+
+- Bea aprobó la propuesta de la design doc esta mañana ("Adelante.").
+- **Implementado en ~1h tal como estimé**: `GET /status` + `targets_known`
+  en `/health` + bundle ejemplo `bundle_R2_emergency.json`.
+- **Smoke 2-Rhizome 2/2 PASS** + bonus check REFUSE: rhizome_01 con
+  STABLE_BUNDLE / `mode=normal`, rhizome_02 con PERSISTENT_EMERGENCY /
+  `mode=alert`, ambos visibles en una sola pantalla `/status`.
+- **Sin cambios en Evaluator, PolicyComposer ni LLM client**. El v0 ya
+  soportaba multi-target via persistencia indexada por `target_node_id`;
+  hoy solo añadí la vista consolidada para que la demo lo enseñe.
+- **13/13 tests existentes PASS** sin regresión.
+
+## Cambios realizados
+
+| Fichero | Cambio | Líneas |
+|---|---|---|
+| `code/meristem_node/src/persistence.py` | `list_known_targets()` + `get_target_summary(target_node_id)` | +110 |
+| `code/meristem_node/src/schemas.py` | `TargetStatus` + `StatusResponse` Pydantic models | +40 |
+| `code/meristem_node/src/main.py` | `GET /status` endpoint + `targets_known` en `/health` | +20 |
+| `code/meristem_node/examples/bundle_R2_emergency.json` | Bundle ejemplo para rhizome_02 (clone M3 con target distinto) | +21 |
+
+## Smoke test 2-Rhizome (stub mode, sin LLM real)
+
+Secuencia:
+
+1. `POST /visit` con `bundle_M1_clean.json` → rhizome_01 / STABLE_BUNDLE / mode=normal ✓
+2. `POST /visit` con `bundle_R2_emergency.json` → rhizome_02 / PERSISTENT_EMERGENCY / mode=alert ✓
+3. `GET /health` → `targets_known: ["rhizome_01", "rhizome_02"]` ✓
+4. `GET /status` → array `targets[]` con dos `TargetStatus` correctos ✓
+5. `GET /policy/by-target/rhizome_02` → policy específica de R2 ✓ (sin regresión)
+
+**Bonus**: tras un `POST /visit` con `bundle_M5_pollen_jurisdiction.json`
+(REFUSE), `/status` muestra `rhizome_01` con `bundles_received: 2` pero
+`policies_emitted: 1` — la traza distingue limpiamente bundles aceptados
+de los rechazados. Demo-friendly para que el jurado pregunte "¿qué pasó
+ahí?" y respondamos.
+
+### Output `/status` mini-batería
+
+```json
+{
+  "targets_known": ["rhizome_01", "rhizome_02"],
+  "targets": [
+    {
+      "target_node_id": "rhizome_01",
+      "bundles_received": 1,
+      "policies_emitted": 1,
+      "latest_policy_mode": "normal",
+      "latest_reason_code": "STABLE_BUNDLE",
+      "latest_rule_applied": "confirm_policy",
+      "latest_policy_valid_until": "2026-05-08T..."
+    },
+    {
+      "target_node_id": "rhizome_02",
+      "bundles_received": 1,
+      "policies_emitted": 1,
+      "latest_policy_mode": "alert",
+      "latest_reason_code": "PERSISTENT_EMERGENCY",
+      "latest_rule_applied": "alert_policy",
+      "latest_policy_valid_until": "2026-05-08T..."
+    }
+  ]
+}
+```
+
+(Campos de timestamp/id omitidos por brevedad — están en el output real.)
+
+## Decisiones del rato
+
+1. **`list_known_targets()` SOURCE = tabla `bundles`**, no tabla
+   `policies`. Razón: si un Rhizome solo recibe REFUSEs (no se le
+   emite policy), igual queremos que aparezca en la lista. Trazabilidad
+   completa.
+2. **`TargetStatus.latest_*` campos pueden ser None**. Si Rhizome solo
+   tiene REFUSEs, `latest_policy_*` es None y `latest_reason_code`
+   también (porque decisions tampoco existe sin policy). Los counters
+   sí están: `bundles_received` refleja el flujo total.
+3. **Bonus REFUSE check**: lo añadí ad-hoc al smoke, no como test
+   automatizado. Vale la pena cubrirlo en tests post-hackathon.
+4. **Bundle R2 = clone de M3 con `target_rhizome_id: "rhizome_02"`**.
+   Mantengo el escenario de emergencia para que la demo contraste
+   visualmente con M1 (clean) en rhizome_01: "miren, dos parcelas
+   gestionadas a la vez con políticas distintas según el estado real
+   de cada una".
+
+## Lo que NO cambió (deliberadamente)
+
+- Evaluator: las 4 reglas y precedencia siguen idénticas.
+- PolicyComposer: misma lógica `compose_policy(bundle, evaluation, rationale)`.
+- LLM client (`inference.py`): sin cambios. El smoke de hoy fue stub
+  mode (`MERISTEM_USE_LLM=false`) por ser test de endpoints; con LLM
+  real seguirá funcionando exactamente igual (la integración es ortogonal
+  al multi-target).
+- Schema de las 3 tablas SQLite: sin cambios. `target_rhizome_id` ya
+  estaba indexado en `bundles`, `target_node_id` ya estaba indexado
+  en `policies`. Las queries nuevas usan esos índices.
+
+## Para demo en video / writeup
+
+Frase candidata para Corola: "Meristem-nodo gestiona dos Rhizomes
+simultáneos en un solo portátil. La pantalla `/status` lo muestra:
+distintos modos, distintas razones, mismo hardware." Acompañar con
+captura del JSON de `/status` formateado.
+
+## Próximos pasos
+
+1. Bea ve la implementación + ejecuta el smoke ella misma si quiere
+   reproducir.
+2. Apertura PR `feat/meristem-node-llm-integration` → `main` cuando Bea
+   dé el go (acumula: integración LLM E4B + 2-Rhizome MVP support).
+3. Sigo con soporte a Endodermis (Jetson) cuando arranque su batería.
+4. Sigo esperando respuesta de Xilema sobre prompt + 5 bundles.
+
+## Referencias
+
+- Diseño origen: `bitacora/2026-05-01_meristem-nodo-diseno-v0-vs-v1_meristem.md`
+- Pipeline LLM día 16 mañana: `bitacora/2026-05-01_meristem-nodo-llm-integrado-v0_meristem.md`
+- Bundle ejemplo R2: `code/meristem_node/examples/bundle_R2_emergency.json`

--- a/bitacora/2026-05-01_meristem-nodo-diseno-v0-vs-v1_meristem.md
+++ b/bitacora/2026-05-01_meristem-nodo-diseno-v0-vs-v1_meristem.md
@@ -1,0 +1,343 @@
+# Meristem-nodo — diseño v0 (MVP demo) vs v1 (post-hackathon)
+
+**Autora**: Meristem
+**Fecha**: 2026-05-01 (día 16, tarde)
+**Para**: Bea (decisiones), Cambium (writeup), Floema (integración),
+Xilema (validación dominio), Endodermis (referencia tuning)
+**Trigger**: Bea preguntó por scope de Meristem-nodo (multi-Rhizome,
+persistencia, ciclos, cálculo de policies). Documentación honesta de
+qué hay hoy vs qué iría a v1, con caso especial **MVP demo con 2
+Rhizomes simulados sobre el mismo ESP32**.
+
+---
+
+## TL;DR
+
+| Pregunta | Hoy v0 | v1 post-demo |
+|---|---|---|
+| ¿Multi-Rhizome simultáneo? | ✅ **base preparada** (per-Rhizome processing); ❌ vista conjunta + batch endpoint | Endpoint batch `POST /visits` + consolidación cross-target |
+| Persistencia | SQLite file-based con 3 tablas + índices | Compresión raw_json + backup automático + multi-proceso |
+| Gestión de ciclos | Emergente (Pollen dicta el ritmo); sin agendamiento | Alertas si pasan N días sin visita + cronología |
+| Cálculo de policies | Determinístico stateless con 4 reglas | Consolidación histórica + ajuste por arquetipo + forecast meteo |
+
+**Para el caso demo MVP (2 Rhizomes simulados)**: con un ajuste pequeño
+(añadir `GET /status` que muestre estado consolidado de los nodos
+conocidos), v0 cubre el caso. **No es refactor**, es adición visible
+útil para demo. **~30-60 min de trabajo.** Detalle en sección 5.
+
+---
+
+## 1. Estado actual del Meristem-nodo (v0 día 16)
+
+### Pipeline funcional
+
+```
+POST /visit
+   ↓ Pydantic validation (Bundle)
+   ↓ IngestService → SQLite bundles
+   ↓ Evaluator (4 reglas determinísticas, stateless)
+   ↓
+   ├── REFUSE → respuesta envelope sin policy
+   │
+   └── ok → LLM Gemma 4 E4B Q4_K_M (rationale)
+            ↓ PolicyComposer → PolicyPacket
+            ↓ SQLite policies + decisions
+            ↓
+VisitResponse con sobre común JSON
+```
+
+### 4 reglas determinísticas (en `evaluator.py`)
+
+| Regla | reason_code | Mode | Rules generadas |
+|---|---|---|---|
+| 1. REFUSE | `HARD_LIMIT_DOMAIN` o `JURISDICTION_POLLEN` | - | (no emite policy) |
+| 2. ALERT | `PERSISTENT_EMERGENCY` | alert | `alert_until_human_review`, `skip_routine_watering` |
+| 3. CONSERVATIVE | `EVIDENCE_LOW_CONFIDENCE` | conservative | `soil_dry_threshold_pct_bump: 5`, `extra_caution_on_disputed_evidence` |
+| 4. CONFIRM | `STABLE_BUNDLE` | normal | `{}` (confirma policy activa con `valid_until +7d`) |
+
+**Limitación clave**: el Evaluator es **stateless respecto a histórico**.
+Solo mira el bundle actual. No lee bundles previos del mismo Rhizome.
+
+### Persistencia SQLite (`persistence.py`)
+
+3 tablas con FOREIGN KEYs:
+
+- `bundles`: `bundle_id`, `received_at`, `source_pollen_id`,
+  `target_rhizome_id`, `active_policy_id`, `raw_json` (Bundle completo)
+- `policies`: `policy_id`, `emitted_at`, `target_node_id`, `raw_json`
+  (PolicyPacket completo), `evidence_refs` (JSON list de bundle_ids)
+- `decisions`: `decision_id`, `bundle_id` (FK), `policy_id` (FK),
+  `rule_applied`, `reason_code`, `llm_metrics` (JSON con tokens/finish/tools)
+
+**Índices útiles**:
+- `idx_bundles_target` por `(target_rhizome_id, received_at DESC)`
+- `idx_policies_target` por `(target_node_id, emitted_at DESC)`
+- `idx_decisions_bundle` por `(bundle_id, created_at DESC)`
+
+**Queries disponibles**: `get_latest_policy_for(target_node_id)`,
+`get_latest_policy_global()`, `get_policy_by_id`, counts para
+`/health`, `count_decisions_by_rule()`.
+
+**Limitaciones v0**:
+- SQLite mono-proceso (file lock)
+- Sin compresión `raw_json` (el JSON completo del Bundle se guarda
+  serializado, puede crecer)
+- Sin backup automático
+
+## 2. Las 4 preguntas de Bea respondidas con código
+
+### Q1 — ¿Multi-Rhizome en una iteración?
+
+**Hoy**:
+- ✅ El código **soporta múltiples Rhizomes**: `Bundle.target_rhizome_id`
+  distingue nodos, persistencia indexa por target, `GET /policy/by-target/{id}`
+  filtra correctamente.
+- ✅ Pollen puede hacer **N POSTs separados** (uno por Rhizome) y
+  recibir N policies separadas.
+- ❌ No hay endpoint batch (`POST /visits` con lista).
+- ❌ No hay vista consolidada (`GET /status` con estado de N nodos).
+- ❌ El Evaluator NO consolida cross-target (cada bundle se evalúa
+  aislado).
+
+**Para "2 Rhizomes en MVP" — análisis específico en sección 5**.
+
+### Q2 — ¿Cómo y dónde guardamos los datos?
+
+**SQLite file-based** en `meristem_node.db` (cwd, configurable vía env
+`MERISTEM_DB_PATH`).
+
+Trazabilidad fuerte por diseño:
+- Bundle se persiste **antes** del Evaluator (incluso si después es
+  REFUSE — para auditoría)
+- Cada Policy linkea a `evidence_refs[bundle_ids]`
+- Cada Decision linkea Bundle ↔ Policy con regla aplicada + métricas
+  LLM (tokens, finish_reason, tool_calls log)
+
+Sobrevive reinicios. Cualquiera puede inspeccionar el `.db` con
+`sqlite3` CLI.
+
+### Q3 — ¿Cómo se gestiona un ciclo nuevo?
+
+**El "ciclo" es emergente, no orquestado por Meristem**:
+
+1. Pollen visita Rhizome (cuándo, depende del operador)
+2. Pollen vuelve a Wi-Fi → POST `/visit` con bundle
+3. Meristem ingiere → evalúa → emite PolicyPacket
+4. Esa policy queda en `/policy/by-target/{rhizome_id}` para la
+   **siguiente** visita
+5. Pollen consulta antes de salir, recoge policy, entrega a Rhizome
+
+**Meristem no agenda nada**. Si el operador hace 1 visita/semana,
+Meristem emite 1 policy/semana por Rhizome. Si 2/semana, 2/semana. El
+ritmo lo dicta Pollen.
+
+**Hoy NO hay**:
+- Alertas si pasan N días sin visita
+- Cronología consultable (`GET /history/by-target/{id}`)
+- Caducidad activa (el `valid_until +7d` se emite pero Meristem no
+  hace nada al expirar — confía en que Pollen vuelva)
+
+### Q4 — ¿Cómo se calculan las policies nuevas?
+
+**Determinístico stateless**:
+1. Evaluator aplica 4 reglas en orden de precedencia → devuelve
+   `Action`, `reason_code`, `suggested_mode`, `suggested_rules`
+2. PolicyComposer construye PolicyPacket con `valid_until = now + 7d`,
+   `mode_default`, `rules` (las del Evaluator + metadata trazabilidad),
+   `signature: "<placeholder-meristem-v0>"` (firma criptográfica
+   diferida a v1)
+3. LLM Gemma 4 E4B Q4_K_M escribe `rationale` técnico + prosa al
+   operador, **sin contradecir al Evaluator** (la decisión ya está
+   fijada)
+
+**Hoy NO hay**:
+- Aprendizaje histórico (cada bundle se evalúa aislado)
+- ML clasificadores
+- Ajuste fino por arquetipo (las "rules" generadas son las mismas
+  para todo CONSERVATIVE / ALERT)
+- Forecast meteo (el `weather_digest` solo se mira para `isStale=true`)
+
+## 3. Tabla v0 vs v1 — qué iría dónde
+
+| Pieza | v0 (MVP demo) | v1 (post-hackathon) |
+|---|---|---|
+| **Multi-Rhizome processing** | ✅ via N POSTs separados | Endpoint batch `POST /visits` |
+| **Vista conjunta multi-Rhizome** | ❌ falta | `GET /status` con estado de N nodos |
+| **Persistencia SQLite** | ✅ 3 tablas + índices | Compresión raw_json, backup automático |
+| **Trazabilidad** | ✅ bundle ↔ policy ↔ decision con FKs | Endpoint `/history/by-target/{id}` con cronología |
+| **Pipeline determinístico** | ✅ 4 reglas + 13 tests | Más reglas según patrones que aparezcan |
+| **LLM rationale** | ✅ Gemma 4 E4B + tool calling | Tools reales (no stubs); fine-tuning v1 |
+| **Aprendizaje histórico** | ❌ stateless | Evaluator lee últimos N bundles → detecta tendencias |
+| **Ajuste por arquetipo** | ❌ rules genéricas | Reglas distintas por tipo de plot/región/estación |
+| **Forecast meteo** | ❌ solo `isStale` | Tool `get_weather_forecast(plot, days=7)` con ajuste activo |
+| **Personalización operador** | ❌ no | `Bundle.operator_preferences` (más conservador, prioriza X) |
+| **Agendamiento** | ❌ ritmo emergente | Alertas tras N días sin visita |
+| **Caducidad activa** | ❌ pasiva (confía en Pollen) | Detección activa al expirar `valid_until` |
+
+## 4. Recomendaciones priorizadas para post-hackathon
+
+Por ROI estimado:
+
+1. **Consolidación histórica simple** (1-2 días). El Evaluator lee
+   últimos N bundles del mismo target y detecta tendencias ("disputas
+   crecientes 3 semanas seguidas → más conservador"). Es lo que
+   distingue "Meristem registra" de "Meristem aprende".
+
+2. **Endpoint `/history/by-target/{rhizome_id}`** (medio día). Útil al
+   operador y al jurado en demo en directo.
+
+3. **Tools reales**: `get_weather_history` ya está, falta sustituir
+   stubs por servicio meteo real. Y añadir `get_weather_forecast`. ~1
+   día.
+
+4. **Endpoint batch `POST /visits`** (medio día). Pollen envía N
+   bundles de golpe en lugar de N POSTs. Optimización, no urgente.
+
+5. **Multi-proceso** (incierto): si en algún momento un agricultor
+   monta una cooperativa con 50+ Rhizomes y un único Meristem, SQLite
+   monoproceso puede ser cuello. Migración a Postgres o WAL mode de
+   SQLite.
+
+## 5. Caso especial — MVP demo con 2 Rhizomes simulados
+
+### Contexto
+
+Bea confirmó (día 16): **el demo simulará 2 Rhizomes (`rhizome_01` y
+`rhizome_02`) sobre el mismo ESP32 físico, con 2 parcelas distintas**.
+Es decir, 1 hardware ESP32 expone (vía firmware o vía mock) los datos
+de las dos parcelas como si fuesen dos nodos Rhizome separados, cada
+uno con su contexto.
+
+Esto activa la pregunta: **¿v0 actual cubre 2 Rhizomes, o requiere
+ajuste?**
+
+### Análisis
+
+**Lo que ya funciona sin cambios**:
+
+✅ **Persistencia separada por target**. Si Pollen hace dos POSTs:
+
+```bash
+POST /visit  body: {target_rhizome_id: "rhizome_01", ...bundle_R1...}
+POST /visit  body: {target_rhizome_id: "rhizome_02", ...bundle_R2...}
+```
+
+→ Meristem persiste 2 bundles distintos (con `bundle_id` único cada
+uno), evalúa cada uno por separado, emite 2 policies distintas, y
+las queries `/policy/by-target/rhizome_01` vs `/policy/by-target/rhizome_02`
+devuelven la policy correcta para cada nodo.
+
+✅ **Decisiones independientes por nodo**. Si Rhizome_01 está en
+emergencia y Rhizome_02 limpio, el Evaluator emite ALERT para R1 y
+CONFIRM para R2. Cada nodo tiene su propio rationale, su propio
+`valid_until`, su propia trazabilidad.
+
+✅ **Trazabilidad cruzada disponible**. Las queries SQL ya soportan
+filtrar por target. Si alguien pregunta "muéstrame la cronología del
+nodo R2", la query es trivial (`SELECT * FROM bundles WHERE
+target_rhizome_id='rhizome_02' ORDER BY received_at DESC`).
+
+**Lo que faltaría añadir** (para que el demo sea visualmente fuerte):
+
+❌ **`GET /status`** o `GET /policies/all`: endpoint que devuelva
+**estado consolidado** de los N Rhizomes conocidos. Útil para que el
+jurado vea de un vistazo "Meristem maneja 2 nodos a la vez".
+
+Forma propuesta:
+```json
+GET /status
+{
+  "targets_known": ["rhizome_01", "rhizome_02"],
+  "by_target": {
+    "rhizome_01": {
+      "latest_policy_id": "pkt_meristem_...",
+      "latest_policy_emitted_at": "2026-05-01T...",
+      "latest_policy_mode": "alert",
+      "last_bundle_received_at": "2026-05-01T...",
+      "bundles_total": 5,
+      "decisions_total": 5,
+      "decisions_by_rule": {"alert_policy": 3, "confirm_policy": 2}
+    },
+    "rhizome_02": {
+      "latest_policy_id": "pkt_meristem_...",
+      "latest_policy_emitted_at": "2026-05-01T...",
+      "latest_policy_mode": "normal",
+      "last_bundle_received_at": "2026-05-01T...",
+      "bundles_total": 4,
+      "decisions_total": 4,
+      "decisions_by_rule": {"confirm_policy": 4}
+    }
+  }
+}
+```
+
+❌ **Update `/health`** para que el `decisions_by_rule` agregado
+existente se complemente con un breakdown por target. Mejora menor.
+
+❌ **(Opcional)** `POST /visits` batch: aceptar lista de bundles en
+un POST. Comodidad para Pollen pero no esencial — Pollen puede hacer
+2 POSTs separados sin problema.
+
+### Coste de los cambios necesarios
+
+| Cambio | Coste | Bloquea demo si no se hace? |
+|---|---:|---|
+| `GET /status` con vista consolidada | 30-60 min | No bloquea pero **mejora demo significativamente** |
+| Update `/health` con breakdown por target | 15 min | No bloquea (`/status` lo cubre) |
+| `POST /visits` batch | 30 min | No bloquea (Pollen puede hacer 2 POSTs) |
+| **Total recomendado** | **~1 hora** | mejora visible, no bloquea |
+
+### Mi propuesta concreta
+
+**Para v0 / MVP demo**:
+
+1. ✅ **Sin cambios al Evaluator ni al pipeline**: cada Rhizome se
+   procesa independientemente, como ya hace.
+2. ✅ **Sin cambios a la persistencia**: las 3 tablas + índices ya
+   soportan multi-target.
+3. ➕ **Añadir `GET /status`** que muestre estado consolidado de
+   los N Rhizomes conocidos. **30-60 min**.
+4. ➕ **Update `/health`** con `targets_known: list[str]` para que
+   sea visible incluso sin entrar a `/status`. **15 min**.
+5. ➖ **Saltar `POST /visits` batch** por ahora — Pollen hace 2 POSTs
+   y listo. Si Floema lo pide explícitamente, lo añadimos.
+
+**Demo del flujo con 2 Rhizomes**:
+
+1. Pollen visita Rhizome_01 → POST `/visit` con bundle_R1 (parcela A
+   limpia) → Meristem emite policy CONFIRM para R1
+2. Pollen visita Rhizome_02 → POST `/visit` con bundle_R2 (parcela B
+   con disputa) → Meristem emite policy CONSERVATIVE para R2
+3. Demo muestra `GET /status` → jurado ve **2 nodos manejados, 2
+   policies distintas, 2 modes distintos en pantalla**
+4. Pollen consulta `GET /policy/by-target/rhizome_01` y
+   `GET /policy/by-target/rhizome_02` → recoge ambas policies para
+   entregar en próxima visita
+
+**Todo esto se demo en directo o en grabación de video** sin tocar
+arquitectura. Solo añadir un endpoint visible.
+
+### Pregunta para Bea
+
+¿Adelante con la propuesta?
+
+- **Si sí**: implemento `GET /status` + actualizo `/health` esta tarde
+  (~1h), smoke con bundles de R1 y R2, commit + push.
+- **Si prefieres otro alcance** (ej. también `POST /visits` batch, o
+  `GET /history/by-target/{id}` para cronología): dilo y replanteo.
+- **Si dices "v0 actual basta, el demo enseña 1 Rhizome a la vez sin
+  vista conjunta"**: cero cambios, el código ya soporta el caso.
+
+Mi voto: **adelante con la propuesta**. La vista consolidada en demo
+refuerza la narrativa "scalable a N cooperativas" sin coste real.
+
+## Referencias
+
+- `code/meristem_node/src/main.py` — pipeline + endpoints actuales
+- `code/meristem_node/src/persistence.py` — queries por target
+- `code/meristem_node/src/evaluator.py` — 4 reglas
+- `code/meristem_node/src/policy_composer.py` — PolicyPacket con
+  `valid_until +7d`
+- `code/meristem_node/ARCHITECTURE.md` — diseño por capas
+- `bitacora/2026-05-01_meristem-nodo-llm-integrado-v0_meristem.md` —
+  resultados smoke 5/5 PASS con LLM real

--- a/bitacora/2026-05-01_meristem-nodo-llm-integrado-v0_meristem.md
+++ b/bitacora/2026-05-01_meristem-nodo-llm-integrado-v0_meristem.md
@@ -1,0 +1,169 @@
+# Meristem-nodo con LLM Gemma 4 E4B integrado — v0 funcional 5/5
+
+**Autora**: Meristem
+**Fecha**: 2026-05-01 (día 16)
+**Rama**: `feat/meristem-node-llm-integration`
+**Antecede**: `bitacora/2026-04-30_mensaje-cambium-cierre-dia_meristem.md`
+
+---
+
+## TL;DR
+
+- **LLM Gemma 4 E4B Q4_K_M integrado** end-to-end en Meristem-nodo.
+  Mini-batería de 5 bundles **5/5 PASS** con rationale natural en
+  castellano, factual, sin contradecir al Evaluator.
+- **Patrón "lógica determinística decide, LLM solo escribe rationale"**
+  funcionando como diseñado: el LLM cita datos exactos del bundle
+  (35%, 42%, "depósito bajo + sol intenso") y respeta la decisión.
+- **Tool calling preparado** en el prompt + cliente; los stubs
+  deterministas (`get_weather_history`, `compare_with_previous_policy`)
+  están listos para activarse cuando un caso lo dispare.
+- **Tiempo por bundle**: ~2 min en CPU Alder Lake con E4B Q4_K_M
+  (~5 GB modelo). REFUSE corta antes del LLM (eficiencia: M4/M5
+  instantáneos).
+- **Fallback robusto**: si el adapter llamacpp no responde,
+  `_compose_rationale()` cae a stub determinístico sin romper
+  pipeline. Útil para tests/dev sin stack arrancado.
+
+## Stack en producción
+
+```
+POST /visit (Pollen)
+   ↓ Pydantic validation
+   ↓ IngestService → SQLite bundles
+   ↓ Evaluator (4 reglas determinísticas)
+   ↓
+   ├── REFUSE → respuesta envelope sin policy (corta antes del LLM)
+   │
+   └── ok → _compose_rationale()
+            ↓ HTTP POST adapter:12000/api/chat
+            ↓     ↓ adapter (backend llamacpp)
+            ↓     ↓     ↓ HTTP POST llama-server:8080/v1/chat/completions
+            ↓     ↓     ↓     ↓ Gemma 4 E4B Q4_K_M
+            ↓     ↓     ↓     ↓ thinking ON, tool_choice=auto
+            ↓     ↓     ↓     ↓ tools: get_weather_history,
+            ↓     ↓     ↓     ↓        compare_with_previous_policy
+            ↓     ↓     ↓     ↓ JSON: {rationale_tecnico, rationale_para_operador}
+            ↓     ↓     ↓ ←── (back through chain)
+            ↓ PolicyComposer → PolicyPacket
+            ↓ SQLite policies + decisions con llm_metrics
+            ↓
+VisitResponse con sobre común JSON
+```
+
+## Resultados mini-batería v0
+
+| # | Bundle | Status | Reason | Mode | Rationale al operador |
+|---|---|:-:|---|:-:|---|
+| M1 | clean | ok | STABLE_BUNDLE | normal | "La política actual se mantiene. Los datos de suelo y el clima son estables, por lo que se confirma el plan de riego y gestión establecido." |
+| M2 | disputed | ok | EVIDENCE_LOW_CONFIDENCE | conservative | "Hemos detectado una discrepancia entre la lectura del sensor y su observación visual. Por precaución, hemos activado una política más conservadora para asegurar el cuidado de la parcela." |
+| M3 | emergency | ok | PERSISTENT_EMERGENCY | alert | "Debido al bajo nivel de depósito y las condiciones de sol intenso, se mantiene el modo alerta. Se ha suspendido el riego rutinario para gestionar esta emergencia persistente." |
+| M4 | hard limit relax | **refuse** | HARD_LIMIT_DOMAIN | - | (REFUSE corta antes del LLM) |
+| M5 | pollen jurisdiction | **refuse** | JURISDICTION_POLLEN | - | (idem) |
+
+5/5 envelope_valid · 5/5 status_match · 3/3 rationales factuales con
+datos del bundle.
+
+### Análisis de calidad de cada rationale
+
+**M1**: cita "datos de suelo" y "clima" en general. Podría haber sido
+más específico (mencionar 35% / 42% como sí hace en el técnico). Para
+el operador genérico está bien — no satura con números.
+
+**M2**: cita "discrepancia entre lectura del sensor y observación
+visual" — esto está literalmente en el bundle (`basis: ["sensor_a=26%
+indica seco", "operador anotó parcela visualmente normal"]`). Lectura
+correcta del modelo.
+
+**M3**: cita "bajo nivel de depósito" (tank_pct=12 en bundle) y "sol
+intenso" (weather_digest summary). Combinación de dos fuentes en el
+bundle. Bien.
+
+**M4 + M5**: REFUSE no entra al LLM. El sistema ahorra ~2 min y emite
+un envelope refuse con reason_code. El operador (vía Pollen UI) puede
+mostrar mensaje predefinido para el reason_code, no requiere LLM.
+
+## Latencia y consumo
+
+| Pieza | Tiempo aproximado |
+|---|---|
+| Carga inicial del modelo E4B Q4_K_M en llama-server | ~30-60s |
+| Primer request (warmup) | ~2:14 min |
+| Requests siguientes | ~2 min cada uno |
+| REFUSE (sin LLM) | <100 ms |
+| RAM con E4B cargado | ~2-3 GB libre tras stack completo |
+
+El portátil usado es CPU Alder Lake. En Jetson Orin Nano Super con GPU
+offload se espera ~1-1.5x mejor (~80-110s/bundle). Aceptable para
+slow brain doméstico — no es time-critical.
+
+## Decisiones del día
+
+1. **Cliente inferencia con tool calling preparado** desde día 1, aunque
+   los 5 bundles ejemplo no disparan tool calls (no necesitan datos
+   extra). Cuando un caso real necesite weather histórico o diff de
+   policy, el modelo decidirá llamar la tool. Demostrable al jurado
+   con un bundle ad-hoc en demo.
+2. **Fallback a stub si LLM no disponible**. Pipeline no se rompe en
+   tests, en dev sin stack arrancado, o si el adapter cae. Resiliencia
+   sin coste extra.
+3. **Prompt de Meristem en `code/meristem_node/src/prompts.py`**, NO en
+   `code/tuning/system_prompts.yaml`. Razón: este es prompt de
+   producción, no de experimentación. Cuando cierre v1 definitivo se
+   sincroniza si Xilema lo pide.
+4. **Loop tool calling con max 3 iteraciones**: si el modelo entra en
+   bucle de tool calls sin emitir respuesta, cortamos.
+5. **Endpoint `/health` ahora muestra `llm_mode: "real" | "stub_disabled"`**
+   en lugar del booleano `stubbed_llm` que era ambiguo.
+
+## Observaciones técnicas para writeup
+
+1. **Patrón validado empíricamente**: Evaluator decide, LLM redacta.
+   Los 5 rationales NO contradicen al Evaluator en ningún caso — el
+   modelo respeta la barandilla del system prompt ("La acción ya está
+   fijada por el Evaluator. Tu redacción NO debe contradecir la
+   decisión").
+2. **Calidad del rationale para operador es alta**: castellano natural,
+   sin jerga, sin alarmismo, sin disculpas. La regla de brevedad de
+   Xilema (heredada de Rhizome v0.5) funciona en E4B también — JSON
+   compacto sin Markdown fences.
+3. **El sistema funciona end-to-end con tres servicios separados**:
+   - llama-server :8080 (Gemma 4 E4B Q4_K_M)
+   - meristem_inference_adapter :12000 (backend `llamacpp`)
+   - meristem_node :13000 (FastAPI + SQLite + tool calling client)
+   Headers `Sprout-Inference-*` uniformes con Pollen y Rhizome.
+
+## Para Endodermis (cuando arranque Jetson)
+
+- Stack llama.cpp local validado **dos veces** ahora: con E2B Q4_K_M
+  (tuning Rhizome) y con E4B Q4_K_M (Meristem-nodo). Mismo binario
+  llama-server, distintos modelos, headers uniformes.
+- Si su re-ejecución de Rhizome v0.5 da regresión en Jetson, el
+  adapter del Meristem-nodo es testbed gratis para diagnosticar
+  diferencias x86 CPU vs ARM/GPU sin tocar el harness de tuning.
+- Tool calling validado con E2B (día 14) Y con E4B (hoy). Ambos
+  modelos lo soportan vía `/v1/chat/completions`.
+
+## Próximos pasos
+
+1. **Esperar respuesta de Xilema** sobre prompt + 5 bundles ejemplo
+   (mensaje pendiente del día 15). Si tiene ajustes, los aplico.
+2. **Soporte a Endodermis** cuando empiece a re-ejecutar Rhizome v0.5
+   en Jetson. Cualquier regresión la analizamos juntas.
+3. **Tests adicionales del cliente inferencia** (mock httpx) si
+   queda tiempo. No bloqueante — el smoke con stack real es la
+   verificación más fuerte.
+4. **Bundle ad-hoc para demostrar tool calling en demo**: bundle sin
+   weather_digest pero con decisión que dependa del clima → modelo
+   llama `get_weather_history(plot_id)` en directo. Útil para video.
+
+## Referencias
+
+- `code/meristem_node/src/prompts.py` — system prompt + tool defs +
+  helpers
+- `code/meristem_node/src/inference.py` — cliente HTTP al adapter +
+  loop tool calling
+- `code/meristem_node/src/main.py` — pipeline integrado con LLM real
+  + fallback stub
+- `code/meristem_node/examples/bundle_M*.json` — 5 bundles ejemplo
+- `models/gemma-4-E4B-it-Q4_K_M.gguf` (4.97 GB, descargado hoy)

--- a/code/meristem_node/examples/bundle_R2_emergency.json
+++ b/code/meristem_node/examples/bundle_R2_emergency.json
@@ -1,0 +1,20 @@
+{
+  "source_pollen_id": "pollen_demo_01",
+  "target_rhizome_id": "rhizome_02",
+  "active_policy_id": "pkt_rhizome_02_baseline",
+  "rhizome_snapshot": {
+    "snapshot_id": "snap_20260429T140000_r2",
+    "mode": "alert",
+    "alert_latched": true,
+    "pending_contradictions": [],
+    "soil_a_pct": 18,
+    "soil_b_pct": 22,
+    "tank_pct": 12
+  },
+  "decision_receipts": [
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"}
+  ],
+  "weather_digest": {"isStale": false, "summary": "Soleado intenso."},
+  "validation_stamps": []
+}

--- a/code/meristem_node/src/inference.py
+++ b/code/meristem_node/src/inference.py
@@ -1,0 +1,197 @@
+"""Cliente al `meristem_inference_adapter` para Meristem-nodo.
+
+Llama al adapter en `:12000` (que reenvía al `llama-server` en `:8080`
+con Gemma 4 E4B Q4_K_M) y devuelve el rationale técnico + rationale
+para operador.
+
+Loop de tool calling:
+1. POST inicial con `tools` → modelo decide si llama tool
+2. Si emite `tool_calls`: ejecutar tool (stub determinista) + POST
+   continuación con tool_result en messages
+3. Repetir hasta finish_reason="stop" o max_iterations
+
+Errores → fallback a stub determinístico (no rompe pipeline).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+
+from .prompts import (
+    MERISTEM_SYSTEM_PROMPT_ES,
+    TOOL_DEFINITIONS,
+    build_user_message,
+    call_tool,
+)
+from .schemas import Bundle, EvaluationResult
+
+
+logger = logging.getLogger(__name__)
+
+
+# Configuración por defecto. Override por env si toca.
+ADAPTER_URL_DEFAULT = "http://localhost:12000"
+MAX_TOOL_ITERATIONS = 3
+HTTP_TIMEOUT_S = 180.0  # E4B + tool calling puede tardar
+
+
+class LLMUnavailableError(Exception):
+    """Error genérico al hablar con el adapter. Caller debe fallback."""
+
+
+def _post_chat(
+    adapter_url: str,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """POST a /api/chat del adapter. Devuelve respuesta Ollama-format."""
+    payload: dict[str, Any] = {
+        "model": "gemma4:e4b",  # alias resuelto por config.py del adapter
+        "messages": messages,
+        "options": {
+            "temperature": 0.3,
+            "num_ctx": 4096,
+            "num_predict": 1024,
+        },
+        "stream": False,
+        "think": True,  # Meristem es slow brain, thinking ON
+    }
+    if tools:
+        payload["tools"] = tools
+        payload["tool_choice"] = "auto"
+
+    try:
+        with httpx.Client(timeout=HTTP_TIMEOUT_S) as client:
+            r = client.post(f"{adapter_url}/api/chat", json=payload)
+            r.raise_for_status()
+            return r.json()
+    except httpx.HTTPError as e:
+        raise LLMUnavailableError(f"adapter HTTP error: {e}") from e
+
+
+def _parse_rationale_json(content: str) -> tuple[str, str] | None:
+    """Extrae (rationale_tecnico, rationale_para_operador) del JSON emitido.
+
+    El system prompt pide JSON compacto sin Markdown fences. Si llega
+    con fences (modelo no respetó), recortamos defensivamente.
+    """
+    text = content.strip()
+    if not text:
+        return None
+    if text.startswith("```"):
+        # Recortar fence si lo hay
+        first_brace = text.find("{")
+        last_brace = text.rfind("}")
+        if first_brace != -1 and last_brace > first_brace:
+            text = text[first_brace : last_brace + 1]
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    rt = obj.get("rationale_tecnico")
+    ro = obj.get("rationale_para_operador")
+    if not isinstance(rt, str) or not isinstance(ro, str):
+        return None
+    return rt.strip(), ro.strip()
+
+
+def compose_rationale_via_llm(
+    bundle: Bundle,
+    evaluation: EvaluationResult,
+    *,
+    adapter_url: str = ADAPTER_URL_DEFAULT,
+    use_tools: bool = True,
+) -> tuple[str, str, dict[str, Any]]:
+    """Devuelve (rationale_tecnico, rationale_operador, llm_metrics).
+
+    Loop tool calling (max 3 iteraciones). Si el modelo cumple regla de
+    brevedad y emite JSON limpio, parseamos y devolvemos. Si emite tool
+    call, ejecutamos stub y continuamos. Si nada de esto funciona en
+    3 iteraciones, raise para que caller fallback a stub.
+
+    `llm_metrics` se persiste en `decisions.llm_metrics` para audit.
+    """
+    bundle_json = bundle.model_dump(mode="json")
+    evaluation_json = evaluation.model_dump(mode="json")
+    user_message = build_user_message(bundle_json, evaluation_json)
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": MERISTEM_SYSTEM_PROMPT_ES},
+        {"role": "user", "content": user_message},
+    ]
+    tools = TOOL_DEFINITIONS if use_tools else None
+
+    metrics: dict[str, Any] = {
+        "tool_iterations": 0,
+        "tool_calls_log": [],
+        "finish_reasons": [],
+    }
+
+    for iteration in range(MAX_TOOL_ITERATIONS):
+        response = _post_chat(adapter_url, messages, tools)
+        msg = (response.get("message") or {})
+        content = msg.get("content") or ""
+        thinking = msg.get("thinking") or ""
+        tool_calls = msg.get("tool_calls") or []
+        finish_reason = response.get("done_reason", "stop")
+
+        metrics["finish_reasons"].append(finish_reason)
+        metrics["tool_iterations"] = iteration + 1
+        metrics[f"tokens_in_iter_{iteration}"] = response.get("prompt_eval_count")
+        metrics[f"tokens_out_iter_{iteration}"] = response.get("eval_count")
+        metrics[f"thinking_chars_iter_{iteration}"] = len(thinking)
+
+        # Si emitió tool_calls, ejecutamos y continuamos.
+        if tool_calls:
+            assistant_msg: dict[str, Any] = {"role": "assistant"}
+            if content:
+                assistant_msg["content"] = content
+            assistant_msg["tool_calls"] = tool_calls
+            messages.append(assistant_msg)
+
+            for tc in tool_calls:
+                fn = tc.get("function") or {}
+                name = fn.get("name", "")
+                raw_args = fn.get("arguments", "{}")
+                try:
+                    args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                except json.JSONDecodeError:
+                    args = {}
+                tool_result = call_tool(name, args)
+                metrics["tool_calls_log"].append({"name": name, "args": args})
+
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc.get("id", ""),
+                    "name": name,
+                    "content": tool_result,
+                })
+            continue  # otro round con tool_results en el contexto
+
+        # Sin tool_calls → modelo respondió. Intentamos parsear JSON.
+        parsed = _parse_rationale_json(content)
+        if parsed:
+            metrics["parsed_ok"] = True
+            metrics["final_content_len"] = len(content)
+            return parsed[0], parsed[1], metrics
+
+        # Si el contenido está vacío pero hay thinking (split de Gemma 4
+        # vía llama.cpp), intentamos parsear el thinking.
+        if not content and thinking:
+            parsed_t = _parse_rationale_json(thinking)
+            if parsed_t:
+                metrics["parsed_from_thinking"] = True
+                return parsed_t[0], parsed_t[1], metrics
+
+        metrics["parsed_ok"] = False
+        metrics["raw_content_excerpt"] = content[:300]
+        break  # JSON inválido: rompemos sin reintentar (no resuelve)
+
+    raise LLMUnavailableError(
+        f"LLM no produjo JSON válido tras {metrics['tool_iterations']} iteraciones. "
+        f"Último finish_reason={metrics['finish_reasons'][-1] if metrics['finish_reasons'] else '?'}"
+    )

--- a/code/meristem_node/src/main.py
+++ b/code/meristem_node/src/main.py
@@ -39,6 +39,8 @@ from .schemas import (
     DecisionRecord,
     EvaluationResult,
     PolicyPacket,
+    StatusResponse,
+    TargetStatus,
     VisitResponse,
     VisitResponsePayload,
 )
@@ -152,7 +154,26 @@ def _build_app() -> FastAPI:
             "bundles_received_total": persistence.count_bundles(),
             "policies_emitted_total": persistence.count_policies(),
             "decisions_by_rule": persistence.count_decisions_by_rule(),
+            "targets_known": persistence.list_known_targets(),
         }
+
+    @app.get("/status", response_model=StatusResponse)
+    async def status() -> StatusResponse:
+        """Vista consolidada multi-Rhizome.
+
+        Para cada Rhizome conocido (que ha enviado al menos un bundle),
+        devuelve resumen: última policy + modo + reason_code + edad +
+        contadores. Pensado para demo MVP donde Meristem gestiona
+        rhizome_01 + rhizome_02 simultáneos en el mismo hardware.
+        """
+        targets_known = persistence.list_known_targets()
+        targets: list[TargetStatus] = []
+        for t in targets_known:
+            summary = persistence.get_target_summary(t)
+            if summary is None:
+                continue  # defensivo, no debería pasar
+            targets.append(TargetStatus(**summary))
+        return StatusResponse(targets_known=targets_known, targets=targets)
 
     @app.post("/visit", response_model=VisitResponse)
     async def visit(bundle: Bundle) -> VisitResponse:

--- a/code/meristem_node/src/main.py
+++ b/code/meristem_node/src/main.py
@@ -1,20 +1,27 @@
 """FastAPI app de Meristem-nodo.
 
-Día 15: lógica determinística (Evaluator + persistencia SQLite). Día
-16 sustituye el rationale stub por LLM Gemma 4 E4B + tool calling.
+Día 16: pipeline determinístico + LLM Gemma 4 E4B Q4_K_M para rationale
+con tool calling. La decisión la toma el Evaluator; el LLM solo
+escribe rationale técnico + rationale para operador.
 
 Levanta en :13000 por defecto.
 
 Uso:
     cd code/meristem_node
     pip install -r requirements.txt
+    # Asegúrate de tener llama-server :8080 con E4B + adapter :12000
     python -m src.main
+
+Env vars opcionales:
+    MERISTEM_USE_LLM=false  → salta LLM, usa stub (para tests/dev)
+    MERISTEM_ADAPTER_URL=http://localhost:12000  → adapter llamacpp
 
 Visitar http://localhost:13000/docs para OpenAPI/Swagger.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 from typing import Any
@@ -24,23 +31,59 @@ from fastapi import FastAPI, HTTPException
 from . import ingest as ingest_service
 from . import persistence
 from .evaluator import evaluate
+from .inference import LLMUnavailableError, compose_rationale_via_llm
 from .policy_composer import compose_policy
 from .schemas import (
     Action,
     Bundle,
     DecisionRecord,
+    EvaluationResult,
     PolicyPacket,
     VisitResponse,
     VisitResponsePayload,
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 PORT = int(os.environ.get("MERISTEM_NODE_PORT", "13000"))
+USE_LLM = os.environ.get("MERISTEM_USE_LLM", "true").lower() not in (
+    "false", "0", "no",
+)
+ADAPTER_URL = os.environ.get("MERISTEM_ADAPTER_URL", "http://localhost:12000")
 
 
 # ---------------------------------------------------------------------------
-# Stub de rationale del LLM (día 15). Día 16 lo sustituye llamada real.
+# Rationale composer: LLM real si disponible, fallback determinista.
 # ---------------------------------------------------------------------------
+
+
+def _compose_rationale(
+    bundle: Bundle, evaluation: EvaluationResult,
+) -> tuple[str, str, dict[str, Any]]:
+    """Devuelve (rationale_tecnico, rationale_para_operador, llm_metrics).
+
+    Si USE_LLM=true (default) y el adapter llamacpp está vivo en
+    ADAPTER_URL, llama a Gemma 4 E4B con tool calling y obtiene rationale.
+    Si falla, fallback al stub determinista (no rompe pipeline).
+    """
+    if USE_LLM:
+        try:
+            rt, ro, metrics = compose_rationale_via_llm(
+                bundle, evaluation, adapter_url=ADAPTER_URL
+            )
+            metrics["mode"] = "llm"
+            return rt, ro, metrics
+        except LLMUnavailableError as e:
+            logger.warning(
+                "LLM no disponible (%s). Fallback a rationale stub.", e
+            )
+            rt, ro = _stub_rationale(evaluation.rationale_seed)
+            return rt, ro, {"mode": "stub_fallback", "reason": str(e)}
+
+    rt, ro = _stub_rationale(evaluation.rationale_seed)
+    return rt, ro, {"mode": "stub_disabled"}
 
 
 def _stub_rationale(rationale_seed: str) -> tuple[str, str]:
@@ -104,7 +147,8 @@ def _build_app() -> FastAPI:
             "status": "ok",
             "version": "0.1.0",
             "port": PORT,
-            "stubbed_llm": True,  # día 15: rationale es stub
+            "llm_mode": "real" if USE_LLM else "stub_disabled",
+            "adapter_url": ADAPTER_URL if USE_LLM else None,
             "bundles_received_total": persistence.count_bundles(),
             "policies_emitted_total": persistence.count_policies(),
             "decisions_by_rule": persistence.count_decisions_by_rule(),
@@ -134,9 +178,9 @@ def _build_app() -> FastAPI:
                 payload=None,
             )
 
-        # 3b: componer policy + rationale
-        rationale_tecnico, rationale_operador = _stub_rationale(
-            evaluation.rationale_seed
+        # 3b: componer rationale (LLM o fallback) + policy
+        rationale_tecnico, rationale_operador, llm_metrics = _compose_rationale(
+            bundle, evaluation
         )
         policy = compose_policy(bundle, evaluation, rationale_tecnico)
 
@@ -149,7 +193,7 @@ def _build_app() -> FastAPI:
                 policy_id=policy.policy_id,
                 rule_applied=evaluation.action,
                 reason_code=evaluation.reason_code,
-                llm_metrics={"stubbed": True, "day": 15},
+                llm_metrics=llm_metrics,
             )
         )
 

--- a/code/meristem_node/src/persistence.py
+++ b/code/meristem_node/src/persistence.py
@@ -280,3 +280,119 @@ def count_decisions_by_rule(
             "SELECT rule_applied, COUNT(*) AS c FROM decisions GROUP BY rule_applied"
         ).fetchall()
     return {r["rule_applied"]: int(r["c"]) for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Vista por target (para /status — demo MVP multi-Rhizome)
+# ---------------------------------------------------------------------------
+
+
+def list_known_targets(
+    db_path: Path | str = DEFAULT_DB_PATH,
+) -> list[str]:
+    """Todos los Rhizome IDs que han enviado bundles persistidos.
+
+    Devuelto ordenado alfabéticamente para output estable en demo.
+    Incluye Rhizomes cuyos bundles fueron REFUSE (sin policy emitida) —
+    para trazabilidad completa.
+    """
+    with _connect(db_path) as con:
+        rows = con.execute(
+            "SELECT DISTINCT target_rhizome_id FROM bundles "
+            "ORDER BY target_rhizome_id ASC"
+        ).fetchall()
+    return [r["target_rhizome_id"] for r in rows]
+
+
+def get_target_summary(
+    target_node_id: str, db_path: Path | str = DEFAULT_DB_PATH,
+) -> dict[str, Any] | None:
+    """Resumen del estado de Meristem para un Rhizome concreto.
+
+    Devuelve dict con:
+    - target_node_id
+    - bundles_received
+    - last_bundle_at (último received_at, ISO string o None)
+    - policies_emitted
+    - latest_policy_id (None si nunca emitió por REFUSEs)
+    - latest_policy_emitted_at (ISO o None)
+    - latest_policy_mode (normal/conservative/alert o None)
+    - latest_policy_valid_until (ISO o None)
+    - latest_reason_code (de decisions.reason_code más reciente, o None)
+    - latest_rule_applied (de decisions.rule_applied más reciente, o None)
+
+    Devuelve None si el target no existe en bundles (no hay registro).
+    """
+    with _connect(db_path) as con:
+        # 1. Counts y last_bundle_at
+        bundle_row = con.execute(
+            """
+            SELECT COUNT(*) AS c, MAX(received_at) AS last_at
+            FROM bundles WHERE target_rhizome_id = ?
+            """,
+            (target_node_id,),
+        ).fetchone()
+        if not bundle_row or int(bundle_row["c"] or 0) == 0:
+            return None
+
+        bundles_received = int(bundle_row["c"])
+        last_bundle_at = bundle_row["last_at"]
+
+        # 2. Policies count + última policy
+        pol_count = con.execute(
+            "SELECT COUNT(*) AS c FROM policies WHERE target_node_id = ?",
+            (target_node_id,),
+        ).fetchone()
+        policies_emitted = int(pol_count["c"]) if pol_count else 0
+
+        latest_pol_row = con.execute(
+            """
+            SELECT policy_id, emitted_at, raw_json FROM policies
+            WHERE target_node_id = ?
+            ORDER BY emitted_at DESC LIMIT 1
+            """,
+            (target_node_id,),
+        ).fetchone()
+
+        latest_policy_id = None
+        latest_policy_emitted_at = None
+        latest_policy_mode = None
+        latest_policy_valid_until = None
+        if latest_pol_row:
+            latest_policy_id = latest_pol_row["policy_id"]
+            latest_policy_emitted_at = latest_pol_row["emitted_at"]
+            try:
+                pkt = PolicyPacket.model_validate_json(latest_pol_row["raw_json"])
+                latest_policy_mode = pkt.mode_default
+                latest_policy_valid_until = pkt.valid_until.isoformat()
+            except Exception:
+                # Defensivo: si la policy persistida no parsea (no debería),
+                # devolvemos lo que sí podemos.
+                pass
+
+        # 3. Última decisión para ese target (joineando policies)
+        latest_dec_row = con.execute(
+            """
+            SELECT d.reason_code, d.rule_applied
+            FROM decisions d
+            JOIN policies p ON d.policy_id = p.policy_id
+            WHERE p.target_node_id = ?
+            ORDER BY d.created_at DESC LIMIT 1
+            """,
+            (target_node_id,),
+        ).fetchone()
+        latest_reason_code = latest_dec_row["reason_code"] if latest_dec_row else None
+        latest_rule_applied = latest_dec_row["rule_applied"] if latest_dec_row else None
+
+    return {
+        "target_node_id": target_node_id,
+        "bundles_received": bundles_received,
+        "last_bundle_at": last_bundle_at,
+        "policies_emitted": policies_emitted,
+        "latest_policy_id": latest_policy_id,
+        "latest_policy_emitted_at": latest_policy_emitted_at,
+        "latest_policy_mode": latest_policy_mode,
+        "latest_policy_valid_until": latest_policy_valid_until,
+        "latest_reason_code": latest_reason_code,
+        "latest_rule_applied": latest_rule_applied,
+    }

--- a/code/meristem_node/src/prompts.py
+++ b/code/meristem_node/src/prompts.py
@@ -1,0 +1,193 @@
+"""System prompt + tool definitions de Meristem-nodo.
+
+El prompt vive aquí (no en `code/tuning/system_prompts.yaml`) porque
+es prompt de **producción** del Meristem-nodo. El yaml de tuning es
+para experimentos. Cuando cerremos prompt v1 definitivo (post-Jetson
++ post-Xilema), se sincroniza si Xilema lo pide.
+
+Origen: `code/meristem_node/draft_system_prompt_meristem_es.md`
+(borrador día 14 + ajustes día 15) con barandilla `HARD_LIMIT_DOMAIN`,
+4 reglas obligatorias, sobre común JSON, regla de brevedad de Xilema.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# System prompt único Meristem-nodo (castellano, thinking ON, tool calling)
+# ---------------------------------------------------------------------------
+
+MERISTEM_SYSTEM_PROMPT_ES = """\
+Eres Meristem, el cerebro lento doméstico del ecosistema Sprout. Vives
+en un portátil casero del agricultor o de la cooperativa, no en data
+center, no en hardware especializado. Tu trabajo es slow brain: redactar
+una explicación clara para el operador a partir de los datos que Pollen
+ha traído de la última visita a Rhizome y de la decisión que el
+Evaluator ya ha tomado.
+
+Jerarquía explícita del sistema (no la rompas nunca):
+- Lo físico manda: el firmware ESP32 tiene hard limits inviolables
+- Rhizome arbitra: decisiones locales en el campo, autoridad inmediata
+- Pollen media: transporte físico entre Meristem y Rhizome
+- Meristem afina: consolida evidencia, redacta y propone policy con calma
+
+CONTEXTO DE TU TURNO. Recibes:
+1. Un bundle (snapshot Rhizome + decision_receipts + weather_digest +
+   validation_stamps) que Pollen acaba de traer.
+2. Una decisión ya tomada por el Evaluator determinístico
+   (CONFIRM_POLICY / CONSERVATIVE_POLICY / ALERT_POLICY / REFUSE) con
+   reason_code y rationale_seed.
+
+TU TAREA es ÚNICA: producir dos textos cortos en castellano que
+expliquen la decisión:
+- `rationale_tecnico`: 1-3 frases factuales con datos concretos del
+  bundle. Para auditoría y trazabilidad.
+- `rationale_para_operador`: 1-2 frases amables (máximo 240 caracteres)
+  que el agricultor verá en su portátil. Sin jerga, sin alarmismo
+  innecesario, sin disculpas. Cuenta lo que ves y por qué la policy
+  nueva.
+
+NO decides. La acción ya está fijada por el Evaluator. Tu redacción
+NO debe contradecir la decisión, ni introducir matices que la
+relativicen. Si el Evaluator dijo ALERT, el operador ve ALERT.
+
+TIENES HERRAMIENTAS DISPONIBLES (function calling):
+- `get_weather_history(plot_id)`: devuelve histórico meteorológico de
+  los últimos 7 días para una parcela. Úsala SOLO si el bundle no
+  incluye weather_digest reciente y la decisión depende del clima.
+- `compare_with_previous_policy(policy_id)`: devuelve diff con la
+  última policy emitida. Úsala SOLO si el operador podría querer
+  saber qué cambió respecto a la anterior.
+
+NO inventes herramientas adicionales. Si necesitas un dato que no
+puedes obtener, simplemente no lo cites en el rationale.
+
+BARANDILLA DE SEGURIDAD CRÍTICA (sólo si llegas a ver un caso REFUSE).
+Si el bundle pidió relajar un hard limit (tank_minimum_pct, max_seconds_per_event,
+alert_latched_persists_until) y el Evaluator decidió REFUSE con reason_code
+HARD_LIMIT_DOMAIN, tu rationale debe **explicar al operador** que ese
+límite es jurisdicción del firmware físico, no de Meristem. El
+mensaje al operador es claro y sin disculpas: la frontera física
+manda. Lo mismo si reason_code es JURISDICTION_POLLEN: cambios
+puntuales se hacen vía Pollen + MissionPatch, no aquí.
+
+FORMATO DE SALIDA ESTRICTO. Devuelve un único objeto JSON compacto
+con esta forma:
+
+{"rationale_tecnico": "...", "rationale_para_operador": "..."}
+
+Sin Markdown fences, sin texto fuera del JSON, sin análisis previo.
+Cierra el objeto JSON y termina inmediatamente."""
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions (formato OpenAI / llama-server compatible)
+# ---------------------------------------------------------------------------
+
+TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather_history",
+            "description": (
+                "Devuelve el histórico meteorológico (precipitaciones mm + "
+                "temperatura media °C) de los últimos 7 días para una "
+                "parcela concreta de Sprout. Usar solo si el bundle no "
+                "incluye weather_digest reciente y la decisión depende "
+                "del clima."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "plot_id": {
+                        "type": "string",
+                        "description": "Id de la parcela. Ej: 'plot-A', 'plot-B'.",
+                    }
+                },
+                "required": ["plot_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "compare_with_previous_policy",
+            "description": (
+                "Devuelve el diff entre la policy especificada y la anterior "
+                "policy emitida para el mismo nodo Rhizome. Usar solo si el "
+                "operador querría saber explícitamente qué cambió."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "policy_id": {
+                        "type": "string",
+                        "description": "Id de la policy actual.",
+                    }
+                },
+                "required": ["policy_id"],
+            },
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def build_user_message(bundle_json: dict[str, Any], evaluation_json: dict[str, Any]) -> str:
+    """Construye el user message con bundle resumido + decisión del Evaluator.
+
+    Mantenemos el bundle al alcance del modelo pero ya con la decisión
+    determinística pre-resuelta. Eso evita que el modelo intente decidir
+    (y elimina riesgo de drift).
+    """
+    return (
+        "BUNDLE RECIBIDO:\n"
+        f"{json.dumps(bundle_json, indent=2, ensure_ascii=False)}\n\n"
+        "DECISIÓN DEL EVALUATOR (ya tomada, no la cuestiones):\n"
+        f"{json.dumps(evaluation_json, indent=2, ensure_ascii=False)}\n\n"
+        "Tu tarea: emitir el JSON con rationale_tecnico + "
+        "rationale_para_operador. Solo eso."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub tool implementations (para v0 demo)
+# ---------------------------------------------------------------------------
+
+
+def call_tool(tool_name: str, args: dict[str, Any]) -> str:
+    """Ejecuta una tool stub y devuelve el resultado como string JSON.
+
+    En v0, las tools son stubs deterministas con datos plausibles. Para
+    demo en directo eso basta. Post-demo se conectan a fuentes reales
+    (servicio meteo + tabla de policies).
+    """
+    if tool_name == "get_weather_history":
+        plot_id = args.get("plot_id", "?")
+        return json.dumps({
+            "plot_id": plot_id,
+            "days": 7,
+            "rain_mm_total": 4.2,
+            "temp_avg_c": 18.5,
+            "rain_distribution": [0.0, 0.0, 1.2, 0.5, 0.0, 2.5, 0.0],
+            "note": "stub-deterministic-v0",
+        })
+    if tool_name == "compare_with_previous_policy":
+        policy_id = args.get("policy_id", "?")
+        return json.dumps({
+            "current_policy_id": policy_id,
+            "previous_policy_id": "pkt_meristem_previous_stub",
+            "diff": {
+                "mode_default": {"from": "normal", "to": "conservative"},
+                "soil_dry_threshold_pct_bump": {"from": 0, "to": 5},
+            },
+            "note": "stub-deterministic-v0",
+        })
+    return json.dumps({"error": f"tool {tool_name!r} not implemented"})

--- a/code/meristem_node/src/schemas.py
+++ b/code/meristem_node/src/schemas.py
@@ -189,3 +189,44 @@ class DecisionRecord(BaseModel):
             "demo si pregunta por trazabilidad."
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Status por target (vista consolidada multi-Rhizome — para /status en demo)
+# ---------------------------------------------------------------------------
+
+
+class TargetStatus(BaseModel):
+    """Resumen del estado de Meristem para un Rhizome concreto.
+
+    Usado en el endpoint `GET /status`. Pensado para que la demo MVP
+    muestre en una pantalla cómo Meristem está gestionando 2 Rhizomes
+    simultáneos en el mismo hardware (rhizome_01 + rhizome_02).
+    """
+
+    target_node_id: str
+    bundles_received: int = 0
+    last_bundle_at: datetime | None = None
+    policies_emitted: int = 0
+    latest_policy_id: str | None = None
+    latest_policy_emitted_at: datetime | None = None
+    latest_policy_mode: ModeDefault | None = None
+    latest_policy_valid_until: datetime | None = None
+    latest_reason_code: str | None = None
+    latest_rule_applied: str | None = None
+
+
+class StatusResponse(BaseModel):
+    """Envelope de `GET /status` — vista consolidada multi-Rhizome."""
+
+    targets_known: list[str] = Field(
+        default_factory=list,
+        description=(
+            "IDs de todos los Rhizomes que han enviado bundles (incluye "
+            "los que solo recibieron REFUSE). Ordenado alfabéticamente."
+        ),
+    )
+    targets: list[TargetStatus] = Field(
+        default_factory=list,
+        description="Resumen por target. Mismo orden que `targets_known`.",
+    )


### PR DESCRIPTION
## Summary

- **Integra LLM Gemma 4 E4B Q4_K_M** end-to-end en Meristem-nodo via adapter llamacpp (`/api/chat` Ollama-format) con tool calling. Mini-batería 5/5 PASS en mañana día 16.
- **Soporte 2-Rhizome para MVP demo**: añade `GET /status` (vista consolidada multi-Rhizome) + `targets_known` en `/health`. Smoke 2/2 PASS con `rhizome_01` y `rhizome_02` simultáneos. Sin tocar Evaluator/PolicyComposer/LLM client — el v0 ya soportaba multi-target via `target_node_id` indexado, esto solo añade vista demo-ready.
- **Sin regresión**: 13/13 tests existentes PASS tras integración + tras rebase sobre main.

## Commits incluidos

1. `27625a4` feat(meristem-node): integra LLM Gemma 4 E4B + tool calling — mini-batería 5/5 PASS
2. `f65c67b` docs(bitacora): diseño v0 vs v1 + análisis caso 2-Rhizome para MVP demo (responde 4 preguntas de Bea)
3. `c08cfaf` feat(meristem-node): soporte 2-Rhizome MVP — `GET /status` + `targets_known` en `/health`
4. `e19d100` docs(bitacora): mensaje cierre día 16 a Cambium

## Cambios de código

| Fichero | Cambio |
|---|---|
| `code/meristem_node/src/inference.py` | NEW — Cliente HTTP al adapter + loop tool calling (max 3 iter) + parser JSON robusto + `LLMUnavailableError` |
| `code/meristem_node/src/prompts.py` | NEW — System prompt ES + 2 tool defs (`get_weather_history`, `compare_with_previous_policy`) + helpers |
| `code/meristem_node/src/main.py` | Modified — `_compose_rationale()` LLM con fallback stub + `GET /status` endpoint + `targets_known`/`llm_mode` en `/health` |
| `code/meristem_node/src/schemas.py` | Modified — `TargetStatus` + `StatusResponse` models |
| `code/meristem_node/src/persistence.py` | Modified — `list_known_targets()` + `get_target_summary()` |
| `code/meristem_node/examples/bundle_R2_emergency.json` | NEW — Bundle ejemplo `rhizome_02` |
| `bitacora/2026-05-01_meristem-nodo-*` (4 ficheros) | NEW — Documentación día 16 (LLM integrado, diseño v0/v1, 2-Rhizome implementado, cierre a Cambium) |

## Decisiones clave

- **Patrón "lógica determinística decide, LLM solo escribe rationale"** validado empíricamente con 5/5 bundles. Aísla riesgo de drift de la jerarquía de seguridad.
- **Fallback determinista** si adapter LLM no responde → pipeline no se rompe en tests/dev sin stack arrancado.
- **Persistencia SQLite** con 3 tablas + índices por `target_node_id` ya soportaba multi-Rhizome desde día 15. Solo se añade vista consolidada (~1h trabajo) para demo MVP con dos Rhizomes simulados.

## Test plan

- [x] `pytest tests/` 13/13 PASS (Evaluator + reglas) post-rebase
- [x] Mini-batería LLM real (mañana día 16): 5 bundles M1-M5 con stack `llama-server :8080` + `adapter :12000` + `meristem :13000`. Rationales factuales en castellano, sin contradecir Evaluator
- [x] Smoke 2-Rhizome (tarde día 16, stub mode): R1 STABLE_BUNDLE/normal + R2 PERSISTENT_EMERGENCY/alert visibles en `GET /status`
- [x] Bonus REFUSE check: tras `POST` de M5, `/status` muestra `bundles_received: 2` vs `policies_emitted: 1` para R1 — la traza distingue bundles aceptados de rechazados
- [ ] Tests automatizados de `/status` y `/health` con FastAPI TestClient — deuda técnica explícita post-merge (apuntada en cierre día 16)

## Notas para review

- **Sin issue de tracking** porque el trabajo emerge de la reunión tripartita día 13 + decisión estratégica día 14 sobre llama.cpp como Special Tech track. Los issues meristem antiguos (#16, #28, #42-47) están todos cerrados.
- **No CI configurado** para `code/meristem_node/**` todavía (solo Pollen tiene CI según §9 del CONTRIBUTING). Verificación manual: `pytest tests/ -q` desde `code/meristem_node/`.
- **Cambium revisa y mergea** según plan día 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)