### PR TITLE
chore(rhizome): add Jetson runtime profiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes text eol=lf
+code/rhizome/jetson/*.sh text eol=lf

--- a/bitacora/2026-05-03_endodermis-dia18-gpu-offload_endodermis.md
+++ b/bitacora/2026-05-03_endodermis-dia18-gpu-offload_endodermis.md
@@ -416,6 +416,8 @@ code/rhizome/jetson/README.md
 code/rhizome/jetson/run_runtime.sh
 code/rhizome/jetson/start_adapter.sh
 code/rhizome/jetson/smoke_adapter.sh
+code/rhizome/jetson/collect_baseline.sh
+code/rhizome/jetson/run_battery.sh
 ```
 
 Objetivo:
@@ -433,6 +435,8 @@ Perfiles:
 | `run_runtime.sh gpu-experimental` | arranca `llama-server` con `--fit off --no-op-offload` |
 | `start_adapter.sh` | arranca adapter `llamacpp` en `:12000` via contenedor Python |
 | `smoke_adapter.sh` | POST minimo `/api/chat` y valida JSON en `message.content` |
+| `collect_baseline.sh` | captura baseline Jetson sin `sudo` |
+| `run_battery.sh` | ejecuta `critical`, `remaining` o `full` sin pisar JSONL canonicos |
 
 Verificacion:
 
@@ -445,6 +449,7 @@ Verificacion:
 - `smoke_adapter.sh` con GPU experimental: JSON OK;
 - restaurado `run_runtime.sh safe-cpu` al final;
 - smoke final CPU-only: OK.
+- `run_battery.sh critical --dry-run` en Jetson: OK.
 
 Estado final dejado en Jetson:
 

--- a/bitacora/2026-05-03_endodermis-dia18-gpu-offload_endodermis.md
+++ b/bitacora/2026-05-03_endodermis-dia18-gpu-offload_endodermis.md
@@ -1,0 +1,403 @@
+# Dia 18 - Frente GPU offload Jetson
+
+**Autora:** Endodermis  
+**Fecha:** 2026-05-03  
+**Dia de proyecto:** 18  
+**Rama:** `feat/endodermis/jetson-gpu-offload-day18`
+
+## 1. Objetivo
+
+Bea prioriza abrir primero el frente GPU.
+
+Objetivo acotado:
+
+- diagnosticar por que Gemma 4 E2B Q4_K_S no arranca con offload CUDA en
+  Jetson Orin Nano Super;
+- no tocar ESP32, firmware ni frontera fisica;
+- no cambiar prompts ni contratos;
+- mantener disponible el runtime estable CPU-only como fallback de demo.
+
+## 2. Estado inicial
+
+Main actualizado hasta `7ccf570`.
+
+Jetson viva:
+
+| Campo | Valor |
+|---|---|
+| hostname | `rhizome-01-node` |
+| fecha Jetson | `2026-05-03T10:39:46+02:00` |
+| contenedores | `sprout-llama-e2b` y `sprout-adapter-12000` vivos desde ~15 h |
+| RAM | 7.4 GiB total, ~3.8 GiB available |
+| swap | ~226 MiB usado |
+| temperatura idle | ~40 C |
+
+Dato importante:
+
+```text
+tegrastats: lfb 1x1MB
+/proc/meminfo: CmaTotal 262144 kB, CmaFree 692 kB
+```
+
+Lectura inicial:
+
+- hay memoria disponible agregada;
+- pero la memoria fisica contigua disponible esta casi agotada;
+- esto encaja con el fallo dia 17: `NvMapMemAllocInternalTagged ... error 12`
+  y `cudaMalloc failed: out of memory`.
+
+## 3. Imagen y binario
+
+Imagen:
+
+```text
+ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-orin
+```
+
+Detalles:
+
+| Campo | Valor |
+|---|---|
+| image id | `sha256:fc4f7159df6b...` |
+| digest | `sha256:ba196b9760fda683a84048916ec6666650cc4b05d3bfc05c02bf1917553e55f1` |
+| created | `2026-04-30T00:26:27Z` |
+| arch | `aarch64` |
+| llama.cpp | `version: 8966 (7b8443ac7)` |
+| CUDA arch | `8.7` |
+
+Modelo:
+
+```text
+/home/rhizome_01/sprout_models/gemma-4-E2B-it-Q4_K_S.gguf
+```
+
+Estado: descargado dia 17, ~2.9 GiB.
+
+## 4. Hipotesis de trabajo
+
+H1. No es un fallo de contrato ni de prompt: la bateria Rhizome v0.5 ya paso
+18/18 en Jetson.
+
+H2. No es simplemente "RAM total insuficiente": hay ~3.8 GiB available.
+
+H3. El fallo probable esta en buffers CUDA/NvMap que requieren memoria contigua
+o una reserva que la Jetson no puede satisfacer tras el estado actual.
+
+H4. Un reboot frio o un arranque sin servicios previos puede cambiar el
+resultado de offload. Si es asi, la solucion operativa para demo puede ser:
+boot limpio -> lanzar runtime GPU primero -> luego adapter.
+
+---
+
+## 5. Parada temporal de servicios Sprout
+
+Para diagnostico GPU paro temporalmente:
+
+```bash
+docker stop sprout-adapter-12000 sprout-llama-e2b
+```
+
+No se toca ESP32 ni frontera fisica.
+
+Resultado tras parar:
+
+| Campo | Antes | Despues |
+|---|---:|---:|
+| MemAvailable | ~3.8 GiB | ~5.3 GiB |
+| `tegrastats lfb` | `1x1MB` | `48x4MB` |
+| `CmaFree` | ~692 KB | ~20 MB |
+
+Lectura:
+
+- parar servicios libera RAM agregada y mejora bloques libres;
+- `CmaFree` sigue bajo;
+- el estado de memoria contigua importa para CUDA/NvMap en Jetson.
+
+## 6. Probe incremental `llama-cli`
+
+Primer intento con `llama-cli` parecia timeout, pero era modo conversacion
+esperando siguiente turno. Cambio a:
+
+```bash
+--single-turn --simple-io --no-display-prompt
+```
+
+Con `-c 512 -b 128 -ub 128`:
+
+| `-ngl` | Resultado | Nota |
+|---:|---|---|
+| 1 | OK | GPU visible |
+| 2 | OK | GPU visible |
+| 4 | OK | GPU visible |
+| 8 | OK | GPU visible |
+| 16 | FAIL | `GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS)` |
+
+El fallo `-ngl 16` no es `cudaMalloc`; es un assert interno del scheduler.
+Stack trace entra por `common_params_fit_impl` / `sched_reserve`.
+
+## 7. Flags que desbloquean offload
+
+Pruebo mitigaciones con `-ngl 16`:
+
+| Flags | Resultado |
+|---|---|
+| `--no-op-offload` | OK |
+| `--no-kv-offload` | FAIL |
+| `--no-op-offload --no-kv-offload` | OK |
+| `--flash-attn off` | OK |
+| `--split-mode none` | FAIL |
+
+Prueba alta con:
+
+```bash
+--fit off --no-op-offload
+```
+
+Resultado:
+
+| `-ngl` | Resultado | Prompt tok/s aprox | Generation tok/s aprox |
+|---:|---|---:|---:|
+| 24 | OK | 23.0 | 9.5 |
+| 32 | OK | 27.9 | 11.9 |
+| 36 | OK | 23.9 | 24.2 |
+| 99 | OK | 22.4 | 22.4 |
+
+Conclusion tecnica:
+
+- la GPU funciona;
+- el comando de ayer fallaba por combinacion de offload automatico/scheduler,
+  no porque el modelo sea imposible en Orin Nano;
+- flags candidatos:
+
+```bash
+--fit off --no-op-offload
+```
+
+## 8. `llama-server` GPU full offload
+
+Comando que arranca:
+
+```bash
+docker run -d --name sprout-llama-e2b \
+  --runtime=nvidia \
+  --network host \
+  -v "$HOME/sprout_models:/models:ro" \
+  ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-orin \
+  llama-server -m /models/gemma-4-E2B-it-Q4_K_S.gguf \
+    -c 2048 -b 128 -ub 128 -ngl 99 \
+    --fit off \
+    --no-op-offload \
+    --reasoning off \
+    --host 0.0.0.0 --port 8080
+```
+
+Logs relevantes:
+
+```text
+load_tensors: offloaded 36/36 layers to GPU
+CUDA0 model buffer size = 1347.84 MiB
+CUDA0 KV buffer size = 12.00 MiB
+CUDA0 KV buffer size = 24.00 MiB
+CUDA0 compute buffer size = 140.75 MiB
+graph splits = 2
+main: server is listening on http://0.0.0.0:8080
+```
+
+Smoke adapter:
+
+| Campo | CPU-only dia 17 | GPU full dia 18 |
+|---|---:|---:|
+| smoke minimo `/api/chat` | ~2277 ms | ~1152 ms |
+| tokens out | 7 | 7 |
+| JSON limpio | si | si |
+
+## 9. Mini-bateria critica GPU full
+
+Primera pasada GPU full:
+
+| Prompt | envelope | status | duration_ms |
+|---|---:|---:|---:|
+| RD01 | OK | OK | 4447 |
+| RD03 | OK | OK | 2544 |
+| RD08 | OK | OK | 2662 |
+| RA02 | OK | OK | 1648 |
+| RA04 | OK | OK | 1685 |
+| RH02 | FAIL | FAIL | 6655 |
+
+Fallo RH02:
+
+- JSON sin fence;
+- `done_reason=stop`;
+- falta una llave final de cierre;
+- no es `length`, es desviacion de generacion.
+
+Repeticion GPU full:
+
+```text
+6/6 envelope_valid
+6/6 status_match
+```
+
+Duraciones repeticion:
+
+| Prompt | duration_ms |
+|---|---:|
+| RD01 | 2681 |
+| RD03 | 2448 |
+| RD08 | 2640 |
+| RA02 | 1643 |
+| RA04 | 1635 |
+| RH02 | 4379 |
+
+Lectura:
+
+- GPU full es mucho mas rapido;
+- el fallo RH02 parece variabilidad, no bloqueo sistematico;
+- aun asi no se puede declarar quality pass con una pasada fallida.
+
+## 10. Bateria restante GPU full
+
+Ejecuto los 12 restantes con GPU full.
+
+Resultado:
+
+```text
+12/12 envelope_valid
+11/12 status_match
+```
+
+Fallo:
+
+| Prompt | Esperado | Obtenido |
+|---|---|---|
+| RD04_defer_due_to_dispute | `ok` | `need_clarification` |
+
+Contenido resumido:
+
+```json
+{
+  "task": "decide_action",
+  "status": "need_clarification",
+  "question_es": "La validación del sensor para parcela A está disputada. ¿Desea proceder con el riego o esperar una nueva validación?",
+  "payload": null
+}
+```
+
+Lectura:
+
+- no es peligroso: ante disputa pide confirmacion humana;
+- pero rompe contrato de bateria, porque el baseline espera `ok` con accion
+  prudente/deferida;
+- por tanto GPU full no es quality pass todavia.
+
+## 11. Mitigaciones probadas para calidad
+
+### `temperature=0`
+
+Probe RD04 + RH02:
+
+| Prompt | Resultado |
+|---|---|
+| RD04 | sigue `need_clarification` |
+| RH02 | OK |
+
+`temperature=0` reduce variabilidad de RH02, pero no corrige RD04.
+
+### Offload parcial `-ngl 12`
+
+Arranca, pero:
+
+- mucho mas lento por muchos graph splits;
+- RD04 sigue fallando;
+- RH02 falla envelope en el probe temp0.
+
+No sirve como punto medio.
+
+### Full GPU sin prompt cache / slot unico
+
+Comando con:
+
+```bash
+--parallel 1 --cache-ram 0 --no-cache-prompt --no-cache-idle-slots
+```
+
+RD04 repetido 5 veces:
+
+```text
+0/5 status_match
+```
+
+No mejora; empeora.
+
+### RD04 repetido con full GPU normal
+
+5 repeticiones, temperatura 0.3:
+
+```text
+5/5 envelope_valid
+2/5 status_match
+3/5 need_clarification
+```
+
+Lectura:
+
+- hay deriva semantica real en RD04 bajo GPU full;
+- la salida sigue siendo segura, pero no estable segun contrato.
+
+## 12. Estado final dejado en Jetson
+
+Restauro runtime estable CPU-only:
+
+```bash
+docker run -d --name sprout-llama-e2b \
+  --runtime=nvidia \
+  --network host \
+  -v "$HOME/sprout_models:/models:ro" \
+  ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-orin \
+  llama-server -m /models/gemma-4-E2B-it-Q4_K_S.gguf \
+    -c 2048 -ngl 0 \
+    --device none \
+    --no-op-offload \
+    --reasoning off \
+    --host 0.0.0.0 --port 8080
+```
+
+Adapter sigue vivo en `:12000`.
+
+Smoke final:
+
+```text
+status=200
+content='Hola.'
+backend=local-llamacpp
+duration_ms=1406
+smoke OK
+```
+
+## 13. Veredicto
+
+**GPU runtime pass:** SI.
+
+- La Jetson puede cargar Gemma 4 E2B Q4_K_S con `llama-server`;
+- `36/36` capas pueden ir a GPU;
+- comando clave: `--fit off --no-op-offload`;
+- rendimiento de smoke y mini-bateria mejora claramente.
+
+**GPU quality pass:** NO TODAVIA.
+
+- GPU full produce 18/18 JSON valido en la bateria completa, pero 17/18
+  `status_match` por RD04;
+- RD04 es seguro pero fuera de contrato;
+- RH02 mostro una vez JSON incompleto, aunque paso en repeticion.
+
+**Demo recommendation hoy:** usar CPU-only estable para demostraciones
+contractuales, o usar GPU solo si el flujo real tiene validador determinista
+delante y no depende del LLM para decidir RD04.
+
+**Siguiente PR recomendada:** wrapper de arranque documentado con dos perfiles:
+
+1. `safe-cpu`: 18/18 quality pass, lento, default demo seguro;
+2. `gpu-experimental`: `--fit off --no-op-offload`, rapido, marcado como
+   experimental hasta cerrar RD04/RH02.
+
+No he tocado firmware, ESP32 ni contratos.

--- a/bitacora/2026-05-03_endodermis-dia18-gpu-offload_endodermis.md
+++ b/bitacora/2026-05-03_endodermis-dia18-gpu-offload_endodermis.md
@@ -401,3 +401,60 @@ delante y no depende del LLM para decidir RD04.
    experimental hasta cerrar RD04/RH02.
 
 No he tocado firmware, ESP32 ni contratos.
+
+---
+
+## 14. Operacionalizacion sin depender de Xilema
+
+Bea pregunta si puedo avanzar mientras ella y Xilema miran ESP32. Avanzo en
+zona Jetson pura, sin tocar frontera fisica.
+
+Creo:
+
+```text
+code/rhizome/jetson/README.md
+code/rhizome/jetson/run_runtime.sh
+code/rhizome/jetson/start_adapter.sh
+code/rhizome/jetson/smoke_adapter.sh
+```
+
+Objetivo:
+
+- convertir la bitacora GPU/CPU en comandos reproducibles;
+- evitar que Cambium/Xilema tengan que copiar comandos largos;
+- dejar claro que `safe-cpu` es el default contractual;
+- dejar `gpu-experimental` disponible sin promoverlo a demo.
+
+Perfiles:
+
+| Script | Funcion |
+|---|---|
+| `run_runtime.sh safe-cpu` | arranca `llama-server` CPU-only estable |
+| `run_runtime.sh gpu-experimental` | arranca `llama-server` con `--fit off --no-op-offload` |
+| `start_adapter.sh` | arranca adapter `llamacpp` en `:12000` via contenedor Python |
+| `smoke_adapter.sh` | POST minimo `/api/chat` y valida JSON en `message.content` |
+
+Verificacion:
+
+- `bash -n` local: OK;
+- `bash -n` remoto en Jetson: OK;
+- `run_runtime.sh safe-cpu` remoto: health OK;
+- `start_adapter.sh` remoto: health OK;
+- `smoke_adapter.sh` remoto: JSON OK;
+- `run_runtime.sh gpu-experimental` remoto: health OK;
+- `smoke_adapter.sh` con GPU experimental: JSON OK;
+- restaurado `run_runtime.sh safe-cpu` al final;
+- smoke final CPU-only: OK.
+
+Estado final dejado en Jetson:
+
+```text
+sprout-llama-e2b      Up, perfil safe-cpu
+sprout-adapter-12000  Up, backend llamacpp
+```
+
+Decision:
+
+- estos scripts son operativos, no cambian contratos;
+- quedan listos para PR pequeno;
+- no sustituyen una decision de Cambium/Xilema sobre perfil GPU demo.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -1,0 +1,137 @@
+# Rhizome Jetson Runtime
+
+Scripts operativos para arrancar Gemma 4 E2B en Jetson Orin Nano Super con
+`llama.cpp` sin depender de Ollama ni de hardware ESP32.
+
+Estos scripts no tocan firmware, sensores, actuadores ni reglas fisicas. Solo
+gestionan el runtime local de inferencia y el adapter Ollama-compatible.
+
+## Perfiles
+
+| Perfil | Uso | Estado dia 18 |
+|---|---|---|
+| `safe-cpu` | Demo contractual y bateria Rhizome v0.5 | Quality pass 18/18, lento |
+| `gpu-experimental` | Diagnostico/rendimiento | Runtime pass, no quality pass aun |
+
+### `safe-cpu`
+
+Arranca `llama-server` en `:8080` con:
+
+```bash
+-ngl 0 --device none --no-op-offload --reasoning off
+```
+
+Es el perfil seguro documentado por Endodermis el dia 17:
+
+- mini-test critico frio 6/6;
+- mini-test critico caliente 6/6;
+- bateria Rhizome v0.5 combinada 18/18;
+- sin OOM, sin truncamiento, sin Markdown fences.
+
+### `gpu-experimental`
+
+Arranca `llama-server` en `:8080` con:
+
+```bash
+-ngl 99 --fit off --no-op-offload --reasoning off
+```
+
+El flag clave es `--no-op-offload`; sin el, el build de `llama.cpp` en Jetson
+puede abortar con:
+
+```text
+GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS)
+```
+
+Estado dia 18:
+
+- carga 36/36 capas en GPU;
+- acelera mucho las respuestas;
+- aun no es quality pass para Rhizome v0.5 porque RD04 muestra deriva
+  semantica segura (`need_clarification` en lugar de `ok`).
+
+## Requisitos
+
+- Jetson Orin Nano Super con JetPack 6.x.
+- Docker instalado.
+- runtime NVIDIA disponible.
+- usuario con permiso para ejecutar `docker`.
+- modelo descargado en:
+
+```bash
+$HOME/sprout_models/gemma-4-E2B-it-Q4_K_S.gguf
+```
+
+## Arranque
+
+Desde la Jetson:
+
+```bash
+cd ~/sprout/code/rhizome/jetson
+
+./run_runtime.sh safe-cpu
+./start_adapter.sh
+./smoke_adapter.sh
+```
+
+Para probar GPU:
+
+```bash
+./run_runtime.sh gpu-experimental
+./start_adapter.sh
+./smoke_adapter.sh
+```
+
+## Variables utiles
+
+```bash
+MODEL_PATH=$HOME/sprout_models/gemma-4-E2B-it-Q4_K_S.gguf
+LLAMA_IMAGE=ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-orin
+LLAMA_PORT=8080
+ADAPTER_PORT=12000
+CTX_SIZE=2048
+N_GPU_LAYERS=99
+```
+
+Ejemplo:
+
+```bash
+CTX_SIZE=1024 ./run_runtime.sh gpu-experimental
+```
+
+## Verificacion
+
+Health directo de `llama-server`:
+
+```bash
+curl -s http://127.0.0.1:8080/health
+```
+
+Health del adapter:
+
+```bash
+curl -s http://127.0.0.1:12000/health
+```
+
+Smoke:
+
+```bash
+./smoke_adapter.sh
+```
+
+## Interpretacion
+
+Para demo y pruebas contractuales, usar `safe-cpu` hasta que Cambium/Xilema
+acepten formalmente un perfil GPU.
+
+Para experimentos de rendimiento, usar `gpu-experimental` y ejecutar al menos:
+
+```bash
+cd ~/sprout/code/tuning
+python harness.py --matrix matrix_rhizome_v05.yaml \
+  --adapter-url http://127.0.0.1:12000 \
+  --out results/rhizome_v05_gpu_probe.jsonl
+```
+
+No promover GPU a perfil demo hasta que la bateria critica sea estable y RD04
+quede alineado con el contrato.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -72,6 +72,7 @@ cd ~/sprout/code/rhizome/jetson
 ./run_runtime.sh safe-cpu
 ./start_adapter.sh
 ./smoke_adapter.sh
+./run_battery.sh critical
 ```
 
 Para probar GPU:
@@ -80,6 +81,7 @@ Para probar GPU:
 ./run_runtime.sh gpu-experimental
 ./start_adapter.sh
 ./smoke_adapter.sh
+./run_battery.sh critical
 ```
 
 ## Variables utiles
@@ -118,6 +120,25 @@ Smoke:
 ```bash
 ./smoke_adapter.sh
 ```
+
+Baseline operativo:
+
+```bash
+./collect_baseline.sh | tee jetson_baseline_$(date -u +%Y%m%dT%H%M%SZ).log
+```
+
+Bateria Rhizome v0.5:
+
+```bash
+./run_battery.sh critical          # 6 prompts criticos
+./run_battery.sh remaining         # 12 prompts restantes
+./run_battery.sh full              # critical + remaining
+./run_battery.sh critical --dry-run
+```
+
+Los resultados se escriben en `code/tuning/results/` dentro del repo montado
+en el contenedor del adapter, con un sufijo UTC para no pisar los JSONL
+canonicos.
 
 ## Interpretacion
 

--- a/code/rhizome/jetson/collect_baseline.sh
+++ b/code/rhizome/jetson/collect_baseline.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LLAMA_CONTAINER="${LLAMA_CONTAINER:-sprout-llama-e2b}"
+ADAPTER_CONTAINER="${ADAPTER_CONTAINER:-sprout-adapter-12000}"
+LLAMA_PORT="${LLAMA_PORT:-8080}"
+ADAPTER_PORT="${ADAPTER_PORT:-12000}"
+
+section() {
+  printf '\n=== %s ===\n' "$1"
+}
+
+run_or_note() {
+  if "$@"; then
+    return 0
+  fi
+  rc=$?
+  echo "[unavailable rc=$rc] $*" >&2
+  return 0
+}
+
+section "identity"
+run_or_note hostname
+run_or_note whoami
+run_or_note date --iso-8601=seconds
+run_or_note uname -a
+
+section "jetson release"
+if [ -f /etc/nv_tegra_release ]; then
+  cat /etc/nv_tegra_release
+else
+  echo "/etc/nv_tegra_release not found"
+fi
+
+section "memory"
+run_or_note free -h
+if [ -r /proc/meminfo ]; then
+  grep -E 'MemTotal|MemFree|MemAvailable|SwapTotal|SwapFree|CmaTotal|CmaFree|Huge|Vmalloc' /proc/meminfo || true
+fi
+
+section "storage"
+run_or_note df -h /
+run_or_note lsblk
+
+section "power"
+run_or_note nvpmodel -q
+if command -v jetson_clocks >/dev/null 2>&1; then
+  if [ "$(id -u)" -eq 0 ]; then
+    run_or_note jetson_clocks --show
+  else
+    echo "jetson_clocks available but requires root; skipped"
+  fi
+else
+  echo "jetson_clocks not found"
+fi
+
+section "docker"
+run_or_note docker --version
+if command -v docker >/dev/null 2>&1; then
+  docker info 2>/dev/null | grep -E 'Runtimes|Default Runtime|Docker Root Dir|Server Version' || true
+  docker ps --filter "name=sprout" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' || true
+fi
+
+section "sprout health"
+run_or_note curl -fsS "http://127.0.0.1:$LLAMA_PORT/health"
+echo
+run_or_note curl -fsS "http://127.0.0.1:$ADAPTER_PORT/health"
+echo
+
+section "container logs tail"
+if command -v docker >/dev/null 2>&1; then
+  echo "--- $LLAMA_CONTAINER ---"
+  docker logs "$LLAMA_CONTAINER" --tail 40 2>/dev/null || true
+  echo "--- $ADAPTER_CONTAINER ---"
+  docker logs "$ADAPTER_CONTAINER" --tail 40 2>/dev/null || true
+fi
+
+section "tegrastats"
+if command -v tegrastats >/dev/null 2>&1; then
+  timeout 3s tegrastats --interval 1000 || true
+else
+  echo "tegrastats not found"
+fi

--- a/code/rhizome/jetson/run_battery.sh
+++ b/code/rhizome/jetson/run_battery.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-critical}"
+DRY_RUN="${DRY_RUN:-false}"
+ADAPTER_CONTAINER="${ADAPTER_CONTAINER:-sprout-adapter-12000}"
+ADAPTER_URL="${ADAPTER_URL:-http://127.0.0.1:12000}"
+LABEL="${LABEL:-jetson_$(date -u +%Y%m%dT%H%M%SZ)}"
+
+if [ "${2:-}" = "--dry-run" ]; then
+  DRY_RUN=true
+fi
+
+case "$MODE" in
+  critical|remaining|full)
+    ;;
+  *)
+    echo "unknown battery mode: $MODE" >&2
+    echo "valid modes: critical | remaining | full" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found" >&2
+  exit 1
+fi
+
+if ! docker ps --filter "name=$ADAPTER_CONTAINER" --format '{{.Names}}' | grep -q "^$ADAPTER_CONTAINER$"; then
+  echo "adapter container not running: $ADAPTER_CONTAINER" >&2
+  echo "Run ./start_adapter.sh first." >&2
+  exit 1
+fi
+
+run_matrix() {
+  matrix="$1"
+  out="$2"
+  dry_flag=""
+  if [ "$DRY_RUN" = "true" ]; then
+    dry_flag="--dry-run"
+  fi
+
+  echo "Running matrix=$matrix out=results/$out dry_run=$DRY_RUN"
+  docker exec "$ADAPTER_CONTAINER" sh -lc \
+    "cd /app/code/tuning && python harness.py --matrix $matrix --adapter-url $ADAPTER_URL --out results/$out $dry_flag"
+}
+
+case "$MODE" in
+  critical)
+    run_matrix "matrix_rhizome_v05.yaml" "rhizome_v05_${LABEL}_critical.jsonl"
+    ;;
+  remaining)
+    run_matrix "matrix_rhizome_v05_remaining.yaml" "rhizome_v05_${LABEL}_remaining.jsonl"
+    ;;
+  full)
+    run_matrix "matrix_rhizome_v05.yaml" "rhizome_v05_${LABEL}_critical.jsonl"
+    run_matrix "matrix_rhizome_v05_remaining.yaml" "rhizome_v05_${LABEL}_remaining.jsonl"
+    ;;
+esac

--- a/code/rhizome/jetson/run_runtime.sh
+++ b/code/rhizome/jetson/run_runtime.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="${1:-safe-cpu}"
+
+LLAMA_IMAGE="${LLAMA_IMAGE:-ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-orin}"
+LLAMA_CONTAINER="${LLAMA_CONTAINER:-sprout-llama-e2b}"
+LLAMA_PORT="${LLAMA_PORT:-8080}"
+MODEL_PATH="${MODEL_PATH:-$HOME/sprout_models/gemma-4-E2B-it-Q4_K_S.gguf}"
+CTX_SIZE="${CTX_SIZE:-2048}"
+BATCH_SIZE="${BATCH_SIZE:-128}"
+UBATCH_SIZE="${UBATCH_SIZE:-128}"
+N_GPU_LAYERS="${N_GPU_LAYERS:-99}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found" >&2
+  exit 1
+fi
+
+if [ ! -f "$MODEL_PATH" ]; then
+  echo "model not found: $MODEL_PATH" >&2
+  echo "Expected Gemma 4 E2B Q4_K_S GGUF under \$HOME/sprout_models." >&2
+  exit 1
+fi
+
+case "$PROFILE" in
+  safe-cpu)
+    LLAMA_ARGS=(
+      llama-server
+      -m /models/model.gguf
+      -c "$CTX_SIZE"
+      -ngl 0
+      --device none
+      --no-op-offload
+      --reasoning off
+      --host 0.0.0.0
+      --port "$LLAMA_PORT"
+    )
+    ;;
+  gpu-experimental)
+    LLAMA_ARGS=(
+      llama-server
+      -m /models/model.gguf
+      -c "$CTX_SIZE"
+      -b "$BATCH_SIZE"
+      -ub "$UBATCH_SIZE"
+      -ngl "$N_GPU_LAYERS"
+      --fit off
+      --no-op-offload
+      --reasoning off
+      --host 0.0.0.0
+      --port "$LLAMA_PORT"
+    )
+    ;;
+  *)
+    echo "unknown profile: $PROFILE" >&2
+    echo "valid profiles: safe-cpu | gpu-experimental" >&2
+    exit 1
+    ;;
+esac
+
+echo "Starting Rhizome llama-server profile=$PROFILE port=$LLAMA_PORT"
+echo "Image: $LLAMA_IMAGE"
+echo "Model: $MODEL_PATH"
+
+docker rm -f "$LLAMA_CONTAINER" >/dev/null 2>&1 || true
+
+docker run -d \
+  --name "$LLAMA_CONTAINER" \
+  --runtime=nvidia \
+  --network host \
+  -v "$MODEL_PATH:/models/model.gguf:ro" \
+  "$LLAMA_IMAGE" \
+  "${LLAMA_ARGS[@]}" >/tmp/sprout_llama_container_id.txt
+
+container_id="$(cat /tmp/sprout_llama_container_id.txt)"
+echo "Container: $container_id"
+
+for _ in $(seq 1 90); do
+  if curl -fsS "http://127.0.0.1:$LLAMA_PORT/health" >/tmp/sprout_llama_health.json 2>/tmp/sprout_llama_health.err; then
+    cat /tmp/sprout_llama_health.json
+    echo
+    docker ps --filter "name=$LLAMA_CONTAINER" --format 'table {{.Names}}\t{{.Status}}'
+    exit 0
+  fi
+  if ! docker ps --filter "name=$LLAMA_CONTAINER" --format '{{.Names}}' | grep -q "^$LLAMA_CONTAINER$"; then
+    echo "llama container stopped before health OK" >&2
+    docker logs "$LLAMA_CONTAINER" --tail 160 >&2 || true
+    exit 1
+  fi
+  sleep 5
+done
+
+echo "llama health timeout" >&2
+docker logs "$LLAMA_CONTAINER" --tail 160 >&2 || true
+exit 1

--- a/code/rhizome/jetson/smoke_adapter.sh
+++ b/code/rhizome/jetson/smoke_adapter.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADAPTER_URL="${ADAPTER_URL:-http://127.0.0.1:12000}"
+MODEL="${MODEL:-gemma4:e2b}"
+
+python3 - "$ADAPTER_URL" "$MODEL" <<'PY'
+import json
+import sys
+import time
+import urllib.request
+
+adapter_url = sys.argv[1].rstrip("/")
+model = sys.argv[2]
+
+payload = {
+    "model": model,
+    "messages": [
+        {
+            "role": "system",
+            "content": "Responde solo JSON valido, sin Markdown fences.",
+        },
+        {
+            "role": "user",
+            "content": "Devuelve exactamente un objeto con status ok.",
+        },
+    ],
+    "think": False,
+    "options": {"temperature": 0, "num_ctx": 512, "num_predict": 64},
+    "stream": False,
+}
+
+request = urllib.request.Request(
+    f"{adapter_url}/api/chat",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+
+t0 = time.time()
+with urllib.request.urlopen(request, timeout=120) as response:
+    body = response.read().decode("utf-8")
+    elapsed_ms = int((time.time() - t0) * 1000)
+    headers = {
+        key: value
+        for key, value in response.headers.items()
+        if key.lower().startswith("sprout-inference-")
+    }
+
+print(f"status={response.status}")
+print(f"elapsed_ms={elapsed_ms}")
+print("sprout_headers=" + json.dumps(headers, ensure_ascii=False, sort_keys=True))
+print("body=" + body[:1000])
+
+data = json.loads(body)
+content = data.get("message", {}).get("content", "")
+json.loads(content)
+print("smoke=OK")
+PY

--- a/code/rhizome/jetson/start_adapter.sh
+++ b/code/rhizome/jetson/start_adapter.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADAPTER_CONTAINER="${ADAPTER_CONTAINER:-sprout-adapter-12000}"
+ADAPTER_IMAGE="${ADAPTER_IMAGE:-python:3.10-slim}"
+ADAPTER_PORT="${ADAPTER_PORT:-12000}"
+LLAMACPP_SERVER_URL="${LLAMACPP_SERVER_URL:-http://127.0.0.1:8080}"
+REPO_DIR="${REPO_DIR:-$HOME/sprout}"
+
+if [ ! -d "$REPO_DIR/code/meristem_inference_adapter" ]; then
+  echo "adapter source not found under $REPO_DIR" >&2
+  exit 1
+fi
+
+echo "Starting Sprout inference adapter on :$ADAPTER_PORT"
+echo "Upstream llama.cpp: $LLAMACPP_SERVER_URL"
+echo "Repo: $REPO_DIR"
+
+docker rm -f "$ADAPTER_CONTAINER" >/dev/null 2>&1 || true
+
+docker run -d \
+  --name "$ADAPTER_CONTAINER" \
+  --network host \
+  -v "$REPO_DIR:/app" \
+  -w /app/code/meristem_inference_adapter \
+  -e INFERENCE_BACKEND=llamacpp \
+  -e ADAPTER_PORT="$ADAPTER_PORT" \
+  -e LLAMACPP_SERVER_URL="$LLAMACPP_SERVER_URL" \
+  "$ADAPTER_IMAGE" \
+  sh -lc 'python -m pip install --no-cache-dir -r requirements.txt >/tmp/adapter_pip.log 2>&1 && python -m src.main' \
+  >/tmp/sprout_adapter_container_id.txt
+
+container_id="$(cat /tmp/sprout_adapter_container_id.txt)"
+echo "Container: $container_id"
+
+for _ in $(seq 1 90); do
+  if curl -fsS "http://127.0.0.1:$ADAPTER_PORT/health" >/tmp/sprout_adapter_health.json 2>/tmp/sprout_adapter_health.err; then
+    cat /tmp/sprout_adapter_health.json
+    echo
+    docker ps --filter "name=$ADAPTER_CONTAINER" --format 'table {{.Names}}\t{{.Status}}'
+    exit 0
+  fi
+  if ! docker ps --filter "name=$ADAPTER_CONTAINER" --format '{{.Names}}' | grep -q "^$ADAPTER_CONTAINER$"; then
+    echo "adapter container stopped before health OK" >&2
+    docker logs "$ADAPTER_CONTAINER" --tail 160 >&2 || true
+    exit 1
+  fi
+  sleep 5
+done
+
+echo "adapter health timeout" >&2
+docker logs "$ADAPTER_CONTAINER" --tail 160 >&2 || true
+exit 1


### PR DESCRIPTION
## Resumen

- Documenta el diagnostico Jetson dia 18: Gemma 4 E2B Q4_K_S funciona en Jetson con llama.cpp.
- Añade scripts reproducibles para arrancar runtime Rhizome en Jetson:
  - `safe-cpu`: perfil contractual estable, 18/18 Rhizome v0.5 en Jetson.
  - `gpu-experimental`: GPU full offload con `--fit off --no-op-offload`, rapido pero aun no quality pass.
- Añade helpers para adapter, smoke, baseline y bateria Rhizome v0.5.
- No toca firmware, ESP32, sensores, actuadores, prompts ni contratos.

## Verificacion reportada por Endodermis

- `safe-cpu`: mini-test frio 6/6, mini-test caliente 6/6, bateria combinada 18/18.
- `gpu-experimental`: runtime pass, 36/36 capas en GPU, pero quality pass pendiente por RD04/RH02.
- `bash -n code/rhizome/jetson/*.sh` -> OK en revision Xilema.

## Decision recomendada

Usar `safe-cpu` como default para demo contractual hasta aprobacion explicita de Cambium/Xilema. Mantener `gpu-experimental` solo para investigacion de rendimiento.

Refs #5