### PR TITLE
feat(endodermis): jetson day19 main verify + battery helper strict

### DIFF
--- a/bitacora/2026-05-04_endodermis-dia19-main-verify_endodermis.md
+++ b/bitacora/2026-05-04_endodermis-dia19-main-verify_endodermis.md
@@ -1,0 +1,151 @@
+# Dia 19 - Verificacion PRs mergeados desde main
+
+**Autora:** Endodermis
+**Fecha:** 2026-05-04
+**Dia de proyecto:** 19
+**Rama:** `feat/endodermis/jetson-day19-main-verify`
+
+## 1. Arranque
+
+Mensaje de Cambium recibido.
+
+PRs relevantes ya mergeadas en `main`:
+
+- #68 BME280 estable (`d0e72ac`)
+- #69 perfiles Jetson (`c2c85bb`)
+- #70 primer ping Jetson-ESP32 (`d090972`)
+
+Local:
+
+- `main` actualizado a `dfef91d`
+- autor local configurado como `Endodermis <endodermis@sprout.local>`
+
+Jetson:
+
+- `~/sprout` actualizado de `2e19178` a `dfef91d`
+- `rhizome_01` pertenece a `docker` y `dialout`
+- no habia contenedores Sprout vivos al empezar
+
+## 2. Lectura de Xilema antes de tocar Jetson
+
+Leo `bitacora/2026-05-03_jetson-esp32-primer-ping_xilema.md`.
+
+Hallazgos relevantes:
+
+- Jetson detecto ESP32 en `/dev/ttyACM0`.
+- El bloqueo fue permiso `dialout`, ya resuelto.
+- Se valido `STATUS`, `HOST_HEARTBEAT`, `TELEMETRY`, `WATER A 12` rechazado
+  por `TANK_LOW`, `ALERT_LATCHED` y `RESET_ALERT`.
+- No hubo bomba, reles ni 12V.
+
+Decision mia:
+
+- no abrir `/dev/ttyACM0`;
+- no repetir ping;
+- no tocar firmware ni frontera fisica.
+
+## 3. Scripts Jetson desde main
+
+Ejecuto desde `~/sprout/code/rhizome/jetson`:
+
+```bash
+./collect_baseline.sh
+./run_runtime.sh safe-cpu
+./start_adapter.sh
+./smoke_adapter.sh
+LABEL=day19_main_verify ./run_battery.sh critical --dry-run
+```
+
+Resultados:
+
+| Paso | Resultado |
+|---|---|
+| baseline | OK |
+| `safe-cpu` | health OK |
+| adapter | health OK |
+| smoke safe-cpu | JSON OK |
+| critical dry-run | lista RD01, RD03, RD08, RA02, RA04, RH02 |
+
+Baseline destacada:
+
+| Campo | Valor |
+|---|---|
+| Jetson Linux | R36.4.7 |
+| RAM available inicial | ~5.7 GiB |
+| Swap usada inicial | 0 |
+| `CmaFree` inicial | ~222 MiB |
+| Docker runtime | `nvidia` disponible, default `runc` |
+
+## 4. `gpu-experimental` desde main
+
+Ejecuto:
+
+```bash
+./run_runtime.sh gpu-experimental
+```
+
+Resultado:
+
+```text
+NvMapMemAllocInternalTagged: ... error 12
+cudaMalloc failed: out of memory
+failed to allocate CUDA0 buffer
+failed to load model
+```
+
+Lectura:
+
+- confirma que `gpu-experimental` no es runtime-pass garantizado;
+- aunque dia 18 cargo con `--fit off --no-op-offload`, el perfil sigue siendo
+  sensible al estado de memoria contigua/NvMap;
+- se refuerza la decision de no usar GPU para rodaje ni demo contractual.
+
+## 5. Restauracion
+
+Restauro inmediatamente:
+
+```bash
+./run_runtime.sh safe-cpu
+./smoke_adapter.sh
+```
+
+Resultado:
+
+| Paso | Resultado |
+|---|---|
+| `safe-cpu` | health OK |
+| adapter | seguia vivo |
+| smoke restaurado | JSON OK |
+
+Estado final:
+
+```text
+sprout-llama-e2b      Up, safe-cpu
+sprout-adapter-12000  Up, llamacpp
+```
+
+## 6. Ajuste documental
+
+Actualizo:
+
+- `code/rhizome/jetson/README.md`
+- `code/rhizome/jetson/run_runtime.sh`
+
+Cambios:
+
+- `gpu-experimental` queda descrito como perfil experimental que puede fallar
+  por memoria contigua;
+- `run_runtime.sh gpu-experimental` imprime preflight informativo de memoria
+  (`MemAvailable`, `CmaFree`, `tegrastats`);
+- README indica restaurar `safe-cpu` si falla.
+
+## 7. Veredicto dia 19
+
+`safe-cpu` desde `main`: **PASS**.
+
+`gpu-experimental` desde `main`: **FAIL intermitente / no demo-safe**.
+
+La conclusion de dia 18 se endurece:
+
+> El perfil rapido no solo debe conservar contrato; tambien debe arrancar de
+> forma repetible. Hasta entonces, `safe-cpu` manda.

--- a/bitacora/2026-05-04_endodermis-dia19-main-verify_endodermis.md
+++ b/bitacora/2026-05-04_endodermis-dia19-main-verify_endodermis.md
@@ -149,3 +149,100 @@ La conclusion de dia 18 se endurece:
 
 > El perfil rapido no solo debe conservar contrato; tambien debe arrancar de
 > forma repetible. Hasta entonces, `safe-cpu` manda.
+
+---
+
+## 8. Bateria real segun peticion de Xilema
+
+Xilema pide:
+
+1. repetir `safe-cpu`;
+2. correr `run_battery.sh critical`;
+3. si pasa, correr `run_battery.sh full`;
+4. documentar resultado.
+
+Ejecuto desde `main` en Jetson:
+
+```bash
+cd ~/sprout/code/rhizome/jetson
+./run_runtime.sh safe-cpu
+./start_adapter.sh
+./smoke_adapter.sh
+LABEL=day19_main_safe_cpu ./run_battery.sh critical
+```
+
+Resultado primera pasada:
+
+| Prompt | envelope | status | duration_ms |
+|---|---:|---:|---:|
+| RD01 | OK | OK | 52569 |
+| RD03 | OK | OK | 16449 |
+| RD08 | OK | OK | 20148 |
+| RA02 | OK | OK | 13242 |
+| RA04 | OK | OK | 12909 |
+| RH02 | FAIL | FAIL | 26840 |
+
+Fallo RH02:
+
+```text
+done_reason=stop
+tokens_out=172
+parse_error=json_error: Expecting ',' delimiter
+```
+
+Contenido: JSON casi completo, sin fence, pero falta una llave final de cierre.
+
+Repito una segunda vez:
+
+```bash
+LABEL=day19_main_safe_cpu_repeat ./run_battery.sh critical
+```
+
+Resultado segunda pasada:
+
+| Prompt | envelope | status | duration_ms |
+|---|---:|---:|---:|
+| RD01 | OK | OK | 18033 |
+| RD03 | OK | OK | 16447 |
+| RD08 | OK | OK | 20629 |
+| RA02 | OK | OK | 13155 |
+| RA04 | OK | OK | 13095 |
+| RH02 | FAIL | FAIL | 27337 |
+
+No ejecuto `full` porque `critical` no pasa.
+
+Telemetria posterior:
+
+```text
+RAM 3237/7620MB
+SWAP 91/3810MB
+cpu ~44 C
+gpu ~44 C
+VDD_IN ~3.1 W
+```
+
+Lectura:
+
+- `safe-cpu` sigue arrancando y respondiendo smoke correctamente;
+- los 5 casos de decision/safety pasan;
+- RH02 queda sensible tambien en `safe-cpu` desde `main`;
+- no hay riesgo fisico directo porque RH02 es handoff/summarize, no comando
+  de riego;
+- aun asi, no se debe vender "critical 6/6" hoy.
+
+## 9. Ajuste al helper de bateria
+
+`run_battery.sh` no debe devolver exito si el harness imprime mismatch.
+Actualizo el script para validar el JSONL al terminar:
+
+- error HTTP -> fallo;
+- `envelope_valid=false` -> fallo;
+- `status_match` incorrecto -> fallo.
+
+En modo `full`, si `critical` falla, `remaining` no se ejecuta.
+
+Decision:
+
+- mejor que la automatizacion sea estricta;
+- si el LLM se comporta de forma segura pero fuera de contrato, lo vemos como
+  fallo de bateria y no como pass silencioso.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -152,6 +152,10 @@ Los resultados se escriben en `code/tuning/results/` dentro del repo montado
 en el contenedor del adapter, con un sufijo UTC para no pisar los JSONL
 canonicos.
 
+En modo real, `run_battery.sh` devuelve codigo distinto de cero si cualquier
+run tiene error HTTP, `envelope_valid=false` o `status_match` incorrecto. En
+modo `full`, si `critical` falla, `remaining` no se ejecuta.
+
 ## Interpretacion
 
 Para demo y pruebas contractuales, usar `safe-cpu` hasta que Cambium/Xilema

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -11,7 +11,7 @@ gestionan el runtime local de inferencia y el adapter Ollama-compatible.
 | Perfil | Uso | Estado dia 18 |
 |---|---|---|
 | `safe-cpu` | Demo contractual y bateria Rhizome v0.5 | Quality pass 18/18, lento |
-| `gpu-experimental` | Diagnostico/rendimiento | Runtime pass, no quality pass aun |
+| `gpu-experimental` | Diagnostico/rendimiento | Experimental: puede fallar por memoria contigua y no es quality pass |
 
 ### `safe-cpu`
 
@@ -49,6 +49,18 @@ Estado dia 18:
 - acelera mucho las respuestas;
 - aun no es quality pass para Rhizome v0.5 porque RD04 muestra deriva
   semantica segura (`need_clarification` en lugar de `ok`).
+
+Estado dia 19:
+
+- desde `main`, `gpu-experimental` volvio a fallar una vez con
+  `NvMapMemAllocInternalTagged ... error 12` / `cudaMalloc failed`;
+- por tanto este perfil no es ni runtime-pass garantizado ni demo-safe;
+- si falla, restaurar inmediatamente:
+
+```bash
+./run_runtime.sh safe-cpu
+./smoke_adapter.sh
+```
 
 ## Requisitos
 
@@ -156,3 +168,6 @@ python harness.py --matrix matrix_rhizome_v05.yaml \
 
 No promover GPU a perfil demo hasta que la bateria critica sea estable y RD04
 quede alineado con el contrato.
+
+Si `gpu-experimental` falla durante el arranque, no depurar en caliente durante
+un rehearsal. Restaurar `safe-cpu` y documentar el log.

--- a/code/rhizome/jetson/run_battery.sh
+++ b/code/rhizome/jetson/run_battery.sh
@@ -43,6 +43,40 @@ run_matrix() {
   echo "Running matrix=$matrix out=results/$out dry_run=$DRY_RUN"
   docker exec "$ADAPTER_CONTAINER" sh -lc \
     "cd /app/code/tuning && python harness.py --matrix $matrix --adapter-url $ADAPTER_URL --out results/$out $dry_flag"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    return 0
+  fi
+
+  docker exec "$ADAPTER_CONTAINER" sh -lc "cd /app/code/tuning && python - <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path('results/$out')
+rows = [json.loads(line) for line in path.read_text(encoding='utf-8').splitlines() if line.strip()]
+failures = []
+for rec in rows:
+    envelope = rec.get('envelope') or {}
+    expected = rec.get('expected_status')
+    actual = envelope.get('status') if envelope.get('valid') else None
+    if rec.get('error') or rec.get('http_status') != 200 or not envelope.get('valid') or (expected is not None and actual != expected):
+        failures.append({
+            'run_id': rec.get('run_id'),
+            'prompt_id': rec.get('prompt_id'),
+            'expected_status': expected,
+            'actual_status': actual,
+            'envelope': envelope,
+            'error': rec.get('error'),
+            'http_status': rec.get('http_status'),
+        })
+
+print(f'battery_summary path={path} runs={len(rows)} failures={len(failures)}')
+for failure in failures:
+    print('battery_failure ' + json.dumps(failure, ensure_ascii=False, sort_keys=True))
+
+sys.exit(1 if failures else 0)
+PY"
 }
 
 case "$MODE" in

--- a/code/rhizome/jetson/run_runtime.sh
+++ b/code/rhizome/jetson/run_runtime.sh
@@ -23,6 +23,16 @@ if [ ! -f "$MODEL_PATH" ]; then
   exit 1
 fi
 
+print_gpu_preflight() {
+  echo "GPU experimental preflight (informational, not a gate):"
+  if [ -r /proc/meminfo ]; then
+    grep -E 'MemAvailable|SwapFree|CmaTotal|CmaFree' /proc/meminfo || true
+  fi
+  if command -v tegrastats >/dev/null 2>&1; then
+    timeout 2s tegrastats --interval 1000 || true
+  fi
+}
+
 case "$PROFILE" in
   safe-cpu)
     LLAMA_ARGS=(
@@ -51,6 +61,8 @@ case "$PROFILE" in
       --host 0.0.0.0
       --port "$LLAMA_PORT"
     )
+    print_gpu_preflight
+    echo "Warning: gpu-experimental is not demo-safe; restore safe-cpu if startup fails."
     ;;
   *)
     echo "unknown profile: $PROFILE" >&2


### PR DESCRIPTION
Verificacion Jetson desde main tras merges PRs #68/#69/#70. Bateria critical re-run + helper estricto que falla si envelope_valid=false, error HTTP, o status_match roto. Apunta hallazgo RH02 sensible tambien en safe-cpu desde main.