### PR TITLE
feat(rhizome): summary/since + explain locale + demo two-rhizomes

### DIFF
--- a/bitacora/2026-05-05_endodermis-summary-y-demo-dos-rhizomes_endodermis.md
+++ b/bitacora/2026-05-05_endodermis-summary-y-demo-dos-rhizomes_endodermis.md
@@ -90,3 +90,55 @@ bash -n code/rhizome/jetson/start_demo_two_rhizomes.sh
 ```
 
 Resultado: OK.
+
+## Validacion en Jetson
+
+Ejecuto en Jetson:
+
+```bash
+cd ~/sprout/code/rhizome/jetson
+./start_demo_two_rhizomes.sh
+```
+
+Resultado:
+
+- `rhizome_01` vivo en `:13010`;
+- `rhizome_02` simulado vivo en `:13020`;
+- smoke OK para ambos;
+- `llama-server` sigue vivo en `:8080`;
+- adapter sigue vivo en `:12000`.
+
+Validacion externa desde portatil:
+
+```bash
+curl "http://192.168.1.60:13010/summary/since?locale=es"
+curl "http://192.168.1.60:13020/summary/since?locale=en"
+```
+
+Ambos devuelven payload de summary.
+
+## Validacion de Floema
+
+Bea comunica que Floema ya implemento por su parte:
+
+- consumo del endpoint principal `GET /summary/since`;
+- render del boton "¿Que ha pasado desde mi ausencia?";
+- adaptacion de UI para no presentar `SOIL A` / `SOIL B` como dos sensores
+  fisicos independientes por Rhizome;
+- consumo de los dos endpoints de demo si hace falta para video.
+
+Lectura de Endodermis:
+
+- Pollen ya tiene camino UI para el resumen de ausencia;
+- Jetson ya tiene dos endpoints para demo multi-Rhizome;
+- el segundo nodo sigue siendo simulacion host-side documentada;
+- no se ha tocado ESP32+BME.
+
+## Cierre dia 20
+
+El frente queda listo para revision de Cambium:
+
+- branch: `feat/endodermis/rhizome-visit-summary-demo`;
+- servicios Jetson vivos;
+- trabajo host-side solamente;
+- siguiente tarea tecnica de Endodermis: volver a diagnostico RH02 sin tunear en caliente.

--- a/bitacora/2026-05-05_endodermis-summary-y-demo-dos-rhizomes_endodermis.md
+++ b/bitacora/2026-05-05_endodermis-summary-y-demo-dos-rhizomes_endodermis.md
@@ -1,0 +1,92 @@
+# Dia 20 - Summary principal y demo de dos Rhizomes
+
+**Autora:** Endodermis
+**Fecha:** 2026-05-05
+**Dia de proyecto:** 20
+**Rama:** `feat/endodermis/rhizome-visit-summary-demo`
+
+## Contexto
+
+Bea pide dos cosas:
+
+1. convertir "¿Que ha pasado desde mi ausencia?" en el boton principal de Pollen;
+2. simular dos Rhizomes para video, documentando con claridad que el segundo
+   nodo es una simulacion.
+
+Tambien aparece una pregunta de producto: Pollen muestra `SOIL A` y `SOIL B`
+por cada Rhizome. Mi lectura es que esos campos son sondas dentro de cada nodo,
+no dos Rhizomes.
+
+## Decision tecnica
+
+Amplio la fachada Rhizome -> Pollen con:
+
+- `GET /summary/since?since=...&locale=es|en`
+- `GET /explain/decision/{id}?locale=es|en`
+- soporte de `--node-id`
+- soporte de `--data-dir`
+- script `start_demo_two_rhizomes.sh`
+
+No introduzco llamada LLM en el summary.
+
+## Por que no LLM todavia
+
+El boton principal debe ser muy estable. Para MVP, la "inteligencia" es
+determinista:
+
+- cuenta riegos, bloqueos y alertas;
+- calcula severidad;
+- mira deposito actual;
+- mira sondas A/B;
+- genera highlights y recomendacion;
+- localiza ES/EN.
+
+Gemma 4 E2B puede entrar despues como redactor, pero sobre hechos ya agregados.
+No debe inventar ni reinterpretar recibos.
+
+## Demo multi-Rhizome
+
+`rhizome_01`:
+
+```text
+http://192.168.1.60:13010/
+```
+
+`rhizome_02` simulado:
+
+```text
+http://192.168.1.60:13020/
+```
+
+Datos simulados:
+
+```text
+code/rhizome/demo_data/rhizome_02/
+```
+
+Regla narrativa: si se usa en video, se dice como simulacion host-side de
+interoperabilidad multi-Rhizome, no como segundo ESP32 fisico.
+
+## Pruebas locales
+
+```bash
+cd code/rhizome
+python -m unittest tests.test_sync_facade
+```
+
+Resultado:
+
+```text
+Ran 7 tests
+OK
+```
+
+Scripts:
+
+```bash
+bash -n code/rhizome/jetson/start_sync_facade.sh
+bash -n code/rhizome/jetson/smoke_sync_facade.sh
+bash -n code/rhizome/jetson/start_demo_two_rhizomes.sh
+```
+
+Resultado: OK.

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -69,6 +69,7 @@ visitar la parcela sin depender de mocks Android:
 - `GET /snapshot/latest`
 - `GET /receipts?since=...`
 - `GET /explain/decision/{id}`
+- `GET /summary/since?since=...&locale=es|en`
 
 Como paso MVP, `src/rhizome_sync_facade.py` sirve esos cuatro endpoints desde
 JSON locales con forma de contrato compartido (`code/shared/schemas/examples`).
@@ -76,6 +77,20 @@ Es una fachada de interoperabilidad: no toca ESP32, no abre actuadores, no llama
 al LLM y no sustituye la persistencia real de Rhizome. Su valor es permitir que
 Floema apunte `RhizomeNetworkClient` a una IP real de Jetson mientras el backend
 definitivo de sensores/SQLite termina de cerrarse.
+
+`/summary/since` es el endpoint para el boton principal de Pollen:
+"Que ha pasado desde mi ausencia?". En el MVP de demo compone un resumen
+determinista con:
+
+- conteo de riegos, bloqueos y alertas;
+- severidad `ok | attention | alert`;
+- estado actual de deposito y sondas de suelo A/B;
+- recomendacion breve;
+- localizacion `es` o `en`.
+
+No usa el LLM todavia. Es intencional: desbloquea la UX con una pieza
+testeable y segura. La evolucion natural es que Gemma 4 E2B ayude a redactar
+ese resumen sobre datos ya agregados, sin cambiar hechos ni decisiones.
 
 Arranque local/Jetson:
 
@@ -90,6 +105,7 @@ Prueba minima:
 curl http://127.0.0.1:13010/status
 curl http://127.0.0.1:13010/snapshot/latest
 curl http://127.0.0.1:13010/receipts
+curl "http://127.0.0.1:13010/summary/since?locale=es"
 ```
 
 Base URL para Pollen en la red local del dia 19:
@@ -97,3 +113,20 @@ Base URL para Pollen en la red local del dia 19:
 ```text
 http://192.168.1.60:13010/
 ```
+
+Para video/demo se puede simular un segundo Rhizome en el mismo Jetson:
+
+```bash
+cd code/rhizome/jetson
+./start_demo_two_rhizomes.sh
+```
+
+Esto levanta:
+
+```text
+rhizome_01 -> http://192.168.1.60:13010/
+rhizome_02 -> http://192.168.1.60:13020/
+```
+
+`rhizome_02` usa `code/rhizome/demo_data/rhizome_02`. Debe documentarse como
+simulacion de interoperabilidad multi-Rhizome, no como segundo nodo fisico.

--- a/code/rhizome/demo_data/rhizome_02/decision_receipt.json
+++ b/code/rhizome/demo_data/rhizome_02/decision_receipt.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T15:10:10Z",
+  "origin_node_id": "rhizome_02",
+  "signature": null,
+  "decision_id": "rec_rhizome_02_20260416T151010_e2b1",
+  "snapshot_id": "snap_rhizome_02_20260416T151005_b7c9",
+  "active_policy_id": "pkt_rhizome_02_20260416T083015_a8c4",
+  "action": "WATER_A",
+  "action_params": {
+    "duration_s": 18,
+    "expected_liters": 0.9
+  },
+  "rationale_short": "Soil probe A was below threshold; Rhizome watered briefly within the safe envelope.",
+  "rationale_full": "Soil probe A reported 31.4%, below the active policy threshold. Tank level was 43%, heartbeat was healthy, and the requested 18s duration stayed inside the safe envelope.",
+  "policy_refs": [
+    "rules.soil_moisture_thresholds.parcel_a.min_pct",
+    "rules.max_watering_duration_s",
+    "rules.tank_minimum_pct"
+  ],
+  "contradictions": [],
+  "confidence": 0.84,
+  "executed": true,
+  "execution_details": {
+    "sent_to_esp32_at": "2026-04-16T15:10:10Z",
+    "esp32_ack_at": "2026-04-16T15:10:11Z",
+    "esp32_ack_status": "OK",
+    "actual_duration_s": 18.1,
+    "flow_observed_lpm": 2.9,
+    "estimated_liters_actual": 0.88
+  },
+  "blocked_reason": null
+}

--- a/code/rhizome/demo_data/rhizome_02/decision_receipt_blocked.json
+++ b/code/rhizome/demo_data/rhizome_02/decision_receipt_blocked.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T18:25:40Z",
+  "origin_node_id": "rhizome_02",
+  "signature": null,
+  "decision_id": "rec_rhizome_02_20260416T182540_f4d0",
+  "snapshot_id": "snap_rhizome_02_20260416T182500_c4a1",
+  "active_policy_id": "pkt_rhizome_02_20260416T083015_a8c4",
+  "action": "BLOCK",
+  "action_params": {
+    "blocked_action": "WATER_A",
+    "reason": "watering_window_closed"
+  },
+  "rationale_short": "Rhizome blocked a late watering request because it was outside the active watering window.",
+  "rationale_full": "Soil probe A remained dry, but the active policy only allows watering in the morning window. Rhizome kept the decision traceable and did not send a water command.",
+  "policy_refs": [
+    "rules.watering_window",
+    "rules.soil_moisture_thresholds.parcel_a.min_pct"
+  ],
+  "contradictions": [],
+  "confidence": 0.91,
+  "executed": false,
+  "execution_details": null,
+  "blocked_reason": "watering_window_closed"
+}

--- a/code/rhizome/demo_data/rhizome_02/rhizome_snapshot.json
+++ b/code/rhizome/demo_data/rhizome_02/rhizome_snapshot.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0",
+  "created_at": "2026-04-16T15:12:05Z",
+  "origin_node_id": "rhizome_02",
+  "signature": null,
+  "snapshot_id": "snap_rhizome_02_20260416T151205_b7c9",
+  "mode": "conservative",
+  "active_policy_id": "pkt_rhizome_02_20260416T083015_a8c4",
+  "active_policy_expires_at": "2026-04-17T08:30:15Z",
+  "sensors": {
+    "soil_moisture_a_pct": 31.4,
+    "soil_moisture_b_pct": 34.8,
+    "tank_level_pct": 43.0,
+    "flow_rate_lpm": 0.0,
+    "last_reading_at": "2026-04-16T15:11:58Z"
+  },
+  "vision": {
+    "last_capture_at": "2026-04-16T15:05:00Z",
+    "parcel_a_status": "dry_edges",
+    "parcel_b_status": "stable",
+    "visual_notes": "parcel A shows mild edge dryness; parcel B remains stable"
+  },
+  "health": {
+    "cpu_temp_c": 56.1,
+    "cpu_load_pct": 37.0,
+    "ram_used_gb": 4.6,
+    "ram_total_gb": 7.4,
+    "esp32_heartbeat_ok": true,
+    "last_esp32_ack_at": "2026-04-16T15:12:00Z"
+  },
+  "last_decision_id": "rec_rhizome_02_20260416T151000_e2b1",
+  "pending_contradictions": []
+}

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -154,6 +154,7 @@ GET /status
 GET /snapshot/latest
 GET /receipts?since=...
 GET /explain/decision/{id}
+GET /summary/since?since=...&locale=es|en
 ```
 
 Base URL para Pollen en la red local del dia 19:
@@ -161,6 +162,24 @@ Base URL para Pollen en la red local del dia 19:
 ```text
 http://192.168.1.60:13010/
 ```
+
+Para el video se puede levantar una segunda fachada simulada en el mismo
+Jetson:
+
+```bash
+./start_demo_two_rhizomes.sh
+```
+
+Endpoints de demo:
+
+```text
+rhizome_01 -> http://192.168.1.60:13010/
+rhizome_02 -> http://192.168.1.60:13020/
+```
+
+`rhizome_02` usa datos de `code/rhizome/demo_data/rhizome_02`. Es una
+simulacion host-side de interoperabilidad multi-Rhizome: no hay segundo ESP32,
+no hay segunda bomba y no se toca hardware fisico.
 
 Baseline operativo:
 

--- a/code/rhizome/jetson/smoke_sync_facade.sh
+++ b/code/rhizome/jetson/smoke_sync_facade.sh
@@ -22,6 +22,7 @@ def get_json(path: str):
 status = get_json("/status")
 snapshot = get_json("/snapshot/latest")
 receipts = get_json("/receipts")
+summary = get_json("/summary/since?locale=es")
 
 if status.get("status") != "ready":
     raise SystemExit(f"bad status payload: {status}")
@@ -29,8 +30,10 @@ if not snapshot.get("snapshot_id"):
     raise SystemExit(f"missing snapshot_id: {snapshot}")
 if not receipts or not receipts[0].get("decision_id"):
     raise SystemExit(f"bad receipts payload: {receipts}")
+if not summary.get("summary") or not summary.get("headline"):
+    raise SystemExit(f"bad summary payload: {summary}")
 
-explanation = get_json(f"/explain/decision/{receipts[0]['decision_id']}")
+explanation = get_json(f"/explain/decision/{receipts[0]['decision_id']}?locale=en")
 if not explanation.get("explanation"):
     raise SystemExit(f"bad explanation payload: {explanation}")
 
@@ -39,9 +42,11 @@ print(
         {
             "status": "ok",
             "facade_url": base_url,
+            "node_id": status.get("node_id"),
             "snapshot_id": snapshot["snapshot_id"],
             "receipts": len(receipts),
             "explained_decision_id": receipts[0]["decision_id"],
+            "summary_severity": summary.get("severity"),
         },
         ensure_ascii=False,
         separators=(",", ":"),

--- a/code/rhizome/jetson/start_demo_two_rhizomes.sh
+++ b/code/rhizome/jetson/start_demo_two_rhizomes.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$HOME/sprout}"
+
+cd "$(dirname "$0")"
+
+echo "Starting demo Rhizome facades on one Jetson."
+echo "This is an explicit video/demo simulation, not two physical ESP32 nodes."
+
+FACADE_NODE_ID=rhizome_01 \
+FACADE_PORT=13010 \
+REPO_DIR="$REPO_DIR" \
+./start_sync_facade.sh
+
+FACADE_NODE_ID=rhizome_02 \
+FACADE_PORT=13020 \
+FACADE_DATA_DIR="$REPO_DIR/code/rhizome/demo_data/rhizome_02" \
+REPO_DIR="$REPO_DIR" \
+./start_sync_facade.sh
+
+echo "Smoke rhizome_01 (:13010)"
+FACADE_URL=http://127.0.0.1:13010 ./smoke_sync_facade.sh
+
+echo "Smoke rhizome_02 (:13020)"
+FACADE_URL=http://127.0.0.1:13020 ./smoke_sync_facade.sh
+
+cat <<'TXT'
+Demo endpoints:
+  rhizome_01 -> http://192.168.1.60:13010/
+  rhizome_02 -> http://192.168.1.60:13020/
+
+Document in video/writeup: rhizome_02 is simulated on the same Jetson to show
+multi-Rhizome sync behavior. It does not represent a second physical ESP32.
+TXT

--- a/code/rhizome/jetson/start_sync_facade.sh
+++ b/code/rhizome/jetson/start_sync_facade.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 FACADE_PORT="${FACADE_PORT:-13010}"
 FACADE_HOST="${FACADE_HOST:-0.0.0.0}"
-FACADE_PID_FILE="${FACADE_PID_FILE:-/tmp/sprout_rhizome_sync_facade.pid}"
-FACADE_LOG_FILE="${FACADE_LOG_FILE:-/tmp/sprout_rhizome_sync_facade.log}"
+FACADE_NODE_ID="${FACADE_NODE_ID:-rhizome_01}"
+FACADE_PID_FILE="${FACADE_PID_FILE:-/tmp/sprout_${FACADE_NODE_ID}_sync_facade_${FACADE_PORT}.pid}"
+FACADE_LOG_FILE="${FACADE_LOG_FILE:-/tmp/sprout_${FACADE_NODE_ID}_sync_facade_${FACADE_PORT}.log}"
+FACADE_DATA_DIR="${FACADE_DATA_DIR:-}"
 REPO_DIR="${REPO_DIR:-$HOME/sprout}"
 
 if [ ! -f "$REPO_DIR/code/rhizome/src/rhizome_sync_facade.py" ]; then
@@ -22,15 +24,23 @@ if [ -f "$FACADE_PID_FILE" ]; then
 fi
 
 echo "Starting Rhizome sync facade on ${FACADE_HOST}:${FACADE_PORT}"
+echo "Node: $FACADE_NODE_ID"
 echo "Repo: $REPO_DIR"
 echo "Log: $FACADE_LOG_FILE"
 
+FACADE_ARGS=(
+  --host "$FACADE_HOST"
+  --port "$FACADE_PORT"
+  --node-id "$FACADE_NODE_ID"
+)
+
+if [ -n "$FACADE_DATA_DIR" ]; then
+  FACADE_ARGS+=(--data-dir "$FACADE_DATA_DIR")
+fi
+
 (
   cd "$REPO_DIR/code/rhizome"
-  nohup python -m src.rhizome_sync_facade \
-    --host "$FACADE_HOST" \
-    --port "$FACADE_PORT" \
-    >"$FACADE_LOG_FILE" 2>&1 &
+  nohup python -m src.rhizome_sync_facade "${FACADE_ARGS[@]}" >"$FACADE_LOG_FILE" 2>&1 &
   echo $! >"$FACADE_PID_FILE"
 )
 

--- a/code/rhizome/jetson/start_sync_facade.sh
+++ b/code/rhizome/jetson/start_sync_facade.sh
@@ -8,6 +8,7 @@ FACADE_PID_FILE="${FACADE_PID_FILE:-/tmp/sprout_${FACADE_NODE_ID}_sync_facade_${
 FACADE_LOG_FILE="${FACADE_LOG_FILE:-/tmp/sprout_${FACADE_NODE_ID}_sync_facade_${FACADE_PORT}.log}"
 FACADE_DATA_DIR="${FACADE_DATA_DIR:-}"
 REPO_DIR="${REPO_DIR:-$HOME/sprout}"
+LEGACY_PID_FILE="/tmp/sprout_rhizome_sync_facade.pid"
 
 if [ ! -f "$REPO_DIR/code/rhizome/src/rhizome_sync_facade.py" ]; then
   echo "rhizome sync facade source not found under $REPO_DIR" >&2
@@ -19,6 +20,15 @@ if [ -f "$FACADE_PID_FILE" ]; then
   if [ -n "$old_pid" ] && kill -0 "$old_pid" >/dev/null 2>&1; then
     echo "Stopping previous rhizome sync facade pid=$old_pid"
     kill "$old_pid" >/dev/null 2>&1 || true
+    sleep 1
+  fi
+fi
+
+if [ "$FACADE_NODE_ID" = "rhizome_01" ] && [ "$FACADE_PORT" = "13010" ] && [ -f "$LEGACY_PID_FILE" ]; then
+  legacy_pid="$(cat "$LEGACY_PID_FILE" 2>/dev/null || true)"
+  if [ -n "$legacy_pid" ] && kill -0 "$legacy_pid" >/dev/null 2>&1; then
+    echo "Stopping legacy rhizome sync facade pid=$legacy_pid"
+    kill "$legacy_pid" >/dev/null 2>&1 || true
     sleep 1
   fi
 fi

--- a/code/rhizome/src/rhizome_sync_facade.py
+++ b/code/rhizome/src/rhizome_sync_facade.py
@@ -91,6 +91,14 @@ def _severity(snapshot: dict[str, Any], counts: dict[str, int]) -> str:
     return "ok"
 
 
+def _plural_es(count: int, singular: str, plural: str) -> str:
+    return f"{count} {singular if count == 1 else plural}"
+
+
+def _plural_en(count: int, singular: str, plural: str) -> str:
+    return f"{count} {singular if count == 1 else plural}"
+
+
 def _explain_receipt(receipt: dict[str, Any], locale: str) -> str:
     action = str(receipt.get("action", "")).upper()
     params = receipt.get("action_params", {})
@@ -154,8 +162,9 @@ def _summary_text(
             headline = f"{node_id}: attention needed after your absence"
         highlights = [
             (
-                f"{counts['water']} watering events, {counts['block']} safety blocks, "
-                f"{counts['alert']} alerts."
+                f"{_plural_en(counts['water'], 'watering event', 'watering events')}, "
+                f"{_plural_en(counts['block'], 'safety block', 'safety blocks')}, "
+                f"{_plural_en(counts['alert'], 'alert', 'alerts')}."
             ),
             f"Current tank level is {tank:.0f}%." if tank is not None else "Current tank level is unavailable.",
             (
@@ -168,7 +177,8 @@ def _summary_text(
             highlights.append(f"Latest recorded decision: {latest_action}.")
         summary = (
             f"While you were away, {node_id} recorded {counts['total']} decisions. "
-            f"It watered {counts['water']} times and blocked {counts['block']} actions. "
+            f"It recorded {_plural_en(counts['water'], 'watering event', 'watering events')} "
+            f"and {_plural_en(counts['block'], 'blocked action', 'blocked actions')}. "
             f"Tank is now {tank:.0f}% and soil probes A/B are {soil_a:.0f}% / {soil_b:.0f}%."
             if (
                 tank is not None
@@ -188,7 +198,11 @@ def _summary_text(
     if counts["block"] or counts["alert"]:
         headline = f"{node_id}: conviene revisar lo ocurrido en tu ausencia"
     highlights = [
-        f"{counts['water']} riegos, {counts['block']} bloqueos de seguridad, {counts['alert']} alertas.",
+        (
+            f"{_plural_es(counts['water'], 'riego', 'riegos')}, "
+            f"{_plural_es(counts['block'], 'bloqueo de seguridad', 'bloqueos de seguridad')}, "
+            f"{_plural_es(counts['alert'], 'alerta', 'alertas')}."
+        ),
         f"El deposito esta al {tank:.0f}%." if tank is not None else "No hay lectura de deposito.",
         (
             f"Las sondas de suelo A/B marcan {soil_a:.0f}% / {soil_b:.0f}%."
@@ -200,7 +214,8 @@ def _summary_text(
         highlights.append(f"Ultima decision registrada: {latest_action}.")
     summary = (
         f"Durante tu ausencia, {node_id} registro {counts['total']} decisiones. "
-        f"Regó {counts['water']} veces y bloqueó {counts['block']} acciones. "
+        f"Registro {_plural_es(counts['water'], 'riego', 'riegos')} "
+        f"y {_plural_es(counts['block'], 'accion bloqueada', 'acciones bloqueadas')}. "
         f"El deposito esta al {tank:.0f}% y las sondas A/B marcan {soil_a:.0f}% / {soil_b:.0f}%."
         if (
             tank is not None

--- a/code/rhizome/src/rhizome_sync_facade.py
+++ b/code/rhizome/src/rhizome_sync_facade.py
@@ -17,6 +17,7 @@ from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
 VERSION = "0.1.0"
+SUPPORTED_LOCALES = {"es", "en"}
 
 
 def _repo_root() -> Path:
@@ -42,17 +43,192 @@ def _parse_zulu(value: str | None) -> datetime | None:
     return parsed
 
 
+def _select_locale(query: dict[str, list[str]]) -> str:
+    raw = query.get("locale", ["es"])[0].lower().strip()
+    locale = raw.split("-")[0]
+    return locale if locale in SUPPORTED_LOCALES else "es"
+
+
+def _receipt_sort_key(receipt: dict[str, Any]) -> datetime:
+    return _parse_zulu(receipt.get("created_at")) or datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _receipt_window(receipts: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {
+        "total": len(receipts),
+        "water": 0,
+        "block": 0,
+        "alert": 0,
+        "other": 0,
+        "executed": 0,
+    }
+    for receipt in receipts:
+        action = str(receipt.get("action", "")).upper()
+        if action.startswith("WATER"):
+            counts["water"] += 1
+        elif action == "BLOCK":
+            counts["block"] += 1
+        elif action == "ALERT":
+            counts["alert"] += 1
+        else:
+            counts["other"] += 1
+        if receipt.get("executed") is True:
+            counts["executed"] += 1
+    return counts
+
+
+def _tank_pct(snapshot: dict[str, Any]) -> float | None:
+    value = snapshot.get("sensors", {}).get("tank_level_pct")
+    return float(value) if isinstance(value, int | float) else None
+
+
+def _severity(snapshot: dict[str, Any], counts: dict[str, int]) -> str:
+    tank = _tank_pct(snapshot)
+    if counts["alert"] > 0:
+        return "alert"
+    if counts["block"] > 0 or (tank is not None and tank < 30):
+        return "attention"
+    return "ok"
+
+
+def _explain_receipt(receipt: dict[str, Any], locale: str) -> str:
+    action = str(receipt.get("action", "")).upper()
+    params = receipt.get("action_params", {})
+    rationale = str(receipt.get("rationale_full") or receipt.get("rationale_short") or "").strip()
+    blocked_reason = str(receipt.get("blocked_reason") or "").strip()
+
+    if locale == "en":
+        if action.startswith("WATER"):
+            duration = params.get("duration_s")
+            liters = params.get("expected_liters")
+            return (
+                f"Rhizome executed {action} for {duration}s, expecting about {liters} L. "
+                "The decision was allowed because the snapshot and active policy did not hit "
+                "a safety veto. The detailed DecisionReceipt remains available for audit."
+            )
+        if action == "BLOCK":
+            return (
+                "Rhizome blocked the proposed action because a safety condition had priority. "
+                f"Reason code: {blocked_reason or 'not specified'}. "
+                "The detailed DecisionReceipt remains available for audit."
+            )
+        if action == "ALERT":
+            return "Rhizome raised an alert and did not water."
+        return f"Rhizome recorded {action}."
+
+    if action.startswith("WATER"):
+        duration = params.get("duration_s")
+        liters = params.get("expected_liters")
+        return (
+            f"Rhizome ejecutó {action} durante {duration}s, con unos {liters} L esperados. "
+            "La decisión pasó porque el snapshot y la política activa no activaron ningún veto "
+            f"de seguridad. Nota del recibo: {rationale}"
+        )
+    if action == "BLOCK":
+        return (
+            "Rhizome bloqueó la acción propuesta porque una condición de seguridad tenía prioridad. "
+            f"Código: {blocked_reason or 'sin especificar'}. Nota del recibo: {rationale}"
+        )
+    if action == "ALERT":
+        return f"Rhizome elevó una alerta y no regó. Nota del recibo: {rationale}"
+    return f"Rhizome registró {action}. Nota del recibo: {rationale}"
+
+
+def _summary_text(
+    node_id: str,
+    snapshot: dict[str, Any],
+    receipts: list[dict[str, Any]],
+    counts: dict[str, int],
+    locale: str,
+) -> tuple[str, str, list[str], str]:
+    tank = _tank_pct(snapshot)
+    sensors = snapshot.get("sensors", {})
+    soil_a = sensors.get("soil_moisture_a_pct")
+    soil_b = sensors.get("soil_moisture_b_pct")
+    latest = sorted(receipts, key=_receipt_sort_key)[-1] if receipts else None
+    latest_action = latest.get("action") if latest else None
+
+    if locale == "en":
+        headline = f"{node_id}: {counts['total']} decisions since the last visit"
+        if counts["block"] or counts["alert"]:
+            headline = f"{node_id}: attention needed after your absence"
+        highlights = [
+            (
+                f"{counts['water']} watering events, {counts['block']} safety blocks, "
+                f"{counts['alert']} alerts."
+            ),
+            f"Current tank level is {tank:.0f}%." if tank is not None else "Current tank level is unavailable.",
+            (
+                f"Soil probes A/B read {soil_a:.0f}% / {soil_b:.0f}%."
+                if isinstance(soil_a, int | float) and isinstance(soil_b, int | float)
+                else "Soil probe readings are incomplete."
+            ),
+        ]
+        if latest_action:
+            highlights.append(f"Latest recorded decision: {latest_action}.")
+        summary = (
+            f"While you were away, {node_id} recorded {counts['total']} decisions. "
+            f"It watered {counts['water']} times and blocked {counts['block']} actions. "
+            f"Tank is now {tank:.0f}% and soil probes A/B are {soil_a:.0f}% / {soil_b:.0f}%."
+            if (
+                tank is not None
+                and isinstance(soil_a, int | float)
+                and isinstance(soil_b, int | float)
+            )
+            else f"While you were away, {node_id} recorded {counts['total']} decisions."
+        )
+        recommendation = (
+            "Review the blocked receipt before carrying new water policies."
+            if counts["block"] or counts["alert"]
+            else "No urgent intervention is suggested by this summary."
+        )
+        return headline, summary, highlights, recommendation
+
+    headline = f"{node_id}: {counts['total']} decisiones desde la ultima visita"
+    if counts["block"] or counts["alert"]:
+        headline = f"{node_id}: conviene revisar lo ocurrido en tu ausencia"
+    highlights = [
+        f"{counts['water']} riegos, {counts['block']} bloqueos de seguridad, {counts['alert']} alertas.",
+        f"El deposito esta al {tank:.0f}%." if tank is not None else "No hay lectura de deposito.",
+        (
+            f"Las sondas de suelo A/B marcan {soil_a:.0f}% / {soil_b:.0f}%."
+            if isinstance(soil_a, int | float) and isinstance(soil_b, int | float)
+            else "Las lecturas de suelo estan incompletas."
+        ),
+    ]
+    if latest_action:
+        highlights.append(f"Ultima decision registrada: {latest_action}.")
+    summary = (
+        f"Durante tu ausencia, {node_id} registro {counts['total']} decisiones. "
+        f"Regó {counts['water']} veces y bloqueó {counts['block']} acciones. "
+        f"El deposito esta al {tank:.0f}% y las sondas A/B marcan {soil_a:.0f}% / {soil_b:.0f}%."
+        if (
+            tank is not None
+            and isinstance(soil_a, int | float)
+            and isinstance(soil_b, int | float)
+        )
+        else f"Durante tu ausencia, {node_id} registro {counts['total']} decisiones."
+    )
+    recommendation = (
+        "Revisa el recibo bloqueado antes de transportar nuevas politicas."
+        if counts["block"] or counts["alert"]
+        else "El resumen no sugiere una intervencion urgente."
+    )
+    return headline, summary, highlights, recommendation
+
+
 class RhizomeReadStore:
     """Loads contract-shaped JSON objects from a local directory."""
 
-    def __init__(self, data_dir: Path | None = None) -> None:
+    def __init__(self, data_dir: Path | None = None, node_id: str = "rhizome_01") -> None:
         self.data_dir = data_dir or default_data_dir()
+        self.node_id = node_id
 
     def status(self) -> dict[str, str]:
         return {
             "status": "ready",
             "version": VERSION,
-            "node_id": "rhizome_01",
+            "node_id": self.node_id,
             "mode": "read_only_facade",
             "source": str(self.data_dir),
         }
@@ -86,9 +262,52 @@ class RhizomeReadStore:
     def explain_decision(self, decision_id: str) -> dict[str, str] | None:
         for receipt in self.receipts():
             if receipt.get("decision_id") == decision_id:
-                rationale = str(receipt.get("rationale_short") or "").strip()
-                return {"explanation": rationale or "DecisionReceipt sin rationale_short."}
+                return {
+                    "decision_id": decision_id,
+                    "node_id": self.node_id,
+                    "explanation": _explain_receipt(receipt, "es"),
+                    "source": "deterministic_receipt_explainer",
+                }
         return None
+
+    def explain_decision_locale(self, decision_id: str, locale: str) -> dict[str, str] | None:
+        for receipt in self.receipts():
+            if receipt.get("decision_id") == decision_id:
+                return {
+                    "decision_id": decision_id,
+                    "node_id": self.node_id,
+                    "locale": locale,
+                    "explanation": _explain_receipt(receipt, locale),
+                    "source": "deterministic_receipt_explainer",
+                }
+        return None
+
+    def visit_summary(self, since: str | None = None, locale: str = "es") -> dict[str, Any]:
+        snapshot = self.latest_snapshot()
+        receipts = self.receipts(since=since)
+        counts = _receipt_window(receipts)
+        severity = _severity(snapshot, counts)
+        headline, summary, highlights, recommendation = _summary_text(
+            self.node_id,
+            snapshot,
+            receipts,
+            counts,
+            locale,
+        )
+        return {
+            "node_id": self.node_id,
+            "locale": locale,
+            "since": since,
+            "severity": severity,
+            "headline": headline,
+            "summary": summary,
+            "highlights": highlights,
+            "recommendation": recommendation,
+            "counts": counts,
+            "latest_snapshot_id": snapshot.get("snapshot_id"),
+            "source": "deterministic_demo_summary",
+            "simulation": True,
+        }
 
 
 class RhizomeSyncHandler(BaseHTTPRequestHandler):
@@ -108,6 +327,8 @@ class RhizomeSyncHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/") or "/"
+        query = parse_qs(parsed.query)
+        locale = _select_locale(query)
 
         try:
             if path == "/status":
@@ -119,14 +340,19 @@ class RhizomeSyncHandler(BaseHTTPRequestHandler):
                 return
 
             if path == "/receipts":
-                since = parse_qs(parsed.query).get("since", [None])[0]
+                since = query.get("since", [None])[0]
                 self._send_json(HTTPStatus.OK, self.store.receipts(since=since))
+                return
+
+            if path == "/summary/since":
+                since = query.get("since", [None])[0]
+                self._send_json(HTTPStatus.OK, self.store.visit_summary(since=since, locale=locale))
                 return
 
             prefix = "/explain/decision/"
             if path.startswith(prefix):
                 decision_id = unquote(path[len(prefix) :])
-                explanation = self.store.explain_decision(decision_id)
+                explanation = self.store.explain_decision_locale(decision_id, locale)
                 if explanation is None:
                     self._send_json(
                         HTTPStatus.NOT_FOUND,
@@ -146,9 +372,14 @@ class RhizomeSyncHandler(BaseHTTPRequestHandler):
             self._send_json(HTTPStatus.BAD_REQUEST, {"error": "bad_request", "detail": str(exc)})
 
 
-def make_server(host: str, port: int, data_dir: Path | None = None) -> ThreadingHTTPServer:
+def make_server(
+    host: str,
+    port: int,
+    data_dir: Path | None = None,
+    node_id: str = "rhizome_01",
+) -> ThreadingHTTPServer:
     class Handler(RhizomeSyncHandler):
-        store = RhizomeReadStore(data_dir=data_dir)
+        store = RhizomeReadStore(data_dir=data_dir, node_id=node_id)
 
     return ThreadingHTTPServer((host, port), Handler)
 
@@ -158,10 +389,14 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=13010)
     parser.add_argument("--data-dir", type=Path, default=default_data_dir())
+    parser.add_argument("--node-id", default="rhizome_01")
     args = parser.parse_args()
 
-    server = make_server(args.host, args.port, args.data_dir)
-    print(f"rhizome_sync_facade listening on http://{args.host}:{args.port}", flush=True)
+    server = make_server(args.host, args.port, args.data_dir, args.node_id)
+    print(
+        f"rhizome_sync_facade node_id={args.node_id} listening on http://{args.host}:{args.port}",
+        flush=True,
+    )
     server.serve_forever()
 
 

--- a/code/rhizome/tests/test_sync_facade.py
+++ b/code/rhizome/tests/test_sync_facade.py
@@ -23,8 +23,8 @@ def _get_json(base_url: str, path: str):
         return json.loads(response.read().decode("utf-8"))
 
 
-def _run_server(data_dir: Path):
-    server = make_server("127.0.0.1", 0, data_dir)
+def _run_server(data_dir: Path, node_id: str = "rhizome_01"):
+    server = make_server("127.0.0.1", 0, data_dir, node_id=node_id)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address
@@ -44,11 +44,61 @@ class SyncFacadeTest(unittest.TestCase):
 
         self.assertEqual(status["status"], "ready")
         self.assertEqual(status["mode"], "read_only_facade")
+        self.assertEqual(status["node_id"], "rhizome_01")
         self.assertTrue(snapshot["snapshot_id"])
         self.assertGreaterEqual(snapshot["sensors"]["tank_level_pct"], 0)
         self.assertIsInstance(receipts, list)
         self.assertTrue(receipts[0]["decision_id"])
-        self.assertEqual(explanation["explanation"], receipts[0]["rationale_short"])
+        self.assertEqual(explanation["source"], "deterministic_receipt_explainer")
+        self.assertIn(receipts[0]["action"], explanation["explanation"])
+
+    def test_explanation_can_be_localized_to_english(self):
+        server, base_url = _run_server(default_data_dir())
+        try:
+            receipts = _get_json(base_url, "/receipts")
+            explanation = _get_json(
+                base_url,
+                f"/explain/decision/{receipts[0]['decision_id']}?locale=en",
+            )
+        finally:
+            _stop_server(server)
+
+        self.assertEqual(explanation["locale"], "en")
+        self.assertIn("Rhizome executed", explanation["explanation"])
+
+    def test_visit_summary_is_smart_button_payload(self):
+        server, base_url = _run_server(default_data_dir())
+        try:
+            summary = _get_json(base_url, "/summary/since?locale=es")
+            future_summary = _get_json(
+                base_url,
+                "/summary/since?since=2099-01-01T00:00:00Z&locale=en",
+            )
+        finally:
+            _stop_server(server)
+
+        self.assertEqual(summary["node_id"], "rhizome_01")
+        self.assertEqual(summary["source"], "deterministic_demo_summary")
+        self.assertEqual(summary["severity"], "attention")
+        self.assertEqual(summary["counts"]["total"], 2)
+        self.assertIn("Durante tu ausencia", summary["summary"])
+        self.assertEqual(future_summary["counts"]["total"], 0)
+        self.assertEqual(future_summary["locale"], "en")
+
+    def test_second_rhizome_demo_data_can_run_on_another_port(self):
+        data_dir = default_data_dir().parents[2] / "rhizome" / "demo_data" / "rhizome_02"
+        server, base_url = _run_server(data_dir, node_id="rhizome_02")
+        try:
+            status = _get_json(base_url, "/status")
+            snapshot = _get_json(base_url, "/snapshot/latest")
+            summary = _get_json(base_url, "/summary/since?locale=en")
+        finally:
+            _stop_server(server)
+
+        self.assertEqual(status["node_id"], "rhizome_02")
+        self.assertEqual(snapshot["origin_node_id"], "rhizome_02")
+        self.assertEqual(summary["node_id"], "rhizome_02")
+        self.assertTrue(summary["simulation"])
 
     def test_receipts_since_filter_uses_created_at(self):
         server, base_url = _run_server(default_data_dir())

--- a/coordinacion/2026-05-05_rhizome_summary_and_two_node_demo/README.md
+++ b/coordinacion/2026-05-05_rhizome_summary_and_two_node_demo/README.md
@@ -1,0 +1,113 @@
+# Rhizome summary + two-node demo facade
+
+**Fecha:** 2026-05-05  
+**Autora:** Endodermis  
+**Para:** Bea, Cambium, Floema  
+**Rama:** `feat/endodermis/rhizome-visit-summary-demo`
+
+## Decision
+
+El boton principal de Pollen sera:
+
+```text
+¿Que ha pasado desde mi ausencia?
+```
+
+Rhizome expone un endpoint nuevo:
+
+```text
+GET /summary/since?since=<iso|null>&locale=es|en
+```
+
+Respuesta minima:
+
+```json
+{
+  "node_id": "rhizome_01",
+  "locale": "es",
+  "since": null,
+  "severity": "attention",
+  "headline": "rhizome_01: conviene revisar lo ocurrido en tu ausencia",
+  "summary": "Durante tu ausencia...",
+  "highlights": ["..."],
+  "recommendation": "...",
+  "counts": {
+    "total": 2,
+    "water": 1,
+    "block": 1,
+    "alert": 0,
+    "other": 0,
+    "executed": 1
+  },
+  "latest_snapshot_id": "...",
+  "source": "deterministic_demo_summary",
+  "simulation": true
+}
+```
+
+## Inteligencia aplicada
+
+Para el MVP no llamo al LLM en este endpoint. La inteligencia es determinista:
+
+- cuenta riegos, bloqueos y alertas;
+- calcula severidad `ok | attention | alert`;
+- cruza receipts con snapshot actual;
+- incluye deposito y sondas A/B;
+- genera una recomendacion breve;
+- localiza salida a `es` o `en`.
+
+Motivo: el boton principal necesita ser rapido, testeable y estable. Gemma 4 E2B
+puede entrar despues como redactor sobre hechos ya agregados, no como fuente de
+verdad.
+
+## Dos Rhizomes en el video
+
+Se puede simular `rhizome_02` desde la misma Jetson:
+
+```bash
+cd ~/sprout/code/rhizome/jetson
+./start_demo_two_rhizomes.sh
+```
+
+Endpoints:
+
+```text
+rhizome_01 -> http://192.168.1.60:13010/
+rhizome_02 -> http://192.168.1.60:13020/
+```
+
+`rhizome_02` usa:
+
+```text
+code/rhizome/demo_data/rhizome_02/
+```
+
+Esto debe decirse con claridad en bitacora/writeup si se usa en video:
+
+> rhizome_02 es una simulacion host-side en la misma Jetson para demostrar
+> interoperabilidad multi-Rhizome. No representa un segundo ESP32 fisico.
+
+## Sobre SOIL A / SOIL B
+
+En el contrato actual, `soil_moisture_a_pct` y `soil_moisture_b_pct` son dos
+sondas de suelo dentro de cada Rhizome. Para la UI conviene etiquetarlas como
+`Probe A` / `Probe B` o `Soil probe A/B`, no como dos Rhizomes.
+
+Si el video muestra dos Rhizomes, cada uno puede tener sus propias sondas A/B:
+
+- `rhizome_01`: `:13010`
+- `rhizome_02`: `:13020`
+
+## Cambio sugerido para Floema
+
+Anadir al cliente Android:
+
+```kotlin
+@GET("/summary/since")
+suspend fun getVisitSummary(
+    @Query("since") since: String? = null,
+    @Query("locale") locale: String = "es"
+): VisitSummaryResponse
+```
+
+Y usarlo como payload principal del boton.

--- a/coordinacion/2026-05-05_rhizome_summary_and_two_node_demo/README.md
+++ b/coordinacion/2026-05-05_rhizome_summary_and_two_node_demo/README.md
@@ -111,3 +111,17 @@ suspend fun getVisitSummary(
 ```
 
 Y usarlo como payload principal del boton.
+
+## Estado Floema
+
+Bea confirma al cierre del dia 20 que Floema ya implemento los cambios por su
+parte.
+
+Estado de integracion:
+
+- Pollen puede consumir `GET /summary/since`;
+- el boton principal ya tiene payload Rhizome;
+- UI ajustada para el MVP de un sensor de humedad por Rhizome;
+- demo de dos Rhizomes disponible via `:13010` y `:13020`;
+- `rhizome_02` permanece documentado como simulacion host-side, no segundo
+  nodo fisico.


### PR DESCRIPTION
Endpoint principal Pollen GET /summary/since?since=...&locale=es|en + soporte localizado GET /explain/decision/{id}?locale=es|en. Demo multi-Rhizome desde una sola Jetson (rhizome_01 :13010 + rhizome_02 :13020 simulado, marcado como simulacion host-side). Floema validacion confirmada. Hallazgo: summary/since determinista en MVP, Gemma redacta pero no es fuente de verdad. SOIL A/B no debe comunicarse como dos sensores fisicos.