### PR TITLE
feat(landing-demo): primera version funcional dia 21 (HTML/CSS/JS vanilla)

### DIFF
--- a/landing-demo/README.md
+++ b/landing-demo/README.md
@@ -1,0 +1,118 @@
+# Sprout landing-demo
+
+**Status:** primera version funcional (dia 21). HTML/CSS/JS vanilla, sin
+diseno final. Venation reescribira CSS sobre esta estructura HTML estable
+cuando llegue su turno (dias 22-25). Floema integrara despues.
+
+**Path operativo**: `landing-demo/` en el repo. Se sirve como sitio
+estatico (cualquier hosting de archivos vale).
+
+---
+
+## Estructura
+
+```
+landing-demo/
+├── index.html              hero + 3 nodos + porqué + how-gemma + footer
+├── css/
+│   └── style.css           CSS funcional (no diseno final)
+├── js/
+│   ├── api.js              cliente API + mocks deterministas
+│   ├── rhizome-demo.js     interaccion Rhizome
+│   ├── pollen-demo.js      interaccion Pollen
+│   └── meristem-demo.js    interaccion Meristem
+├── try/
+│   ├── rhizome.html        demo Rhizome (decision + log)
+│   ├── pollen.html         demo Pollen (voz->politica BETA)
+│   └── meristem.html       demo Meristem (bundles -> policy)
+└── README.md               (este archivo)
+```
+
+## Como probar localmente
+
+```bash
+cd landing-demo
+python3 -m http.server 8000
+# abrir http://localhost:8000
+```
+
+O cualquier servidor estatico (`npx serve .`, `caddy file-server`, etc.).
+
+## Modo API: mock vs live
+
+El cliente `js/api.js` tiene una constante:
+
+```js
+const SPROUT_API_MODE = "mock"; // "mock" | "live"
+```
+
+**Por defecto**: `"mock"`. La demo funciona standalone sin red, con
+respuestas plausibles deterministas para los 3 casos (Rhizome E2B,
+Pollen E4B, Meristem E4B). Util para desarrollo + para servir la demo
+sin dependencia de cuenta API.
+
+**Cuando arranquemos API real** (Modal, HuggingFace Inference Endpoints
+o Cloud Run con llama.cpp):
+
+1. Cambiar `SPROUT_API_MODE = "live"`.
+2. Rellenar `SPROUT_API_ENDPOINTS` con las URLs publicadas:
+   ```js
+   const SPROUT_API_ENDPOINTS = {
+     rhizome_e2b: "https://zigiella--gemma-4-e2b.modal.run",
+     pollen_e4b: "https://zigiella--gemma-4-e4b-audio.modal.run",
+     meristem_e4b: "https://zigiella--gemma-4-e4b-tools.modal.run"
+   };
+   ```
+3. CORS habilitado en cada endpoint para el dominio de la demo
+   (`demo.zigiella.com` o equivalente).
+
+## Hosting plan
+
+**Plan A — zigiella.com / Dinahosting** (decision Bea dia 21):
+- Subdominio `demo.zigiella.com` o subdirectorio en pagina existente.
+- Subir contenido de `landing-demo/` via FTP / panel del hosting.
+- DNS: anadir CNAME si subdominio.
+
+**Plan B (provisional) — GitHub Pages**:
+- Activar GitHub Pages sobre rama main, carpeta `/landing-demo/`.
+- URL temporal: `https://zigiella.github.io/sprout/landing-demo/`.
+- Util mientras Bea configura DNS.
+
+## Lo que ESTA en esta primera version
+
+- Estructura HTML completa con copy + textos en EN (master) + tagline ES
+- CSS funcional accesible (mobile-friendly, responsive grids)
+- Hero + 3 cards + porque-importa + how-gemma + footer
+- 3 demos hands-on:
+  - **Rhizome**: form de estado del plot + decision + log live (10 ultimas)
+  - **Pollen**: textarea (mock de voz) + compilacion -> MissionPatch + estado BETA
+  - **Meristem**: 3 escenarios + bundles -> PolicyPacket + decisions_by_rule
+- Disclaimer transparente *"DEMO via API · real app runs local"* en cada try
+- Atribucion Gemma trademark en footer de cada pagina
+- Badge BETA (ambar) en Pollen — color distinto a `signal.seed` (verde lima)
+
+## Lo que NO esta (y se arregla en iteracion 2)
+
+- **Diseno final visual** — Venation reescribe CSS cuando termine cenital + Z99.
+- **API real Gemma 4** — actualmente mock determinista. Live cuando configuremos Modal/HF/CloudRun.
+- **Endpoint publico Meristem** — opcional (Plan B segun Floema). Si arranca, anadir aqui.
+- **Transcripts navegables** del rodaje real — pendiente rodaje + Bract los integra.
+- **Diagramas de arquitectura SVG** — actualmente texto, idealmente diagrama renderizado.
+- **i18n completo** — tagline aparece en ES e EN; resto solo EN. README.es.md tiene contenido castellano.
+- **Animaciones** — sin movimiento por ahora. Venation puede anadir transiciones cuando entre.
+
+## Pasos siguientes
+
+1. **Bea + Cambium**: review de la primera version + decidir hosting (Plan A / Plan B).
+2. **Cambium + Bea**: configurar Modal/HF para Gemma 4 cuando haya tiempo (1-2h setup).
+3. **Venation**: reescribir CSS sobre estructura estable cuando termine cenital E09 + Z99 (dias 22-25).
+4. **Floema**: cuando version visual de Venation este lista, integrar APK demo flavor + Appetize embed en `/try/pollen` para que el jurado pueda probar el APK real al lado de la version web.
+
+---
+
+## Atribucion / Attribution
+
+Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.
+This project is not affiliated with or endorsed by Google.
+
+License: Apache 2.0 (see [`LICENSE`](../LICENSE)). Same as Gemma 4.

--- a/landing-demo/css/style.css
+++ b/landing-demo/css/style.css
@@ -1,0 +1,309 @@
+/*
+  Sprout landing-demo · primera versión funcional · día 21
+  CSS funcional, no diseño final. Venation reescribirá CSS sobre
+  esta estructura HTML estable cuando llegue su turno (días 22-25).
+  Paleta: neutra, accesible, sobria. Cero verde-lima signal.seed
+  (que se reserva para "AI active" en el sistema visual oficial).
+*/
+
+:root {
+  --bg: #fafaf7;
+  --bg-soft: #f0eee8;
+  --ink: #1a1a1a;
+  --ink-soft: #555;
+  --muted: #8a8a8a;
+  --accent: #2d5a4a;       /* verde oliva sobrio */
+  --accent-ink: #1a3a30;
+  --beta: #d97706;         /* ámbar/orange para BETA badge */
+  --rule: #d8d6cf;
+  --code-bg: #efece4;
+  --max-width: 880px;
+  --r: 8px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  line-height: 1.55;
+  font-size: 17px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+a:hover { color: var(--accent-ink); }
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.section { padding: 56px 0; border-top: 1px solid var(--rule); }
+.bg-soft { background: var(--bg-soft); border-top: none; border-bottom: 1px solid var(--rule); }
+
+/* Hero */
+.hero {
+  padding: 96px 0 64px;
+  background: var(--bg-soft);
+  border-bottom: 1px solid var(--rule);
+}
+.kicker {
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 12px;
+}
+h1 {
+  font-size: 64px;
+  line-height: 1.1;
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+}
+.tagline-en {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: var(--accent-ink);
+}
+.tagline-es {
+  font-size: 17px;
+  margin: 0 0 28px;
+  color: var(--ink-soft);
+}
+.lede {
+  font-size: 18px;
+  max-width: 60ch;
+  margin: 0 0 32px;
+}
+
+/* Buttons */
+.cta-row { display: flex; gap: 12px; flex-wrap: wrap; }
+.btn {
+  display: inline-block;
+  padding: 12px 22px;
+  border-radius: var(--r);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 15px;
+  border: 1px solid transparent;
+}
+.btn-primary {
+  background: var(--accent);
+  color: white;
+}
+.btn-primary:hover { background: var(--accent-ink); color: white; }
+
+.btn-secondary {
+  background: white;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.btn-secondary:hover { background: var(--accent); color: white; }
+
+.btn-ghost {
+  background: transparent;
+  color: var(--ink-soft);
+  border-color: var(--rule);
+}
+.btn-ghost:hover { color: var(--ink); border-color: var(--ink-soft); }
+
+/* Headings */
+h2 { font-size: 32px; margin: 0 0 24px; letter-spacing: -0.01em; }
+h3 { font-size: 22px; margin: 0 0 12px; }
+
+/* Cards grid */
+.grid { display: grid; gap: 24px; }
+.cards-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 720px) {
+  .cards-3 { grid-template-columns: 1fr; }
+  h1 { font-size: 44px; }
+}
+
+.card {
+  background: white;
+  border: 1px solid var(--rule);
+  border-radius: var(--r);
+  padding: 24px;
+}
+.card h3 { margin-top: 0; }
+.card-meta {
+  font-size: 13px;
+  color: var(--muted);
+  margin: -4px 0 12px;
+}
+.card p { margin: 0 0 16px; font-size: 15px; }
+
+/* Lists */
+.howlist {
+  margin: 0 0 24px;
+  padding: 0;
+  list-style: none;
+}
+.howlist li {
+  padding: 16px 0;
+  border-top: 1px solid var(--rule);
+}
+.howlist li:first-child { border-top: none; padding-top: 0; }
+
+/* Inline code */
+code {
+  background: var(--code-bg);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 90%;
+}
+
+/* Muted helpers */
+.muted { color: var(--ink-soft); }
+.small { font-size: 13px; }
+
+/* Footer */
+.footer {
+  border-top: 1px solid var(--rule);
+  padding: 32px 0;
+  font-size: 14px;
+}
+.footer p { margin: 0 0 8px; }
+
+/* ===========================
+   Demo pages (try/*)
+   =========================== */
+
+.demo-header {
+  padding: 56px 0 24px;
+  background: var(--bg-soft);
+  border-bottom: 1px solid var(--rule);
+}
+.demo-header .breadcrumb {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0 0 8px;
+}
+.demo-header h1 { font-size: 40px; margin: 0 0 8px; }
+
+.beta-badge {
+  display: inline-block;
+  background: var(--beta);
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  vertical-align: middle;
+  margin-left: 12px;
+}
+
+.demo-disclaimer {
+  background: #fef9e8;
+  border: 1px solid #f5d97a;
+  border-radius: var(--r);
+  padding: 14px 18px;
+  font-size: 14px;
+  margin: 24px 0;
+}
+.demo-disclaimer strong { color: #8a6a00; }
+
+/* Demo layout */
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin: 24px 0;
+}
+@media (max-width: 720px) {
+  .demo-grid { grid-template-columns: 1fr; }
+}
+
+.demo-panel {
+  background: white;
+  border: 1px solid var(--rule);
+  border-radius: var(--r);
+  padding: 20px;
+}
+.demo-panel h3 {
+  font-size: 16px;
+  margin: 0 0 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+/* Form / inputs */
+.demo-form { margin: 16px 0; }
+.demo-form label {
+  display: block;
+  font-weight: 600;
+  font-size: 14px;
+  margin: 0 0 6px;
+}
+.demo-form textarea,
+.demo-form input[type="text"],
+.demo-form select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--rule);
+  border-radius: var(--r);
+  font-family: inherit;
+  font-size: 15px;
+  background: white;
+}
+.demo-form textarea { min-height: 80px; resize: vertical; }
+.demo-form .hint {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 6px 0 0;
+}
+
+/* Output blocks */
+.output-block {
+  background: var(--code-bg);
+  border-radius: var(--r);
+  padding: 16px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  margin: 12px 0;
+  min-height: 60px;
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.status-pill.ok { background: #e1f3eb; color: var(--accent-ink); }
+.status-pill.alert { background: #fce5e0; color: #a02016; }
+.status-pill.warn { background: #fef0d6; color: #8a6a00; }
+.status-pill.idle { background: #ececec; color: var(--ink-soft); }
+
+/* Log area */
+.log-area {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  background: #1a1f1c;
+  color: #d4ddd6;
+  padding: 16px;
+  border-radius: var(--r);
+  height: 320px;
+  overflow-y: auto;
+}
+.log-area .ts { color: #6b8478; }
+.log-area .ev-decision { color: #b0d4c1; }
+.log-area .ev-veto { color: #f0a090; }
+.log-area .ev-policy { color: #a8c8e0; }

--- a/landing-demo/index.html
+++ b/landing-demo/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sprout — local-first irrigation decisions</title>
+  <meta name="description" content="AI Local-first irrigation decisions for plots the network and the human can't always reach. Three nodes (Rhizome, Pollen, Meristem) + an ESP32 safety coprocessor.">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+<header class="hero">
+  <div class="container">
+    <p class="kicker">AI Local-first · open-source</p>
+    <h1>Sprout</h1>
+    <p class="tagline-en">When network is absent — and the human is far — local criteria still irrigate.</p>
+    <p class="tagline-es" lang="es"><em>Cuando la red no llega y nadie está cerca, el criterio sigue regando.</em></p>
+    <p class="lede">
+      Sprout is a local-first AI architecture for irrigation decisions in remote plots —
+      places where the field, the person and the network rarely coincide in time.
+      Three nodes with distinct jurisdictions, an ESP32 safety coprocessor that vetoes physically,
+      and Gemma 4 doing what it does best on each layer.
+    </p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="#try-it">Try the system</a>
+      <a class="btn btn-ghost" href="https://github.com/zigiella/sprout">View source on GitHub</a>
+    </div>
+  </div>
+</header>
+
+<section id="try-it" class="container section">
+  <h2>Try the three nodes hands-on</h2>
+  <p class="muted">
+    Each demo runs Gemma 4 via API for the live experience. <strong>The real app runs Gemma 4 fully local</strong>
+    on Jetson, Pixel and laptop with no network dependency. We use the API in this demo so you can probe
+    the system from any browser without flashing a Jetson or sideloading an APK.
+  </p>
+
+  <div class="grid cards-3">
+    <article class="card">
+      <h3>Rhizome</h3>
+      <p class="card-meta">Plot node · Gemma 4 E2B · jurisdiction: minutes</p>
+      <p>The autonomous brain that lives next to the sensors. Decides offline whether to irrigate, defer, skip or block. Never moves water directly: an ESP32 with custom firmware enforces hard safety limits.</p>
+      <a class="btn btn-secondary" href="try/rhizome.html">Try Rhizome →</a>
+    </article>
+    <article class="card">
+      <h3>Pollen</h3>
+      <p class="card-meta">Mobile node · Gemma 4 E4B · jurisdiction: visit TTL</p>
+      <p>The roaming brain on the farmer's Android. Multimodal: feeds raw audio to Gemma 4 directly. Compiles human intent into a <code>MissionPatch</code> that the field can use immediately, federates context between plots without direct network.</p>
+      <a class="btn btn-secondary" href="try/pollen.html">Try Pollen →</a>
+    </article>
+    <article class="card">
+      <h3>Meristem</h3>
+      <p class="card-meta">Slow brain · Gemma 4 E4B · jurisdiction: days</p>
+      <p>The kitchen-table brain. Receives bundles from Pollen, evaluates with deterministic logic, emits durable policies. The LLM only writes the rationale — the decision is always auditable down to a concrete rule.</p>
+      <a class="btn btn-secondary" href="try/meristem.html">Try Meristem →</a>
+    </article>
+  </div>
+</section>
+
+<section class="container section bg-soft">
+  <h2>Why local-first AI matters here</h2>
+  <p>
+    In 2023, <strong>48% of the world's land area suffered at least one month of extreme drought</strong> —
+    the second largest extent since 1951.<sup>[1]</sup>
+    Drought affects 1.8 billion people and costs $300 billion per year.<sup>[1]</sup>
+    But the field for which we design doesn't live in continuous connectivity:
+    only 58% of the rural population worldwide uses internet — in low-income countries, 14%.<sup>[2]</sup>
+  </p>
+  <p>
+    The bottleneck isn't data. It's the <strong>lag</strong> between what happens in the plot and the
+    decision that should correct it. When the network fails or the farmer isn't there, that lag is days.
+    Closing it requires <strong>moving the decision where the water is</strong> — not the other way around.
+  </p>
+
+  <p class="muted small">
+    Sources: [1] UNCCD Global Drought Hotspots 2023-2025 + OECD Global Drought Outlook 2025.
+    [2] ITU Facts and Figures 2025. Full references in
+    <a href="https://github.com/zigiella/sprout/blob/main/research/metrics/impact_stats.md">research/metrics/impact_stats.md</a>.
+  </p>
+</section>
+
+<section class="container section">
+  <h2>How Gemma 4 is used</h2>
+  <ul class="howlist">
+    <li>
+      <strong>Multimodal audio nativo</strong> — Pollen feeds raw 16 kHz <code>.wav</code> to
+      Gemma 4 E4B via LiteRT-LM <em>without a separate STT pipeline</em>. The voice
+      <em>"riega un poco menos, esta planta aguanta más seca de lo que crees"</em> compiles
+      into a structured <code>MissionPatch</code> — in the farmer's pocket, no network.
+    </li>
+    <li>
+      <strong>Native tool calling</strong> — Meristem uses Gemma 4 E4B with native tool calling
+      for <code>compose_policy(...)</code> and bundle validation. The deterministic logic
+      decides; the LLM only writes the rationale.
+    </li>
+    <li>
+      <strong>Three-node routing</strong> — three Gemma 4 instances (E2B + E4B + E4B), three
+      jurisdictions, no cloud roundtrip. Each node holds the type of context its layer is
+      responsible for.
+    </li>
+  </ul>
+  <p>
+    <a class="btn btn-ghost" href="https://github.com/zigiella/sprout/blob/main/writeup/draft.md">Read the full technical writeup →</a>
+  </p>
+</section>
+
+<footer class="footer">
+  <div class="container">
+    <p>
+      <strong>Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.</strong>
+      This project is not affiliated with or endorsed by Google.
+    </p>
+    <p class="muted small">
+      Apache 2.0 · maintained by <a href="https://github.com/zigiella">zigiella</a> ·
+      <a href="https://github.com/zigiella/sprout">github.com/zigiella/sprout</a>
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/landing-demo/js/api.js
+++ b/landing-demo/js/api.js
@@ -1,0 +1,242 @@
+/*
+  Sprout landing-demo · cliente API Gemma 4
+  ------------------------------------------------------------
+  Feature-flag SPROUT_API_MODE controla si la demo llama a una API
+  real de Gemma 4 (Modal / HF Inference / Cloud Run) o si usa un
+  generador mock determinista para testar sin dependencias.
+
+  Patrón conservador: por defecto MOCK. Cuando Bea + Cambium
+  configuren los endpoints reales, cambiamos SPROUT_API_MODE a
+  "live" y rellenamos las URLs de SPROUT_API_ENDPOINTS abajo.
+
+  Diseño: el mock devuelve respuestas plausibles para los 3 casos
+  (Rhizome E2B, Pollen E4B, Meristem E4B) lo bastante reales para
+  que el jurado vea cómo funciona la cadena. Cuando llegue la API
+  real, el output será de Gemma 4 vivo, no de este mock.
+*/
+
+const SPROUT_API_MODE = "mock"; // "mock" | "live"
+
+// TODO_API_SETUP: cuando arranquemos Modal / HF Inference, rellenar:
+const SPROUT_API_ENDPOINTS = {
+  rhizome_e2b: null, // p.ej. "https://zigiella--gemma-4-e2b.modal.run"
+  pollen_e4b: null,  // p.ej. "https://zigiella--gemma-4-e4b-audio.modal.run"
+  meristem_e4b: null // p.ej. "https://zigiella--gemma-4-e4b-tools.modal.run"
+};
+
+// ----------------------------------------------------------------
+// API real (placeholder — usar cuando SPROUT_API_MODE === "live")
+// ----------------------------------------------------------------
+
+async function callGemmaLive(endpoint, payload) {
+  if (!endpoint) {
+    throw new Error("SPROUT_API_ENDPOINTS not configured. Set SPROUT_API_MODE='mock' or fill endpoints.");
+  }
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  if (!resp.ok) {
+    const err = await resp.text().catch(() => "(no body)");
+    throw new Error(`API ${resp.status}: ${err}`);
+  }
+  return resp.json();
+}
+
+// ----------------------------------------------------------------
+// Mock determinista para los 3 casos (Rhizome / Pollen / Meristem)
+// ----------------------------------------------------------------
+
+function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function rhizomeDecideMock(state) {
+  // simulamos latencia de inferencia local Jetson
+  await delay(900 + Math.random() * 600);
+  const soil = Number(state.soil_pct ?? 28);
+  const tank = Number(state.tank_pct ?? 65);
+  const heartbeat_age = Number(state.heartbeat_age_s ?? 8);
+
+  let action, reason, candidate_seconds = 18;
+  if (heartbeat_age > 30) {
+    action = "block";
+    reason = "JETSON_HEARTBEAT_LOST";
+    candidate_seconds = 0;
+  } else if (tank < 20) {
+    action = "block";
+    reason = "TANK_LOW";
+    candidate_seconds = 0;
+  } else if (soil > 55) {
+    action = "skip";
+    reason = "SOIL_OK_ENOUGH";
+    candidate_seconds = 0;
+  } else if (soil < 15) {
+    action = "irrigate";
+    reason = "SOIL_DRY_THRESHOLD_REACHED";
+    candidate_seconds = 26;
+  } else {
+    action = "irrigate";
+    reason = "SOIL_BELOW_OPTIMUM";
+    candidate_seconds = 18;
+  }
+
+  // ESP32 SAFE_LIMIT: si la candidate excede max_seconds_per_event = 25, modula
+  const final_seconds = Math.min(candidate_seconds, 25);
+  const modulated = (final_seconds < candidate_seconds);
+
+  return {
+    decision_id: "dec_" + Date.now().toString(36),
+    action,
+    reason,
+    candidate_action: { kind: action, seconds: candidate_seconds },
+    final_action: { kind: action, seconds: final_seconds },
+    modulated,
+    rationale_es: rationaleRhizome(action, reason, soil, tank, modulated, candidate_seconds, final_seconds),
+    rationale_en: rationaleRhizomeEn(action, reason, soil, tank, modulated, candidate_seconds, final_seconds),
+    issued_at: new Date().toISOString(),
+    valid_until_minutes: 30
+  };
+}
+
+function rationaleRhizome(action, reason, soil, tank, modulated, cand, final_s) {
+  if (action === "block" && reason === "TANK_LOW") {
+    return `Bloqueo el riego: el depósito está al ${tank}%, por debajo del mínimo del firmware.`;
+  }
+  if (action === "block" && reason === "JETSON_HEARTBEAT_LOST") {
+    return `Bloqueo el riego: Jetson sin heartbeat por más de 30s. El sistema baja a estado seguro.`;
+  }
+  if (action === "skip") {
+    return `Salto el evento: humedad ${soil}% ya está cómoda, no necesita agua ahora.`;
+  }
+  if (modulated) {
+    return `Riego ${final_s}s. Pedí ${cand}s pero el ESP32 los recortó al sobre seguro (max ${final_s}s por evento).`;
+  }
+  return `Riego ${final_s}s. Humedad ${soil}%, depósito ${tank}%, dentro del envelope seguro.`;
+}
+
+function rationaleRhizomeEn(action, reason, soil, tank, modulated, cand, final_s) {
+  if (action === "block" && reason === "TANK_LOW") {
+    return `Blocked irrigation: tank at ${tank}%, below firmware minimum.`;
+  }
+  if (action === "block" && reason === "JETSON_HEARTBEAT_LOST") {
+    return `Blocked irrigation: Jetson heartbeat lost over 30s. System falls back to safe state.`;
+  }
+  if (action === "skip") {
+    return `Skipping event: soil at ${soil}% is comfortable, no water needed now.`;
+  }
+  if (modulated) {
+    return `Watering ${final_s}s. Requested ${cand}s but ESP32 SAFE_LIMIT capped to ${final_s}s.`;
+  }
+  return `Watering ${final_s}s. Soil ${soil}%, tank ${tank}%, within safe envelope.`;
+}
+
+async function pollenCompileMock(transcript) {
+  await delay(1100 + Math.random() * 700); // simula inferencia E4B audio multimodal
+  const t = (transcript || "").toLowerCase();
+
+  // heuristicas mock — el real LLM hace mejor
+  let priority_plot = "A";
+  if (t.includes("parcela b") || t.includes("plot b")) priority_plot = "B";
+
+  let horizon_h = 72;
+  const m = t.match(/(\d+)\s*(h(oras)?|hour)/);
+  if (m) horizon_h = Number(m[1]);
+
+  let dry_threshold = 35;
+  if (t.includes("seca") || t.includes("menos") || t.includes("drier") || t.includes("less"))
+    dry_threshold = 25;
+
+  let budget_cap_ml = 1500;
+  if (t.includes("menos") || t.includes("less")) budget_cap_ml = 900;
+
+  // simula "confianza suficiente" (4 checks de Mini-Evaluator)
+  const tooShort = t.length < 6;
+  const noKeyword = !(t.match(/(rieg|wat|pollen|less|menos|seca|deposit|tank|parcel|plot)/i));
+  const confidence_ok = !tooShort && !noKeyword;
+
+  if (!confidence_ok) {
+    return {
+      action: "REFUSE_RETRY",
+      reason: "LLM_LOW_CONFIDENCE",
+      message_es: "No estoy seguro de cómo aplicar esto. ¿Puedes repetirlo o decirlo de otra forma?",
+      message_en: "I'm not sure how to apply this. Can you repeat or rephrase?",
+      transcript
+    };
+  }
+
+  return {
+    action: "APPLY_AS_IS",
+    reason: "STABLE_INTENT",
+    mission_patch: {
+      target_node_id: priority_plot === "A" ? "rhizome_01" : "rhizome_02",
+      priority_plot,
+      horizon_h,
+      soil_thresholds: { dry: dry_threshold },
+      budget_cap_ml,
+      operator_note: transcript || ""
+    },
+    rationale_es: `Compilé tu instrucción: prioridad parcela ${priority_plot}, próximas ${horizon_h}h, riego más conservador (umbral seco ${dry_threshold}%, tope ${budget_cap_ml}ml).`,
+    rationale_en: `Compiled your instruction: plot ${priority_plot} priority, next ${horizon_h}h, more conservative irrigation (dry threshold ${dry_threshold}%, cap ${budget_cap_ml}ml).`,
+    valid_until_h: 12
+  };
+}
+
+async function meristemEvaluateMock(bundle) {
+  await delay(1400 + Math.random() * 600); // simula tool calling chain
+  const decisions = bundle?.recent_decisions || [];
+  const blocks = decisions.filter(d => d.action === "block").length;
+  const conf = bundle?.avg_confidence ?? 0.85;
+
+  let mode = "stable";
+  let rationale_es = "Confirmo política activa: bundle limpio, alta confianza, sin alertas persistentes.";
+  let rationale_en = "Confirming active policy: clean bundle, high confidence, no persistent alerts.";
+
+  if (blocks >= 2) {
+    mode = "alert";
+    rationale_es = `Política en modo alerta: ${blocks} bloqueos consecutivos detectados, no es ruido.`;
+    rationale_en = `Policy in alert mode: ${blocks} consecutive blocks detected — not noise.`;
+  } else if (conf < 0.7) {
+    mode = "conservative";
+    rationale_es = "Política conservadora: confianza media baja en los receipts del bundle.";
+    rationale_en = "Conservative policy: average confidence in bundle receipts is low.";
+  }
+
+  return {
+    policy_id: "pol_" + Date.now().toString(36),
+    mode_default: mode,
+    soil_thresholds: { dry: mode === "conservative" ? 35 : 30 },
+    daily_budget_ml: mode === "alert" ? 600 : 1500,
+    valid_until_days: 7,
+    rationale_es,
+    rationale_en,
+    decisions_by_rule: {
+      stable: blocks === 0 ? 1 : 0,
+      alert: blocks >= 2 ? 1 : 0,
+      conservative: (blocks < 2 && conf < 0.7) ? 1 : 0,
+      refuse: 0
+    }
+  };
+}
+
+// ----------------------------------------------------------------
+// API pública usada por las páginas /try
+// ----------------------------------------------------------------
+
+window.SproutAPI = {
+  mode: SPROUT_API_MODE,
+
+  async rhizomeDecide(state) {
+    if (SPROUT_API_MODE === "mock") return rhizomeDecideMock(state);
+    return callGemmaLive(SPROUT_API_ENDPOINTS.rhizome_e2b, { type: "rhizome.decide", state });
+  },
+
+  async pollenCompile(transcript) {
+    if (SPROUT_API_MODE === "mock") return pollenCompileMock(transcript);
+    return callGemmaLive(SPROUT_API_ENDPOINTS.pollen_e4b, { type: "pollen.compile", transcript });
+  },
+
+  async meristemEvaluate(bundle) {
+    if (SPROUT_API_MODE === "mock") return meristemEvaluateMock(bundle);
+    return callGemmaLive(SPROUT_API_ENDPOINTS.meristem_e4b, { type: "meristem.evaluate", bundle });
+  }
+};

--- a/landing-demo/js/meristem-demo.js
+++ b/landing-demo/js/meristem-demo.js
@@ -1,0 +1,112 @@
+/* Sprout landing-demo · try/meristem — primera versión funcional */
+
+(function () {
+  const $ = id => document.getElementById(id);
+
+  const SCENARIOS = {
+    stable: {
+      r01: `scenario: stable
+last 7 days:
+  decisions: 28 irrigate, 4 skip, 0 block
+  avg confidence: 0.91
+  alerts persistent: 0
+weather_digest: ok`,
+      r02: `scenario: stable
+last 7 days:
+  decisions: 24 irrigate, 6 skip, 1 block
+  avg confidence: 0.88
+  alerts persistent: 0
+weather_digest: from_rhizome_01 (ferry by Pollen)`,
+      bundle: { recent_decisions: [{action:"block"}], avg_confidence: 0.90 }
+    },
+    alert: {
+      r01: `scenario: alert
+last 7 days:
+  decisions: 22 irrigate, 2 skip, 4 block (TANK_LOW)
+  avg confidence: 0.85
+  alerts persistent: 2
+weather_digest: ok`,
+      r02: `scenario: stable
+last 7 days:
+  decisions: 26 irrigate, 5 skip, 1 block
+  avg confidence: 0.86
+  alerts persistent: 0
+weather_digest: from_rhizome_01`,
+      bundle: { recent_decisions: [{action:"block"},{action:"block"},{action:"block"}], avg_confidence: 0.85 }
+    },
+    conservative: {
+      r01: `scenario: mixed
+last 7 days:
+  decisions: 25 irrigate, 4 skip, 1 block
+  avg confidence: 0.62
+  validation_stamps: 3 disputed
+weather_digest: contradictory readings`,
+      r02: `scenario: mixed
+last 7 days:
+  decisions: 22 irrigate, 5 skip, 0 block
+  avg confidence: 0.65
+  validation_stamps: 2 caution
+weather_digest: from_rhizome_01 (some receipts disputed)`,
+      bundle: { recent_decisions: [{action:"block"}], avg_confidence: 0.63 }
+    }
+  };
+
+  function applyScenario(name) {
+    const s = SCENARIOS[name];
+    if (!s) return;
+    $("r01").textContent = s.r01;
+    $("r02").textContent = s.r02;
+  }
+
+  $("scenario").addEventListener("change", e => applyScenario(e.target.value));
+
+  $("meristem-form").addEventListener("submit", async ev => {
+    ev.preventDefault();
+    const sName = $("scenario").value;
+    const s = SCENARIOS[sName];
+    if (!s) return;
+
+    const pipe = $("meristem-pipeline");
+    const out = $("policy-output");
+    const rules = $("rules-output");
+
+    out.textContent = "...";
+    rules.textContent = "evaluating...";
+    $("meristem-rationale-es").textContent = "";
+    $("meristem-rationale-en").textContent = "";
+
+    pipe.innerHTML = `<span class="status-pill warn">evaluating</span> Gemma 4 E4B + tool calling...`;
+
+    try {
+      const r = await window.SproutAPI.meristemEvaluate(s.bundle);
+
+      pipe.innerHTML = `<span class="status-pill ok">${r.mode_default.toUpperCase()}</span> policy emitted, valid for ${r.valid_until_days} days`;
+
+      out.textContent = JSON.stringify({
+        policy_id: r.policy_id,
+        mode_default: r.mode_default,
+        soil_thresholds: r.soil_thresholds,
+        daily_budget_ml: r.daily_budget_ml,
+        valid_until_days: r.valid_until_days,
+        policy_origin: "meristem-durable"
+      }, null, 2);
+
+      $("meristem-rationale-es").textContent = r.rationale_es;
+      $("meristem-rationale-en").textContent = r.rationale_en;
+
+      const dr = r.decisions_by_rule;
+      rules.textContent =
+        `stable:        ${dr.stable}
+alert:         ${dr.alert}
+conservative:  ${dr.conservative}
+refuse:        ${dr.refuse}
+
+(Sprout exposes this on /health — judges and farmers can see which rule
+fires most often. Not debug metadata; visible accountability.)`;
+    } catch (err) {
+      pipe.innerHTML = `<span class="status-pill alert">ERROR</span> ${err}`;
+      out.textContent = String(err);
+    }
+  });
+
+})();

--- a/landing-demo/js/pollen-demo.js
+++ b/landing-demo/js/pollen-demo.js
@@ -1,0 +1,71 @@
+/* Sprout landing-demo · try/pollen — primera versión funcional */
+
+(function () {
+  const $ = id => document.getElementById(id);
+  const ta = $("transcript");
+  const pipe = $("pollen-pipeline");
+  const out = $("patch-output");
+
+  const SAMPLES = {
+    "es-clear": "Vuelvo el viernes. Esta planta aguanta más seca de lo que crees, riega un poco menos.",
+    "en-clear": "I'll be back Friday. Plot B takes drier than you think — water it a bit less.",
+    "ambiguous": "uhm pues yo qué sé"
+  };
+
+  document.querySelectorAll("[data-sample]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      ta.value = SAMPLES[btn.dataset.sample] || "";
+      ta.focus();
+    });
+  });
+
+  async function pipelineStep(label, ms) {
+    pipe.textContent = `pollen: ${label}`;
+    return new Promise(r => setTimeout(r, ms));
+  }
+
+  $("pollen-form").addEventListener("submit", async ev => {
+    ev.preventDefault();
+    const transcript = ta.value.trim();
+
+    out.textContent = "...";
+    $("pollen-rationale-es").textContent = "";
+    $("pollen-rationale-en").textContent = "";
+
+    await pipelineStep("listening...", 350);
+    await pipelineStep("compiling (Gemma 4 E4B)...", 500);
+    await pipelineStep("validating schema + hard limits...", 350);
+
+    try {
+      const r = await window.SproutAPI.pollenCompile(transcript);
+
+      if (r.action === "REFUSE_RETRY") {
+        pipe.innerHTML = `<span class="status-pill alert">REFUSE_RETRY</span> ${r.reason}`;
+        out.textContent = JSON.stringify({
+          action: r.action,
+          reason: r.reason,
+          message_to_farmer: { es: r.message_es, en: r.message_en },
+          transcript
+        }, null, 2);
+        $("pollen-rationale-es").textContent = r.message_es;
+        $("pollen-rationale-en").textContent = r.message_en;
+        return;
+      }
+
+      pipe.innerHTML = `<span class="status-pill ok">${r.action}</span> ${r.reason} · sending to Rhizome...`;
+      out.textContent = JSON.stringify({
+        action: r.action,
+        reason: r.reason,
+        mission_patch: r.mission_patch,
+        valid_until_h: r.valid_until_h,
+        policy_origin: "pollen-visit"
+      }, null, 2);
+      $("pollen-rationale-es").textContent = r.rationale_es;
+      $("pollen-rationale-en").textContent = r.rationale_en;
+    } catch (err) {
+      pipe.innerHTML = `<span class="status-pill alert">ERROR</span> ${err}`;
+      out.textContent = String(err);
+    }
+  });
+
+})();

--- a/landing-demo/js/rhizome-demo.js
+++ b/landing-demo/js/rhizome-demo.js
@@ -1,0 +1,127 @@
+/* Sprout landing-demo · try/rhizome — primera versión funcional */
+
+(function () {
+  const PRESETS = {
+    dry: { soil_pct: 12, tank_pct: 70, heartbeat_age_s: 5 },
+    ok: { soil_pct: 60, tank_pct: 65, heartbeat_age_s: 8 },
+    tank_low: { soil_pct: 22, tank_pct: 14, heartbeat_age_s: 7 },
+    heartbeat_lost: { soil_pct: 28, tank_pct: 60, heartbeat_age_s: 45 },
+    modulated: { soil_pct: 8, tank_pct: 55, heartbeat_age_s: 6 }
+  };
+
+  const $ = id => document.getElementById(id);
+
+  function applyPreset(name) {
+    const p = PRESETS[name];
+    if (!p) return;
+    $("soil_pct").value = p.soil_pct;
+    $("tank_pct").value = p.tank_pct;
+    $("heartbeat_age_s").value = p.heartbeat_age_s;
+  }
+
+  $("preset").addEventListener("change", e => {
+    if (e.target.value) applyPreset(e.target.value);
+  });
+
+  $("rhizome-form").addEventListener("submit", async ev => {
+    ev.preventDefault();
+    const state = {
+      soil_pct: $("soil_pct").value,
+      tank_pct: $("tank_pct").value,
+      heartbeat_age_s: $("heartbeat_age_s").value
+    };
+
+    const receipt = $("receipt-output");
+    const status = $("receipt-status");
+    status.className = "status-pill warn";
+    status.textContent = "deciding...";
+    receipt.textContent = "Calling Rhizome (Gemma 4 E2B)...";
+    $("rationale-es").textContent = "";
+    $("rationale-en").textContent = "";
+
+    try {
+      const r = await window.SproutAPI.rhizomeDecide(state);
+      receipt.textContent = JSON.stringify({
+        decision_id: r.decision_id,
+        action: r.action,
+        reason: r.reason,
+        candidate_action: r.candidate_action,
+        final_action: r.final_action,
+        modulated: r.modulated,
+        issued_at: r.issued_at,
+        valid_until_minutes: r.valid_until_minutes
+      }, null, 2);
+
+      $("rationale-es").textContent = r.rationale_es;
+      $("rationale-en").textContent = r.rationale_en;
+
+      if (r.action === "block") { status.className = "status-pill alert"; status.textContent = "BLOCK"; }
+      else if (r.action === "skip") { status.className = "status-pill warn"; status.textContent = "SKIP"; }
+      else if (r.modulated) { status.className = "status-pill warn"; status.textContent = "ESP32 SAFE_LIMIT"; }
+      else { status.className = "status-pill ok"; status.textContent = "IRRIGATE"; }
+    } catch (err) {
+      status.className = "status-pill alert";
+      status.textContent = "error";
+      receipt.textContent = String(err);
+    }
+  });
+
+  // ----------------- Live log -----------------
+
+  const log = $("log-area");
+  let logTimer = null;
+  let entries = [];
+
+  function logEntry(html) {
+    entries.push(html);
+    if (entries.length > 10) entries.shift();
+    log.innerHTML = entries.join("\n");
+    log.scrollTop = log.scrollHeight;
+  }
+
+  function ts() {
+    const d = new Date();
+    return d.toLocaleTimeString("en-GB");
+  }
+
+  async function tick() {
+    // genera estado pseudo-aleatorio
+    const state = {
+      soil_pct: Math.floor(8 + Math.random() * 60),
+      tank_pct: Math.floor(15 + Math.random() * 75),
+      heartbeat_age_s: Math.random() < 0.05 ? 50 : Math.floor(Math.random() * 15)
+    };
+    try {
+      const r = await window.SproutAPI.rhizomeDecide(state);
+      let cls, label;
+      if (r.action === "block") { cls = "ev-veto"; label = "VETO"; }
+      else if (r.modulated) { cls = "ev-veto"; label = "MODULATED"; }
+      else { cls = "ev-decision"; label = r.action.toUpperCase(); }
+
+      const line = `<span class="ts">[${ts()}]</span> <span class="${cls}">${label}</span> ` +
+        `soil=${state.soil_pct}% tank=${state.tank_pct}% ` +
+        `→ ${r.action} (${r.final_action.seconds}s) · ${r.reason}`;
+      logEntry(line);
+    } catch (e) {
+      logEntry(`<span class="ts">[${ts()}]</span> <span class="ev-veto">ERROR</span> ${e}`);
+    }
+  }
+
+  $("log-toggle").addEventListener("click", () => {
+    if (logTimer) {
+      clearInterval(logTimer);
+      logTimer = null;
+      $("log-toggle").textContent = "Start log";
+    } else {
+      tick();
+      logTimer = setInterval(tick, 2200);
+      $("log-toggle").textContent = "Stop log";
+    }
+  });
+
+  $("log-clear").addEventListener("click", () => {
+    entries = [];
+    log.innerHTML = "";
+  });
+
+})();

--- a/landing-demo/try/meristem.html
+++ b/landing-demo/try/meristem.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Try Meristem — Sprout</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+<header class="demo-header">
+  <div class="container">
+    <p class="breadcrumb"><a href="../index.html">← Sprout</a> · Try Meristem</p>
+    <h1>Meristem</h1>
+    <p class="muted">Slow brain · Gemma 4 E4B · llama.cpp · jurisdiction: days</p>
+
+    <div class="demo-disclaimer">
+      <strong>DEMO via API.</strong> The real Meristem runs on the farmer's home laptop with Gemma 4
+      E4B locally — no cloud roundtrip. We use the API in this demo so you can probe it from any
+      browser. The deterministic logic (the <em>Evaluator</em>: 4 rules with precedence + tool calling)
+      is identical to what runs offline.
+    </div>
+  </div>
+</header>
+
+<section class="container section">
+
+  <h2>Two simulated Rhizomes report in</h2>
+  <p>
+    Meristem receives <em>bundles</em> from Pollen at the end of the day — collected receipts, alerts,
+    weather digests from each Rhizome. Below: a synthetic dashboard with two plots reporting their
+    last 7 days. Choose a scenario and ask Meristem to evaluate.
+  </p>
+
+  <form class="demo-form" id="meristem-form">
+    <label for="scenario">Scenario</label>
+    <select id="scenario">
+      <option value="stable">Both plots stable, normal week</option>
+      <option value="alert">Plot A had repeated TANK_LOW blocks</option>
+      <option value="conservative">Mixed receipts with disputed observations</option>
+    </select>
+    <p class="hint">Each scenario triggers a different rule of the Evaluator (stable / alert / conservative).</p>
+
+    <p style="margin-top:16px;">
+      <button class="btn btn-primary" type="submit">Send bundles to Meristem</button>
+    </p>
+  </form>
+
+  <div class="demo-grid">
+    <div class="demo-panel">
+      <h3>rhizome_01 (with weather station)</h3>
+      <pre class="output-block" id="r01">scenario: stable
+last 7 days:
+  decisions: 28 irrigate, 4 skip, 0 block
+  avg confidence: 0.91
+  alerts persistent: 0
+weather_digest: ok</pre>
+    </div>
+    <div class="demo-panel">
+      <h3>rhizome_02 <span class="status-pill warn" style="font-size:10px;">simulated host-side</span></h3>
+      <pre class="output-block" id="r02">scenario: stable
+last 7 days:
+  decisions: 24 irrigate, 6 skip, 1 block
+  avg confidence: 0.88
+  alerts persistent: 0
+weather_digest: from_rhizome_01 (ferry by Pollen)</pre>
+    </div>
+  </div>
+
+  <h2 style="margin-top:48px;">Meristem says</h2>
+  <p id="meristem-pipeline" class="muted small" style="margin:0 0 12px;">idle</p>
+
+  <div class="demo-grid">
+    <div class="demo-panel">
+      <h3>PolicyPacket emitted</h3>
+      <pre class="output-block" id="policy-output">Awaiting bundle...</pre>
+    </div>
+    <div class="demo-panel">
+      <h3>Rationale (LLM)</h3>
+      <p style="font-size:13px; color:var(--muted); margin:0 0 8px;">
+        The deterministic Evaluator decides. Gemma 4 E4B writes the rationale via tool calling.
+      </p>
+      <p id="meristem-rationale-es" style="font-style:italic;"></p>
+      <p id="meristem-rationale-en" style="color:var(--ink-soft); font-size:14px;"></p>
+    </div>
+  </div>
+
+  <h2 style="margin-top:48px;"><code>decisions_by_rule</code> — traceability as product</h2>
+  <p>
+    The system exposes how often each rule of the Evaluator has fired in the last day.
+    This is not debugging metadata; it's <strong>visible accountability of the decision logic</strong>.
+    A judge or a farmer can see, at a glance, which rule fires most often and whether the system is
+    operating in stable, conservative or alert mode.
+  </p>
+  <pre class="output-block" id="rules-output">stable: —
+alert: —
+conservative: —
+refuse: —</pre>
+
+</section>
+
+<footer class="footer">
+  <div class="container">
+    <p>
+      <strong>Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.</strong>
+      This project is not affiliated with or endorsed by Google.
+    </p>
+    <p class="muted small">
+      Apache 2.0 · <a href="../index.html">back to overview</a> ·
+      <a href="https://github.com/zigiella/sprout">github.com/zigiella/sprout</a>
+    </p>
+  </div>
+</footer>
+
+<script src="../js/api.js"></script>
+<script src="../js/meristem-demo.js"></script>
+</body>
+</html>

--- a/landing-demo/try/pollen.html
+++ b/landing-demo/try/pollen.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Try Pollen — Sprout</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+<header class="demo-header">
+  <div class="container">
+    <p class="breadcrumb"><a href="../index.html">← Sprout</a> · Try Pollen <span class="beta-badge">BETA</span></p>
+    <h1>Pollen</h1>
+    <p class="muted">Mobile node · Gemma 4 E4B (multimodal audio) · LiteRT-LM · jurisdiction: visit TTL</p>
+
+    <div class="demo-disclaimer">
+      <strong>BETA — voice → policy.</strong> The real Pollen app on Android feeds raw <code>.wav</code>
+      audio directly to Gemma 4 E4B via LiteRT-LM, with no separate STT pipeline. In this browser demo
+      we accept text instead of audio (browsers can't ship an Android model). The compilation logic and
+      schema validation are the same as on the device. <strong>If the system can't translate with
+      enough confidence, it won't apply — it will tell you to rephrase.</strong>
+    </div>
+  </div>
+</header>
+
+<section class="container section">
+
+  <h2>The farmer speaks. Pollen compiles.</h2>
+  <p>
+    Imagine you're in the plot. Type what you would say to the farmer's phone — short, colloquial,
+    not a structured command. Pollen compiles your voice into a <code>MissionPatch</code> the
+    Rhizome can apply <em>immediately</em>. No round-trip to the cloud, no waiting until the farmer
+    is back home.
+  </p>
+
+  <form class="demo-form" id="pollen-form">
+    <label for="transcript">What you say to the phone</label>
+    <textarea id="transcript" placeholder="e.g. 'Vuelvo el viernes. Esta planta aguanta más seca de lo que crees, riega un poco menos.'">Vuelvo el viernes. Esta planta aguanta más seca de lo que crees, riega un poco menos.</textarea>
+    <p class="hint">Try a few. Try something nonsense too — Pollen should refuse with confidence.</p>
+
+    <div class="grid" style="grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top:12px;">
+      <button type="button" class="btn btn-ghost" data-sample="es-clear">ES · clear instruction</button>
+      <button type="button" class="btn btn-ghost" data-sample="en-clear">EN · clear instruction</button>
+      <button type="button" class="btn btn-ghost" data-sample="ambiguous">Ambiguous (refuse)</button>
+    </div>
+
+    <p style="margin-top:16px;">
+      <button class="btn btn-primary" type="submit">Compile</button>
+    </p>
+  </form>
+
+  <h3 style="margin-top:32px;">Pollen says</h3>
+  <div id="pollen-pipeline" class="muted small" style="margin:0 0 12px;">idle</div>
+
+  <div class="demo-grid">
+    <div class="demo-panel">
+      <h3>MissionPatch</h3>
+      <pre class="output-block" id="patch-output">Awaiting input...</pre>
+    </div>
+    <div class="demo-panel">
+      <h3>Rationale</h3>
+      <p id="pollen-rationale-es" style="font-style:italic;"></p>
+      <p id="pollen-rationale-en" style="color:var(--ink-soft); font-size:14px;"></p>
+    </div>
+  </div>
+
+  <h2 style="margin-top:48px;">How does Pollen know it understood?</h2>
+  <p>
+    Four checks, in order. If any fails, Pollen <strong>refuses</strong> and asks the farmer to
+    rephrase — it never applies a low-confidence translation.
+  </p>
+  <ol>
+    <li><strong>Schema validation</strong> — the JSON the LLM emits must match the <code>MissionPatch</code> schema.</li>
+    <li><strong>No conflict with hard limits</strong> — the proposed policy must not violate the firmware's safety envelope.</li>
+    <li><strong>Syntactic-semantic match</strong> — at least one keyword or number from the transcript must appear in the LLM's rationale or in the patch fields.</li>
+    <li><strong>Explicit model confidence</strong> — if LiteRT-LM exposes <code>logprobs</code>, the threshold is 0.7.</li>
+  </ol>
+  <p>
+    The full spec lives in <a href="https://github.com/zigiella/sprout/blob/main/bitacora/2026-05-05_spec-mini-evaluator-pollen-meristem-a-floema.md">spec-mini-evaluator-pollen</a>
+    (624 lines, 12 test cases, Meristem authored, day 20).
+  </p>
+
+</section>
+
+<footer class="footer">
+  <div class="container">
+    <p>
+      <strong>Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.</strong>
+      This project is not affiliated with or endorsed by Google.
+    </p>
+    <p class="muted small">
+      Apache 2.0 · <a href="../index.html">back to overview</a> ·
+      <a href="https://github.com/zigiella/sprout">github.com/zigiella/sprout</a>
+    </p>
+  </div>
+</footer>
+
+<script src="../js/api.js"></script>
+<script src="../js/pollen-demo.js"></script>
+</body>
+</html>

--- a/landing-demo/try/rhizome.html
+++ b/landing-demo/try/rhizome.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Try Rhizome — Sprout</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+<header class="demo-header">
+  <div class="container">
+    <p class="breadcrumb"><a href="../index.html">← Sprout</a> · Try Rhizome</p>
+    <h1>Rhizome <span class="status-pill ok">running</span></h1>
+    <p class="muted">Plot node · Gemma 4 E2B Q4_K_S · Jetson Orin Nano Super · jurisdiction: minutes</p>
+
+    <div class="demo-disclaimer">
+      <strong>DEMO via API.</strong> The real app runs Gemma 4 E2B fully local on Jetson with no
+      network dependency. We use the API in this demo so you can probe the system from any browser.
+      Latency on the live system in production is in the order of <code>1–2 s</code> for a simple
+      decision; the mock here adds variance (~1 s) on purpose.
+    </div>
+  </div>
+</header>
+
+<section class="container section">
+
+  <h2>Probe a decision</h2>
+  <p>
+    Set the local state of the plot and ask Rhizome to decide. The output includes the rationale
+    in Spanish (the real app's primary language for the Spanish-speaking farmer) and English.
+  </p>
+
+  <form class="demo-form" id="rhizome-form">
+    <div class="grid" style="grid-template-columns: 1fr 1fr; gap:16px;">
+      <label>
+        Soil moisture (%)
+        <input type="number" id="soil_pct" min="0" max="100" value="22">
+      </label>
+      <label>
+        Tank level (%)
+        <input type="number" id="tank_pct" min="0" max="100" value="65">
+      </label>
+      <label>
+        Jetson heartbeat age (s)
+        <input type="number" id="heartbeat_age_s" min="0" max="300" value="8">
+      </label>
+      <label>
+        Preset
+        <select id="preset">
+          <option value="">— custom —</option>
+          <option value="dry">Dry plot, ample tank</option>
+          <option value="ok">Comfortable plot</option>
+          <option value="tank_low">Tank below minimum</option>
+          <option value="heartbeat_lost">Heartbeat lost</option>
+          <option value="modulated">SAFE_LIMIT modulation case</option>
+        </select>
+      </label>
+    </div>
+    <p style="margin-top:16px;">
+      <button class="btn btn-primary" type="submit">Ask Rhizome</button>
+    </p>
+  </form>
+
+  <div class="demo-grid">
+    <div class="demo-panel">
+      <h3>Decision Receipt</h3>
+      <div id="receipt-status" class="status-pill idle">idle</div>
+      <pre class="output-block" id="receipt-output">Awaiting input...</pre>
+    </div>
+    <div class="demo-panel">
+      <h3>Rationale (LLM)</h3>
+      <p style="font-size:13px; color:var(--muted); margin:0 0 8px;">
+        The deterministic logic decides. Gemma 4 E2B only writes the rationale.
+      </p>
+      <p id="rationale-es" style="font-style:italic;"></p>
+      <p id="rationale-en" style="color:var(--ink-soft); font-size:14px;"></p>
+    </div>
+  </div>
+
+  <h2 style="margin-top:48px;">Live decision log (last 10)</h2>
+  <p>
+    A simulated stream of decisions Rhizome would emit over a 10-minute window in the field.
+    Click <em>Start log</em> to watch the system run autonomously. ESP32 SAFE_LIMIT events are highlighted.
+  </p>
+  <p>
+    <button class="btn btn-secondary" id="log-toggle">Start log</button>
+    <button class="btn btn-ghost" id="log-clear">Clear</button>
+  </p>
+  <div class="log-area" id="log-area"></div>
+
+</section>
+
+<footer class="footer">
+  <div class="container">
+    <p>
+      <strong>Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.</strong>
+      This project is not affiliated with or endorsed by Google.
+    </p>
+    <p class="muted small">
+      Apache 2.0 · <a href="../index.html">back to overview</a> ·
+      <a href="https://github.com/zigiella/sprout">github.com/zigiella/sprout</a>
+    </p>
+  </div>
+</footer>
+
+<script src="../js/api.js"></script>
+<script src="../js/rhizome-demo.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Estructura completa landing demo en landing-demo/ con index + 3 try (Rhizome/Pollen/Meristem) + CSS funcional + cliente API mock con TODO_API_SETUP placeholder para Modal/HF/CloudRun. Disclaimer 'DEMO via API real app runs local' + atribucion Gemma trademark en cada pagina. Pendiente: diseno final Venation (dias 22-25), API real (~2h setup), hosting demo.zigiella.com, integracion APK Floema cuando haya version visual.