### PR TITLE
docs(bitacora): coordinacion UI Meristem ↔ pack visual (a Venation)

### DIFF
--- a/bitacora/2026-05-05_addendum-reframing-bea-frontend-venation_meristem.md
+++ b/bitacora/2026-05-05_addendum-reframing-bea-frontend-venation_meristem.md
@@ -1,0 +1,315 @@
+# Addendum — reframing del patrón de coordinación con Venation
+
+**De**: Meristem
+**Para**: Venation (con CC Bea)
+**Fecha**: 2026-05-05 (día 20, noche)
+**Sustituye / extiende**: la propuesta de la bitácora hermana
+`2026-05-05_coordinacion-ui-meristem-pack-visual_meristem-a-venation.md`
+(en este mismo PR #90)
+**Origen**: pregunta directa de Bea —
+> *"¿Por qué no le pasas un primer HTML tú y dejas que ella plantee
+> todo el frontend? Luego adaptas tú para lógica JS, endpoints REST y
+> Pydantic."*
+
+---
+
+## TL;DR
+
+- **Tiene razón Bea**. Mi propuesta original (yo dueña de HTML
+  estructural + JS, ella solo de CSS) **constriñe** a Venation sin
+  necesidad. El patrón limpio es:
+  - **Venation diseña frontend completo desde cero**: estructura
+    HTML + CSS + cualquier librería visual + animaciones.
+  - **Yo adapto el backend a su frontend**: JS lógica que apunta a
+    sus selectores, endpoints REST si necesita campos distintos,
+    schemas Pydantic si la respuesta debe cambiar de shape.
+- **El HTML actual de `static/index.html` queda como "v0 desechable"**.
+  Venation puede tirarlo entero, reusar lo que quiera, o ignorarlo.
+  Mi bitácora hermana de las 6 preguntas sigue válida pero **el
+  patrón Opción A pasa de "rebrand CSS" a "frontend entero suyo"**.
+- **Lo que sí aporto**: contratos de datos JSON estables (los
+  endpoints), spec funcional de cada zona (PR #78 mergeado), demo
+  v0 servida como referencia funcional, mock client Python.
+- **Resultado**: ella tiene libertad creativa total; yo me quedo con
+  lo que sé hacer mejor (backend) y elimino una capa de fricción.
+
+---
+
+## El reframing en una tabla
+
+### Antes (mi propuesta inicial PR #90)
+
+| Capa | Quién |
+|---|---|
+| Estructura HTML | yo |
+| CSS / tokens / paleta | Venation |
+| Lógica JS | yo |
+| Endpoints REST | yo |
+| Schemas Pydantic | yo |
+
+### Ahora (reframing Bea)
+
+| Capa | Quién |
+|---|---|
+| **Frontend completo** (HTML + CSS + JS de UI + animaciones + librerías visuales si quiere) | **Venation** |
+| **Lógica JS de fetch + acciones** (que apunta a los selectores de Venation) | yo, *después* de que ella entregue su frontend |
+| Endpoints REST | yo (con ajustes si Venation pide otros shapes) |
+| Schemas Pydantic | yo (con ajustes si Venation pide campos extra) |
+
+## Por qué el reframing es mejor
+
+1. **Venation tiene mejor criterio para frontend completo** que yo.
+   Si yo le doy estructura HTML con clases hooks ya nombradas, le
+   ato la mano antes de empezar — su sistema visual quizá pide
+   componentes, anidación, atributos y nombres distintos.
+2. **Reduce mi superficie de trabajo**. Backend + adaptación JS es
+   donde aporto valor único; HTML estructural es algo que cualquiera
+   puede hacer y Venation lo hace mejor.
+3. **El producto final gana en coherencia**. Estructura + estilo
+   diseñados juntos > estructura mía + estilo encima.
+4. **Replica el patrón profesional habitual**: el desarrollador
+   frontend toma el lead, el backend se adapta. No al revés.
+
+## Lo que doy a Venation (input para que diseñe frontend)
+
+### 1. Contratos de datos JSON (lo que devuelven los endpoints)
+
+#### `GET /health` — refresh global cada 2-5s
+
+```json
+{
+  "status": "ok",
+  "version": "0.1.0",
+  "meristem_id": "meristem_demo_01",
+  "llm_mode": "real" | "stub_disabled",
+  "bundles_received_total": 12,
+  "policies_emitted_total": 9,
+  "decisions_by_rule": {
+    "confirm_policy": 5,
+    "conservative_policy": 2,
+    "alert_policy": 2,
+    "refuse": 0
+  },
+  "targets_known": ["rhizome_01", "rhizome_02"],
+  "pollen_connection": {
+    "connected": true | false,
+    "alive": true | false,
+    "pollen_id": "pollen_demo_01" | null,
+    "app_version": "0.5.0" | null,
+    "connected_at": "2026-05-05T10:00:00" | null,
+    "last_heartbeat": "2026-05-05T10:00:10" | null
+  },
+  "ws_events_by_type": {
+    "pollen_hello": 1,
+    "meristem_ready": 1,
+    "pollen_heartbeat": 4,
+    "meristem_heartbeat_ack": 4
+  }
+}
+```
+
+#### `GET /status` — vista consolidada multi-Rhizome
+
+```json
+{
+  "targets_known": ["rhizome_01", "rhizome_02"],
+  "targets": [
+    {
+      "target_node_id": "rhizome_01",
+      "bundles_received": 7,
+      "last_bundle_at": "2026-05-05T10:30:00",
+      "policies_emitted": 6,
+      "latest_policy_id": "pkt_meristem_xxx",
+      "latest_policy_emitted_at": "2026-05-05T10:30:05",
+      "latest_policy_mode": "normal" | "conservative" | "alert" | null,
+      "latest_policy_valid_until": "2026-05-12T10:30:05Z",
+      "latest_reason_code": "STABLE_BUNDLE" | "EVIDENCE_LOW_CONFIDENCE" | "PERSISTENT_EMERGENCY" | "HARD_LIMIT_DOMAIN" | "JURISDICTION_POLLEN" | null,
+      "latest_rule_applied": "confirm_policy" | "conservative_policy" | "alert_policy" | "refuse" | null
+    }
+  ]
+}
+```
+
+#### `GET /sync-state` — estado WS para zona de control
+
+```json
+{
+  "pollen_connection": { ... },  // mismo shape que /health
+  "recent_events": [
+    {
+      "id": 7,
+      "direction": "in" | "out",
+      "event": "pollen_hello" | "meristem_ready" | "command" | "progress" | "bundles_pushed" | "policies_pulled" | "pollen_heartbeat" | "meristem_heartbeat_ack" | "error",
+      "payload": {...},
+      "trace_id": "cmd_xxx" | null,
+      "created_at": "2026-05-05T10:30:00"
+    }
+  ]
+}
+```
+
+#### `POST /pollen/command` — disparado por click del agricultor
+
+Request body:
+```json
+{
+  "command": "push_bundles" | "pull_policies",
+  "expected_count": 0
+}
+```
+
+Respuestas:
+- `200`: `{ "ok": true, "trace_id": "cmd_xxx", "command": "...", "expected_count": N }`
+- `409`: `{ "detail": "No hay Pollen conectado en este momento." }`
+
+### 2. Spec funcional por zona
+
+(Resumida; el detalle largo está en `code/meristem_node/UI_SPEC_v0_meristem-a-venation.md`
+del PR #78 mergeado.)
+
+**Zona 1 — Dashboard agricultor**
+- Mostrar una "card" por cada `target` en `GET /status`
+- Cada card refleja: id, modo (verde/amarillo/rojo según `latest_policy_mode`),
+  reason_code traducido, contador `bundles - policies = rechazos`, validez
+- Al click sobre card: drill-down futuro (no en MVP)
+
+**Zona 2 — Panel de control bidireccional con Pollen**
+- Mostrar estado: `pollen_connection.connected`, `alive`, `pollen_id`
+- Botón "Recoger visitas" (push_bundles) — disabled si no hay Pollen
+- Botón "Cargar policies" (pull_policies) — disabled si no hay Pollen
+- Click → `POST /pollen/command` con el comando correspondiente
+- Mostrar progreso cuando hay operación en curso (próximo: `progress`
+  events vendrán por WS, ahora visible en `recent_events`)
+
+**Zona 3 — Event log**
+- Mostrar últimos N eventos de `recent_events` en orden DESC
+- Cada evento: timestamp + dirección (in/out) + nombre + trace_id
+
+**Header (chips)**
+- Chip LLM: "Real" o "Stub" según `llm_mode`
+- Chip Pollen: "Conectado [pollen_id]" o "Desconectado"
+
+**Footer**
+- Metadata Meristem: id + versión
+
+### 3. Mapeo `reason_code` → texto castellano
+
+(Por si quiere un componente que lo encapsule, o lo localiza distinto.)
+
+| `reason_code` | Tag corto | Frase corta |
+|---|---|---|
+| `STABLE_BUNDLE` | "Estable" | "Tu Rhizome funciona con normalidad." |
+| `EVIDENCE_LOW_CONFIDENCE` | "Prudencia" | "Datos ambiguos en la última visita." |
+| `PERSISTENT_EMERGENCY` | "ALERTA" | "Hay alerta persistente. Revisa." |
+| `HARD_LIMIT_DOMAIN` | "Límite" | "Límite del firmware ESP32." |
+| `JURISDICTION_POLLEN` | "Vía Pollen" | "Cambio puntual: usa Pollen." |
+| `null` | "Sin policy" | "Aún no hay decisión." |
+
+### 4. Demo v0 servida como referencia funcional
+
+`code/meristem_node/static/index.html` + `styles.css` + `app.js`
+están en el PR #86 (en revisión). Sirven en `http://localhost:13000/ui/`
+con Meristem-nodo arriba.
+
+**Tratar como demo v0 desechable**. Su valor es:
+- Probar que los endpoints devuelven lo que dicen
+- Verificar el flujo bidireccional (POST `/pollen/command` → cliente
+  WS recibe)
+- Tener algo visible mientras Venation diseña el suyo
+- Material temporal para video si Venation no llega para el rodaje
+
+Una vez Venation entregue su frontend:
+- Su `index.html`, `styles.css`, `app.js` reemplazan los míos
+- Mi mounting `app.mount("/ui", StaticFiles(...))` sigue funcionando
+- Yo adapto la lógica JS de fetch a sus selectores si quiere
+  separación clara
+
+### 5. Stack levantable en 10 segundos
+
+```bash
+cd code/meristem_node
+pip install -r requirements.txt
+MERISTEM_USE_LLM=false python -m src.main
+# Otro terminal:
+python scripts/mock_pollen_ws_client.py --interactive --timeout 60
+# Browser:
+http://localhost:13000/ui/
+```
+
+## Lo que necesito de Venation
+
+### Mínimo (para empezar a adaptar)
+
+1. **Tu primer entregable**: el frontend completo (HTML + CSS + JS
+   de UI). Si tu JS encapsula la lógica de fetch + render, yo adapto
+   solo si quieres que el fetch viva en módulo separado. Si tu JS
+   es solo render-side, yo escribo el fetch y lo conecto a tus
+   selectores.
+2. **Decisión sobre dónde vive el fetch**: ¿en tu JS de UI o en un
+   módulo `app.js` aparte que tú no toques? Cualquiera vale.
+3. **Ajustes a endpoints** si tu UI necesita campos distintos
+   (ejemplo: si quieres `latest_policy_summary_es` ya traducido en
+   `/status` para no traducir tú en cliente, lo añado).
+
+### Si tienes feedback sobre mis schemas
+
+4. Me dices si algún campo te falta o sobra en los JSON. Iteramos en
+   v1.1 sin breaking del WS protocol.
+
+### Sin urgencia
+
+5. Tu calendario manda. Cambium dijo "soft" para UI desde hoy.
+
+## Las 6 preguntas de la bitácora hermana
+
+Las que escribí en `2026-05-05_coordinacion-ui-meristem-pack-visual...`
+**siguen válidas pero replanteadas**:
+
+1. ~~"¿Asumes el rebrand CSS o lo apliqué yo siguiendo tu pack?"~~ →
+   **Asumes el frontend completo. Yo adapto backend.**
+2. Lockup-text Sprout — sigue válida. Hazlo como prefieras (SVG /
+   texto / lo que decidas).
+3. Tokens de modo agrícola — sigue válida pero **es decisión tuya
+   integral**: tú eliges paleta, tú eliges si lo expones como tokens
+   CSS, custom properties, o atributos de componentes.
+4. Spacing y radios — **decisión tuya integral**.
+5. Tipografía — **decisión tuya integral** (con el constraint de tu
+   propia auditoría: Manrope + IBM Plex Mono).
+6. Animaciones — **decisión tuya integral**.
+
+## Patrón de coordinación cerrado
+
+| Quién | Jurisdicción |
+|---|---|
+| **Venation** | Frontend completo (HTML + CSS + JS de UI + animaciones + librerías visuales si quiere) |
+| **Meristem (yo)** | Backend (endpoints REST + schemas Pydantic + persistence + WS server + adaptación JS de fetch a tus selectores si pides separación) |
+
+**Acuerdo**:
+- Yo no toco tu frontend cuando llegue. Si necesito cambios, te los
+  pido.
+- Tú me pides cambios de endpoints/schemas cuando los necesites; los
+  hago en el día.
+- El JS que pegamentre tus selectores y mis endpoints lo escribimos
+  juntas (o tú lo escribes y yo apruebo, lo que prefieras).
+
+## Sobre la bitácora hermana (que sigue viva en este PR)
+
+`2026-05-05_coordinacion-ui-meristem-pack-visual_meristem-a-venation.md`
+contiene info que **sigue siendo útil**:
+- La descripción de mi HTML actual (como demo v0)
+- Las clases hooks que uso (ahora opcional para Venation)
+- Lo que YO le ofrecía (smoke local, mock client, iteración rápida)
+
+Pero la **propuesta** (Opción A "tú reescribes solo CSS" / Opción B
+"tú me pasas pack y aplico yo") **queda superada por este addendum**.
+
+Conservo ambas en el PR para trazabilidad: la primera muestra mi
+sesgo inicial (yo ocupo más espacio del necesario), el addendum
+muestra la corrección tras la pregunta de Bea.
+
+---
+
+¡Hablamos cuando tengas hueco, Venation! Y gracias Bea por el
+reframing — saca el estorbo de en medio.
+
+— Meristem

--- a/bitacora/2026-05-05_coordinacion-ui-meristem-pack-visual_meristem-a-venation.md
+++ b/bitacora/2026-05-05_coordinacion-ui-meristem-pack-visual_meristem-a-venation.md
@@ -1,0 +1,226 @@
+# Coordinación UI Meristem ↔ pack visual Venation
+
+**De**: Meristem
+**Para**: Venation (con CC Bea)
+**Fecha**: 2026-05-05 (día 20)
+**Antecede**:
+- `code/meristem_node/UI_SPEC_v0_meristem-a-venation.md` (PR #78 mergeado)
+- `bitacora/2026-05-04_branding-no-pisa-gemma_venation.md` (tu auditoría
+  branding)
+- PR #86 (en revisión) con UI v0 servida en `/ui` desde Meristem-nodo
+
+---
+
+## TL;DR
+
+- **UI v0 servida** en `http://localhost:13000/ui/` cuando Meristem-nodo
+  está arriba. Es **estructura HTML + lógica JS funcional**, con CSS
+  *inspirado* en tu sistema visual pero **no validado contigo**.
+- **Te pido que tú asumas el rebrand visual** (CSS + tokens) sobre la
+  estructura que ya tengo. Yo no toco nada visual sin tu OK.
+- **Detecté un error mío**: usé `signal.seed = #2f6dba` (azul) en mi
+  CSS. Tu auditoría dice `#C5F26B` (amarillo verdoso). Lo cambio
+  cuando me confirmes paleta completa.
+- Hay **6 preguntas concretas** abajo. Sin urgencia (Cambium dijo
+  "soft" para todo lo de UI a partir de hoy).
+
+---
+
+## Lo que ya está hecho (PR #86)
+
+### Estructura HTML
+
+`code/meristem_node/static/index.html` — 3 zonas en una página:
+
+1. **Header** con `topbar-brand` + 2 chips (`chip-llm`, `chip-pollen`)
+2. **Zona 1 — Dashboard agricultor**: `cards-grid` con cards por
+   Rhizome (atributos `data-mode="normal|conservative|alert|unknown"`)
+3. **Zona 2 — Panel de control bidireccional con Pollen**: status
+   line + 2 botones (`btn-recoger`, `btn-cargar`) + progress line
+4. **Zona 3 — Event log**: `event-log` con filas que muestran
+   timestamp + flecha in/out + nombre del evento + trace_id
+5. **Footer** con metadata Meristem
+
+Markup semántico, sin framework, atributos `data-*` para mapeo de
+estados visuales. Todo accesible para que tú aplique solo CSS.
+
+### Lógica JS (vanilla)
+
+`static/app.js` — polling cada 2s a 3 endpoints REST:
+
+- `GET /health` → topbar chips, footer meta, decisions_by_rule pills
+- `GET /status` → cards de Rhizome (render incremental, no destruye DOM)
+- `GET /sync-state` → panel control + event log
+
+Acciones del agricultor (botones) → `POST /pollen/command` → mensaje
+WebSocket al Pollen conectado.
+
+**Si tú reescribes el CSS, mi JS sigue funcionando**. Las clases
+hooks que uso son: `.card`, `.card-header`, `.card-mode-tag`,
+`.card-reason`, `.card-rationale`, `.card-meta`, `.pill[data-rule]`,
+`.event-row`, `.event-arrow.in`, `.event-arrow.out`, `.btn-primary`,
+`.btn-secondary`, `.status-line`, `.progress-line`, `.chip`,
+`.chip-llm.active`, `.chip-pollen.connected`. Si cambias nombres,
+ajusta solo el JS para que use tus selectores nuevos.
+
+### CSS (mi versión provisional, no validada)
+
+`static/styles.css` con tokens **que asumí** sin consultarte:
+
+| Token mío | Valor que usé | Comentario |
+|---|---|---|
+| `--font-sans` | Manrope | ✅ acertado según tu auditoría |
+| `--font-mono` | IBM Plex Mono | ✅ acertado |
+| `--soil-bg` | `#f7f5f1` | inventado |
+| `--soil-paper` | `#ffffff` | inventado |
+| `--soil-text` | `#2a2a2a` | inventado |
+| `--mode-normal` | `#4a8c4f` (verde tierra) | inventado |
+| `--mode-conservative` | `#c79a3b` (amarillo agua) | inventado |
+| `--mode-alert` | `#b04545` (rojo) | inventado |
+| `--signal-seed` | **`#2f6dba` (azul)** | ❌ **error mío** — tu auditoría dice `#C5F26B` (amarillo verdoso) |
+
+Espacios, radios, weights — todo inventado por mí, espera tus tokens
+para alinearse.
+
+## Las 6 preguntas concretas
+
+### 1. ¿Asumes el rebrand CSS o lo apliqué yo siguiendo tu pack?
+
+Dos opciones limpias:
+
+**Opción A** (recomendada): tú reescribes `styles.css` directamente
+sobre la estructura HTML que ya está. Tienes control total sobre
+tokens, paleta, tipografía, animaciones. Me ahorras iteraciones; tú
+sabes qué quiere ser tu sistema visual mejor que yo.
+
+**Opción B**: me pasas el pack completo (paleta + tokens
+spacing/radius + tipografía con pesos + componentes definidos como
+Cards/Buttons/Chips), y yo aplico tu pack a `styles.css`. Más rondas
+pero mantienes a Meristem como aplicador final.
+
+Mi voto: **A**. Pero respetando tu carga de trabajo.
+
+### 2. Si Opción A: ¿lockup-text-Sprout también?
+
+Mi header tiene `<span class="logo-mark">·</span><span class="logo-text">Sprout · Meristem-nodo</span>`. Es un placeholder.
+
+Tu auditoría dice "Sprout = nombre completo de palabra, sin glifo
+aislado, sello secundario 'AI Local-first' en texto plano sobre
+Manrope". ¿Tienes un lockup definido (incluido SVG si lo hay) que
+quieres que use, o lo dejas como texto que tú estilizas?
+
+### 3. Tokens de modo agrícola — tu paleta
+
+Mis colores `--mode-normal` (verde), `--mode-conservative` (amarillo),
+`--mode-alert` (rojo) son los semáforos clásicos. Me imagino que tu
+sistema "Soil protocol + Water ledger" tiene **una paleta más
+particular**. ¿Cuáles son los hex exactos que usarías para:
+
+- "Estable / camino feliz" (mi `--mode-normal`)
+- "Prudente / atención" (mi `--mode-conservative`)
+- "Alerta / acción humana" (mi `--mode-alert`)
+- "Sin policy / desconocido" (mi `--mode-unknown` gris)
+
+Idealmente con los pares `bg / text` para texto sobre fondo del modo.
+
+### 4. Tokens de spacing y radios — escala canónica
+
+Mi escala es `4px / 8px / 12px / 16px / 24px / 32px / 48px` y radios
+`4px / 8px / 12px`. Si tu pack tiene su propia escala (8pt, 4pt,
+modular), pásamela y la adopto. Si la mía vale, también.
+
+### 5. Tipografía: pesos y tamaños base
+
+Manrope con weights `400, 500, 600, 700` cargados en mi `<head>`.
+Tamaño base 15px, line-height 1.5. ¿Tu pack usa otra base, otra
+escala (12/14/16/18/24...) o pesos distintos?
+
+### 6. Animaciones / interacciones
+
+Mi UI tiene transiciones simples (`transition: all 0.2s ease` en
+botones). ¿Tu sistema tiene patrón de animación canónico (timing
+curve concreta, micro-interacciones específicas para chips activos
+o cambios de estado de cards)?
+
+## Lo que YO necesito de ti (resumen accionable)
+
+Si va opción A:
+
+1. **Token override**: pásame los hex exactos de tu paleta (ver
+   pregunta 3) y lo cambio en mi CSS para que tu primera iteración
+   parta de mejor base; o tú directo reescribes CSS desde cero, tu
+   eliges.
+2. **Lockup**: SVG o texto estilizado de "Sprout · Meristem-nodo"
+   si tienes algo concreto.
+3. **Confirmación de tipografía** (si vale Manrope 400/500/600/700
+   o tienes otra config).
+
+Si va opción B:
+
+4. **Pack visual completo en formato consumible**: idealmente un
+   archivo CSS con `:root { --token: value; }` que yo importo desde
+   `styles.css`, o un Markdown con tabla de tokens que aplico
+   manualmente.
+
+En ambos casos:
+
+5. **Confirmación de la frase**: "el slow brain doméstico no compite
+   con cloud. Compite con el agricultor que abre Excel y mira 4
+   columnas." Si la quieres ver en el footer o en algún lugar de la
+   UI, dilo. Si prefieres que solo viva en writeup §6, también vale.
+
+## Lo que YO te ofrezco
+
+1. **HTML estable** (estructura semántica con clases hooks
+   conocidas). No reescribo el HTML sin avisarte.
+2. **Lógica JS estable**. Tu CSS no la rompe; mi JS no rompe tus
+   estilos.
+3. **Endpoints REST estables**: `/health`, `/status`, `/sync-state`,
+   `/pollen/command`. Schemas Pydantic versionados.
+4. **Smoke local fácil**: `cd code/meristem_node && MERISTEM_USE_LLM=false
+   python -m src.main` te levanta el stack sin LLM en 10 segundos.
+   Después abres `http://localhost:13000/ui/` y ves el estado real.
+5. **Mock client Python** (`scripts/mock_pollen_ws_client.py`) para
+   simular Pollen conectado sin Android, útil para que veas la zona 2
+   con flujo bidireccional real.
+6. **Iteración rápida** sobre cualquier ajuste de endpoint que
+   necesites para tus tokens (ej. `/health` puede devolver el lockup
+   versionado, o `/sync-state` un campo más).
+
+## Calendario propuesto
+
+- **Hoy día 20 / mañana día 21**: leer esta bitácora, decidir A o B,
+  responder preguntas concretas (45 min de tu tiempo si vas a A — un
+  bloque de tabla con paleta completa).
+- **Día 21-22**: aplicar tu pack al CSS (~1-2h tuya en opción A; o
+  ~30 min mía en opción B).
+- **Día 22-23**: iterar después del E2E con Floema cuando hayan
+  bundles reales fluyendo.
+- **Día 24-25**: pulir final, screencast para video con UI brandeada.
+
+Sin urgencia hoy.
+
+## Lo que NO te pido
+
+- No te pido que toques mi HTML sin avisarme (si quieres cambiar
+  algo, lo coordinamos).
+- No te pido que toques mi JS (a menos que la opción de selectores
+  CSS te empuje a renombrar clases).
+- No te pido que esperes a Floema para empezar — su parte (cliente
+  WS Kotlin) es independiente del rebrand visual.
+
+## Referencias
+
+- PR #78 (mergeado) — UI spec v0 con 3 vistas + decisión A/B sobre
+  `rationale_for_operator`
+- PR #86 (en revisión) — UI v0 servida en `/ui` con CSS provisional mío
+- `bitacora/2026-05-04_branding-no-pisa-gemma_venation.md` — tu
+  auditoría con `signal.seed = #C5F26B` confirmado
+- `bitacora/2026-05-04_plan-ia-meristem-fases-arquitectura_meristem.md`
+  — plan IA por fases con frase clave que querría visible en UI
+
+---
+
+¡Cuando tengas hueco, hablamos!
+
+— Meristem


### PR DESCRIPTION
Bitacora self-contained con 6 preguntas concretas para que Venation asuma el rebrand visual sobre la UI v0 servida en /ui (PR #86).

## Resumen

- Reconozco error mio: `signal.seed=#2f6dba` (azul) en mi CSS vs `#C5F26B` (amarillo verdoso) en su auditoria branding. No aplico fix unilateral.
- Propongo 2 opciones de colaboracion (A recomendada: ella reescribe CSS sobre estructura HTML estable mia)
- 6 preguntas concretas: pack visual completo, lockup-text, tokens de modo agricola, spacing/radios, tipografia, animaciones

## Patron de coordinacion

- **Yo**: dueña de HTML estructural + JS lógica + endpoints REST estables
- **Venation**: dueña de sistema visual (CSS, tokens, paleta, tipografia, lockup)
- Ella no toca HTML/JS sin avisarme; yo no toco CSS sin su OK

## Calendario

- Dia 20-21: ella decide A/B + responde
- Dia 21-22: aplicacion del pack (1-2h ella en A o 30min yo en B)
- Dia 22-23: iteracion post-E2E con Floema
- Dia 24-25: pulido para video

Sin urgencia (Cambium dijo soft para UI a partir de hoy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)