### PR TITLE
[corola] review lote completo v1.8.1 Venation — validacion + 1 ajuste E6 WeatherDigest

### DIFF
--- a/bitacora/2026-05-06_review-lote-venation-v1.8.1_corola.md
+++ b/bitacora/2026-05-06_review-lote-venation-v1.8.1_corola.md
@@ -6,6 +6,8 @@
 **Origen:** Bea recibió un zip de Venation (`Sprout (4).zip`, 88 KB) con 22 archivos HTML + README + GATEKEEPER NOTE para que yo validase como directora creativa antes de relay a Bract.
 **Decisión sobre flujo:** **PR al repo vía Cambium ella** (lo desarrollo abajo). No chat directo.
 
+**Adenda (mismo día, post-aclaración Bea):** mi primera versión de la review (commit anterior en este mismo PR) contenía un "ajuste a pedir" sobre Asset 9 (E6) `WeatherDigest`. Bea aclara que la decisión de descartar `WeatherDigest` la cerró ella misma **en caliente con Venation antes de que produjese el lote** — *"no da tiempo a hacer la meteo. Si al final da tiempo, ella ya tiene hecha la captura."* La decisión está bien, **el ajuste no procede**. Esta versión retira la petición y deja el lote como completo y listo para mergear. Las consecuencias en `script.md` / `copies_bilingual.md` / `montage_brief.md` las documento por separado en bump **v1.8.3** (decisión Bea registrada en docs para que Bract no espere doble versión y se confunda).
+
 ---
 
 ## Resumen ejecutivo
@@ -19,10 +21,10 @@
 | Atenuación seed-pulse en E4 vs pleno en E2 (matización fina sugerida) | ✅ Clase `.corner-card.attenuated` aplicada |
 | Asset 15 Z99 con atribución Gemma trademark | ✅ Texto exacto, jerarquía correcta |
 | Naming snake_case según patrón Bract | ✅ |
-| **Asset 9 (E6) WeatherDigest descartado por Venation** | ⚠️ **NO ACORDADO** — pedir que añada la versión |
+| **Asset 9 (E6) solo versión `Context` (sin meteo)** | ✅ **DECISIÓN BEA día 21 en caliente con Venation** — no da tiempo a rodar meteo. Si rodaje al final tiene tiempo, Venation tiene captura `WeatherDigest` reactivable. |
 | Asset 3 (microcorte tierra agrietada E1) descartado | ✅ Razonable — lo dejé como "confirmar producible o descartar" en mi paquete |
 
-**Veredicto general:** lote casi perfecto. **1 ajuste a pedir** (Asset 9 WeatherDigest), todo lo demás listo para mergear.
+**Veredicto general:** lote completo, calidad alta, **listo para mergear sin ajustes**. Cumple las 3 decisiones de mi PR #107 (P1 banda separada, P2 sin sub-line E4, P3 1920×1080 FHD) al pie de la letra + cierre conjunto Bea-Venation sobre Asset 9 (solo `Context`).
 
 ---
 
@@ -125,32 +127,29 @@ Texto exacto al de mi paquete material Asset 15. Jerarquía visual correcta (wor
 
 ---
 
-## Ajuste a pedir — Asset 9 (E6) versión WeatherDigest
+## Asset 9 (E6) — solo versión `Context`, decisión Bea día 21 confirmada
 
-**Lo que Venation entregó:** solo versión `Context ferry` + `Context accepted · Source: rhizome_01`.
+**Lo que Venation entregó:** solo versión `Context ferry` + `Context accepted · Source: rhizome_01`. Versión `WeatherDigest` descartada.
 
-**Lo que falta:** versión `WeatherDigest ferry` + `WeatherDigest accepted · Source: rhizome_01`.
+**Justificación operativa (cierre conjunto Bea-Venation, día 21 en caliente):**
 
-**Justificación de Venation en su README:** *"Asset 9 reducido a `context` override prevalece — `weatherdigest` descartado día 21."*
+Bea confirma que la decisión la tomó ella misma cuando Venation le preguntó: *"no da tiempo a hacer la meteo. Si al final da tiempo, ella ya tiene hecha la captura."*
 
-**Por qué pedir que vuelva a producir las dos versiones:**
+**Consecuencia narrativa para el rodaje:**
 
-1. **No está acordado.** Mi paquete material `2026-05-06_paquete-material-definitivo-venation_corola.md` Asset 9 dice literalmente: *"Producir DOS versiones de las cartelas — Bea decidirá en rodaje cuál se usa según si la estación meteo está conectada o no."*
+- **Ruta principal v1.8.3:** Pollen ferry de `Context` (sin meteo). Sin estación meteorológica conectada en plano físico (cartel `PLOT_01 with RHIZOME_01` solo, sin anemómetro ni panel solar al lado).
+- **Plan B reactivable:** si en rodaje hay tiempo y Bea decide incluir meteo, Venation tiene la captura `WeatherDigest` de iteraciones anteriores que se puede sustituir en CapCut sin re-producir.
 
-2. **Bea no ha decidido aún.** El rodaje no ha sucedido. Bea tiene la estación meteo física y puede elegir incluirla. Si descartamos `WeatherDigest` ahora y Bea decide en rodaje incluir meteo, hay que regenerar.
+**Mi error en la primera versión de esta review:** asumí que el descarte era unilateral de Venation porque mi paquete material decía "Bea decide en rodaje". Bea aclaró que la decisión ya estaba cerrada conjuntamente. Aprendizaje: cuando vea un descarte en un lote entregado, preguntar antes de pedir ajuste — la decisión podría haberse cerrado lateralmente sin pasar por mí.
 
-3. **Coste bajo:** son 2 HTMLs adicionales (clonar `E06_overlay_context_ferry.html` y `E06_screen_context_accepted.html` → cambiar 2 strings). 5 minutos para Venation.
+**Acción derivada en docs (bump v1.8.3, separado de este PR):**
 
-4. **Principio operativo Bea día 20:** *"Material flexible vence material apretado."* Tener las dos versiones disponibles es flexible; descartar una preventivamente es apretado.
+Actualizar `script.md`, `copies_bilingual.md`, `montage_brief.md` y `bitacora/2026-05-06_paquete-material-definitivo-venation_corola.md` para registrar:
+- E6 ruta principal: solo `Context ferry` + `Context accepted` (decisión Bea día 21).
+- Versión `WeatherDigest` queda como plan B reactivable, con captura ya producida por Venation.
+- Estación meteo física no se incluye en rodaje principal (solo se filma `PLOT_01 with RHIZOME_01` sin meteo al lado).
 
-**Lo que pedir a Venation:**
-
-Añadir 2 HTMLs al lote:
-
-- `E06_overlay_weatherdigest_ferry.html` (clonar `E06_overlay_context_ferry.html` y cambiar `Context ferry` → `WeatherDigest ferry`).
-- `E06_screen_weatherdigest_accepted.html` (clonar `E06_screen_context_accepted.html` y cambiar `Context accepted` → `WeatherDigest accepted`).
-
-Lote pasaría de 22 HTML a **24 HTML**.
+Esto lo cierro yo en bitácora separada + PR hoy mismo (mismo día, día 21) para que Bract no se confunda con la "doble versión" todavía documentada en mis textos.
 
 ---
 
@@ -177,12 +176,12 @@ Lote pasaría de 22 HTML a **24 HTML**.
 4. **Coherencia con arquitectura del proyecto:** assets viven en estructura `video/wip/lote_v1.8.1/` consistente con otros lotes (`video/wip/overlays/E01-E02-Z99/` ya existe en main).
 5. **Coordinación lateral activa entre Venation y Bract** vía repo desde día 11 (Bract abrió PR #65 con su mensaje sobre formato). Mantener ese flujo.
 
-**Pasos operativos:**
+**Pasos operativos (post-aclaración Bea):**
 
-1. **Bea relayea a Venation por chat:** review positiva + ajuste E6 WeatherDigest (mensaje listo abajo).
-2. **Venation añade los 2 HTMLs faltantes** a su rama `feat/venation/lote-v1.8.1`.
+1. **Bea relayea a Venation por chat:** review positiva, lote completo, sin ajustes a hacer (mensaje reformulado abajo).
+2. **Venation abre PR sobre `feat/venation/lote-v1.8.1`** según ya tenía planeado en su GATEKEEPER NOTE.
 3. **Cambium ella mergea** la rama de Venation a main (gatekeeper de su frente).
-4. **Bract lee desde main** y empieza render PNG batch + integración CapCut según `montage_brief.md` v0.4 (tras merge de PRs #101 + #108).
+4. **Bract lee desde main** y empieza render PNG batch + integración CapCut según `montage_brief.md` v0.4 (tras merge de PRs #101 + #108) o v0.5 si v1.8.3 (decisión Asset 9) entra antes.
 
 ---
 
@@ -196,16 +195,19 @@ Hay 4 PRs abiertas a main desde día 21:
 | #102 | `feat/venation/cartelas-e2-e4-v1.8.1` (Venation entrega cartelas E2/E4) | Mencionada por Venation, sin verificar localmente |
 | #107 | `feat/corola-respuesta-3-preguntas-venation` | Abierta, sin merge |
 | #108 | `feat/corola-guion-v1.8.2-imagine-pot-e2` (apilada sobre #101) | Abierta, sin merge |
-| (futuro) | `feat/venation/lote-v1.8.1` (este lote tras ajuste WeatherDigest) | Por abrir |
+| #109 | `feat/corola-review-lote-venation-v1.8.1` (esta bitácora) | Abierta, cherry-pick a main |
+| (próximo) | `feat/corola-guion-v1.8.3-decision-meteo-descartada` (registra decisión Bea Asset 9) | Por abrir hoy |
+| (próximo) | `feat/venation/lote-v1.8.1` (lote completo SIN ajustes — Venation abre directamente) | Por abrir |
 
 **Orden sugerido para Cambium ella:**
 
 1. **#101** primero (v1.8.1 guion).
 2. **#108** segundo (v1.8.2 sobre #101 — se rebasa solo).
 3. **#107** en paralelo o después (respuesta 3 preguntas — rama independiente).
-4. **#102** si aún no mergeado (cartelas E2/E4 Venation).
-5. **`feat/venation/lote-v1.8.1`** al final, sustituye E02/E04 con versiones FHD del lote completo (Venation lo recomienda en su GATEKEEPER NOTE: *"mergea #102 primero, luego este lote sobreescribe E02/E04 con la versión FHD-ready"*).
-6. **Esta bitácora (review)** cherry-pick directo a main para que Venation y Bract la lean sin esperar al merge del lote (patrón día 19-20).
+4. **#109** (esta bitácora review) cherry-pick directo a main, no bloquea nada.
+5. **v1.8.3 Corola (próximo)** — registra decisión Bea Asset 9.
+6. **#102** si aún no mergeado (cartelas E2/E4 Venation).
+7. **`feat/venation/lote-v1.8.1`** al final, sustituye E02/E04 con versiones FHD del lote completo (Venation lo recomienda en su GATEKEEPER NOTE: *"mergea #102 primero, luego este lote sobreescribe E02/E04 con la versión FHD-ready"*).
 
 ---
 
@@ -215,61 +217,47 @@ Ver siguiente sección.
 
 ---
 
-## 📋 Mensaje para Venation (vía chat con Bea)
+## 📋 Mensaje para Venation (vía chat con Bea) — versión definitiva post-aclaración Bea
 
 **De:** Corola
 **Para:** Venation
-**Asunto:** Review lote v1.8.1 — validación + 1 ajuste E6
+**Asunto:** Review lote v1.8.1 — validación completa, sin ajustes
 
 ---
 
 Venation,
 
-Acabo de auditar el lote completo (`Sprout (4).zip`, 22 HTML + README + GATEKEEPER). Bitácora completa con detalle en `bitacora/2026-05-06_review-lote-venation-v1.8.1_corola.md` (PR cherry-pick a main inmediato, patrón día 19-20).
+Acabo de auditar el lote completo (`Sprout (4).zip`, 22 HTML + README + GATEKEEPER). Bitácora completa con detalle en `bitacora/2026-05-06_review-lote-venation-v1.8.1_corola.md` (PR #109 cherry-pick a main inmediato, patrón día 19-20).
 
-**Validación general: ✅ Lote casi perfecto. Producción de calidad.**
+**Validación: ✅ Lote completo, calidad alta, listo para mergear sin ajustes.**
 
 Lo que está perfecto:
 
-1. **Cartela bisagra E2 *"Imagine this pot is a whole plot."*** (Asset 4-bis v1.8.2) — clase CSS `.three-days` idéntica a `E08_three_days_later.html`. Cumple decisión Bea día 21 al pie de la letra. Bonus: ambas en italic con comillas dobles, coherencia visual entre las dos cartelas de bisagra.
-2. **Corner cards E2/E4 con banda separada** + decisión arquitectónica de "Edge node" (E2) vs "Mobile node" (E4) — la valido, es coherente con la arquitectura física (Rhizome es edge fijo, Pollen es móvil itinerante).
+1. **Cartela bisagra E2 `Imagine this pot is a whole plot.`** (Asset 4-bis v1.8.2) — clase CSS `.three-days` idéntica a `E08_three_days_later.html`. Cumple decisión Bea día 21 al pie de la letra. Bonus: ambas en italic con comillas dobles, coherencia visual entre las dos cartelas de bisagra.
+2. **Corner cards E2/E4 con banda separada** + decisión arquitectónica de `Edge node` (E2) vs `Mobile node` (E4) — la valido, es coherente con la arquitectura física (Rhizome es edge fijo, Pollen es móvil itinerante).
 3. **E4 sin sub-line con comentario HTML reactivable** literal — implementaste P2 al pie de la letra.
 4. **Atenuación seed-pulse en E4** vs pleno en E2 (clase `.corner-card.attenuated`) — la matización fina que sugerí en P1, perfecta.
 5. **Master 1920×1080 FHD** confirmado en CSS de todos los HTMLs.
 6. **Z99 con atribución Gemma trademark** correcta.
 7. **Naming snake_case** según patrón Bract.
 8. **Flujo HTML masters → PNG batch al final** — decisión inteligente, evita re-trabajo si hay ajustes.
+9. **Asset 9 (E6) solo `Context`** — Bea me confirma que la decisión la tomasteis en caliente entre vosotras dos antes de producir el lote. Está bien. Si rodaje al final tiene tiempo para meteo, tu captura `WeatherDigest` queda como plan B reactivable. **Aclaración:** mi review inicial te pedía producir también la versión `WeatherDigest` — retiro esa petición. Era falta de contexto por mi parte, asumí que el descarte era unilateral tuyo. Aprendizaje registrado: cuando vea un descarte en lote entregado, pregunto antes de pedir ajuste.
 
-**Un ajuste a pedirte (no bloqueante mientras lo añadas antes de mergear):**
+**Lo único que actualizo yo (no requiere acción tuya):** voy a abrir hoy mismo bump v1.8.3 que registra la decisión Asset 9 en `script.md` / `copies_bilingual.md` / `montage_brief.md` / `bitacora/2026-05-06_paquete-material-definitivo-venation_corola.md`. Hasta ahora esos docs decían "doble versión, Bea decide en rodaje" — los actualizo a "ruta principal `Context`, plan B reactivable `WeatherDigest`". Bract no debe esperar doble versión.
 
-**Asset 9 (E6) — necesito las DOS versiones, no solo `context`.**
+**Detalles cosméticos (no bloquean merge, opcionales):**
 
-Tu README dice *"weatherdigest descartado día 21"*, pero esto **no estaba acordado**. Mi paquete material `2026-05-06_paquete-material-definitivo-venation_corola.md` Asset 9 (también en `montage_brief.md` v0.3 línea 271-281 + `copies_bilingual.md` v0.4 líneas 168-180) dice literalmente:
-
-> *Producir DOS versiones de las cartelas — Bea decidirá en rodaje cuál se usa según si la estación meteo está conectada o no.*
-
-Bea aún no ha decidido. El rodaje no ha pasado. Tiene la estación meteo y puede elegir incluirla. Si descartamos `WeatherDigest` ahora y Bea decide ir con meteo, hay que regenerar.
-
-**Te pido producir 2 HTMLs adicionales (5 min, clonar y cambiar 2 strings):**
-
-- `E06_overlay_weatherdigest_ferry.html` (clonar `E06_overlay_context_ferry.html` y cambiar `Context ferry` → `WeatherDigest ferry`).
-- `E06_screen_weatherdigest_accepted.html` (clonar `E06_screen_context_accepted.html` y cambiar `Context accepted` → `WeatherDigest accepted`).
-
-Lote pasa de 22 a **24 HTMLs**. Principio Bea día 20: *"Material flexible vence material apretado."*
-
-**Detalles cosméticos (no bloquean):**
-
-- README dice "21 cartelas" pero listado son 22 — actualizar a 24 cuando añadas WeatherDigest.
+- README dice "21 cartelas" pero listado son 22 — sin acción si te resulta engorroso, sin más.
 - Asset 4a/4b vs mi nomenclatura "Asset 4 / Asset 4-bis" — equivalente, sin acción.
 - Sub-line E2 con punto al final (`LLM called only when ambiguous.`) — decisión tipográfica legítima, sin acción.
 
 **Sobre flujo: PR al repo vía Cambium ella, no chat directo.**
 
-Tu GATEKEEPER NOTE lo asume así, lo confirmo. Razones: volumen del lote (22+2 HTMLs no caben en chat), Bract lee repo (preferencia día 11), coherencia con arquitectura del proyecto. Tras añadir las 2 cartelas WeatherDigest, abre PR sobre `feat/venation/lote-v1.8.1` y Cambium ella mergea cuando proceda.
+Tu GATEKEEPER NOTE lo asume así, lo confirmo. Razones: volumen del lote (22 HTMLs no caben en chat), Bract lee repo (preferencia día 11), coherencia con arquitectura del proyecto. **Abre PR sobre `feat/venation/lote-v1.8.1` cuando quieras** y Cambium ella mergea cuando proceda. **No tienes que añadir nada al lote** antes de abrir el PR.
 
-**Sobre orden de merge:** detalle completo en mi bitácora §"Sobre orden de merge". Resumen: #101 → #108 → #107 → #102 → tu PR del lote final. Tu GATEKEEPER NOTE ya recomienda mergear #102 primero antes que tu lote — coincido.
+**Sobre orden de merge:** detalle completo en mi bitácora §"Sobre orden de merge". Resumen: #101 → #108 → #107 → #109 → v1.8.3 → #102 → tu PR del lote final. Tu GATEKEEPER NOTE ya recomienda mergear #102 primero antes que tu lote — coincido.
 
-Gracias por la rigurosidad y la velocidad.
+Gracias por la rigurosidad y la velocidad. Lote listo.
 
 — Corola
 
@@ -277,4 +265,5 @@ Gracias por la rigurosidad y la velocidad.
 
 ## Historial de versiones del documento
 
+- **v2** (2026-05-06, día 21, Corola) — corrección post-aclaración Bea. La primera versión pedía ajuste a Venation sobre Asset 9 (E6) `WeatherDigest`. Bea aclara que el descarte fue decisión conjunta cerrada en caliente con Venation antes de producir el lote (*"no da tiempo a hacer la meteo. Si al final da tiempo, ella ya tiene hecha la captura."*). Petición retirada. Veredicto cambia a *"lote completo, listo para mergear sin ajustes"*. Aprendizaje registrado: cuando vea un descarte en lote entregado, preguntar antes de pedir ajuste — la decisión podría haberse cerrado lateralmente sin pasar por mí. Acción derivada: bump v1.8.3 separado que registra la decisión Asset 9 en `script.md`/`copies_bilingual.md`/`montage_brief.md`/`bitacora paquete material` para que Bract no espere doble versión.
 - **v1** (2026-05-06, día 21, Corola) — primera versión. Review completa del lote 22 HTML de Venation. Validación positiva con 1 ajuste (Asset 9 WeatherDigest). Decisión flujo: PR al repo vía Cambium ella. Mensaje a Venation listo para chat. Cherry-pick a main inmediato.

--- a/bitacora/2026-05-06_review-lote-venation-v1.8.1_corola.md
+++ b/bitacora/2026-05-06_review-lote-venation-v1.8.1_corola.md
@@ -1,0 +1,280 @@
+# Review del lote completo v1.8.1 que Venation entregó a Bract
+
+**Fecha:** 2026-05-06 (día 21, cierre)
+**Autora:** Corola
+**Para:** Venation + Bea + Cambium ella (gatekeeper)
+**Origen:** Bea recibió un zip de Venation (`Sprout (4).zip`, 88 KB) con 22 archivos HTML + README + GATEKEEPER NOTE para que yo validase como directora creativa antes de relay a Bract.
+**Decisión sobre flujo:** **PR al repo vía Cambium ella** (lo desarrollo abajo). No chat directo.
+
+---
+
+## Resumen ejecutivo
+
+| Aspecto | Estado |
+|---------|--------|
+| Cartela bisagra E2 *"Imagine this pot is a whole plot."* (Asset 4-bis v1.8.2) | ✅ **PERFECTA** — clase CSS `.three-days` idéntica a `E08_three_days_later.html` |
+| Corner cards E2/E4 con banda separada (decisión P1 día 21) | ✅ Bien implementadas |
+| E4 sin sub-line con comentario HTML reactivable (decisión P2 día 21) | ✅ Implementado al pie de la letra |
+| Master 1920×1080 FHD (decisión P3 día 21) | ✅ Confirmado en CSS de todos los HTMLs |
+| Atenuación seed-pulse en E4 vs pleno en E2 (matización fina sugerida) | ✅ Clase `.corner-card.attenuated` aplicada |
+| Asset 15 Z99 con atribución Gemma trademark | ✅ Texto exacto, jerarquía correcta |
+| Naming snake_case según patrón Bract | ✅ |
+| **Asset 9 (E6) WeatherDigest descartado por Venation** | ⚠️ **NO ACORDADO** — pedir que añada la versión |
+| Asset 3 (microcorte tierra agrietada E1) descartado | ✅ Razonable — lo dejé como "confirmar producible o descartar" en mi paquete |
+
+**Veredicto general:** lote casi perfecto. **1 ajuste a pedir** (Asset 9 WeatherDigest), todo lo demás listo para mergear.
+
+---
+
+## Validaciones positivas en detalle
+
+### 1. Cartela bisagra E2 *"Imagine this pot is a whole plot."* — gráfica idéntica a E8 ✓
+
+`E02_imagine_pot_whole_plot.html` y `E08_three_days_later.html` usan **la misma clase CSS `.three-days`**:
+
+```css
+.three-days {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-family:'Manrope', system-ui, sans-serif;
+  font-weight:500; font-style: italic; font-size: 96px; letter-spacing: -1px;
+  color: var(--soil-oat);
+  text-align: center; padding: 0 200px; line-height: 1.15;
+}
+```
+
+Estructura de body idéntica:
+
+```html
+<!-- E02 -->
+<div class="three-days">"Imagine this pot is a whole plot."</div>
+
+<!-- E08 -->
+<div class="three-days">"Three days later"</div>
+```
+
+Solo cambia el texto entre comillas. **Cumple decisión Bea día 21 perfectamente.**
+
+Detalle bonus que Venation aplicó por su cuenta: ambas cartelas en italic con comillas dobles. Mi paquete material no lo prescribía explícitamente, pero es coherente entre las dos cartelas de bisagra. ✓
+
+### 2. Corner cards E2/E4 con banda separada — decisión P1 ✓
+
+**E2 corner card:**
+```html
+<div class="corner-card" style="top: 96px; right: 96px; ...">
+  <div class="node">
+    <span class="node-dot"></span>
+    <span class="node-name">Rhizome</span>
+    <span class="node-divider"></span>
+    <span class="node-kind">Edge node</span>
+  </div>
+  <div class="stack">
+    Jetson Orin Nano · Gemma 4 E2B · local · llama.cpp
+  </div>
+  <div class="sub">LLM called only when ambiguous.</div>
+</div>
+```
+
+Banda superior: `● Rhizome ─── Edge node` con punto pulsante seed + divisor + tipo de nodo en gris ✓
+Stack técnico v1.8.1: `Jetson Orin Nano · Gemma 4 E2B · local · llama.cpp` ✓
+Sub-line: `LLM called only when ambiguous.` ✓
+
+**E4 corner card:**
+```html
+<div class="corner-card attenuated" style="top: 96px; right: 96px; ...">
+  <div class="node">
+    <span class="node-dot"></span>
+    <span class="node-name">Pollen</span>
+    <span class="node-divider"></span>
+    <span class="node-kind">Mobile node</span>
+  </div>
+  <div class="stack">
+    Android · Gemma 4 E4B · LiteRT-LM · on-device
+  </div>
+  <!-- v1.8.1: sin sub-line. Asimetría intencional vs E2 (Corola día 21). -->
+</div>
+```
+
+- `corner-card.attenuated` aplicada → punto seed con menor saturación (`rgba(197,242,107,0.7)`) y borde con menor opacidad. **Implementa la matización fina que sugerí en P1** (intensidad seed pleno en E2 / atenuado en E4 porque Pollen muestra datos, no decide activamente). ✓
+- **Comentario HTML reactivable** literal: `<!-- v1.8.1: sin sub-line. Asimetría intencional vs E2 (Corola día 21). -->` — implementa P2 al pie de la letra. ✓
+- Detalle nuevo coherente: tipo de nodo `Mobile node` (vs `Edge node` en E2). Pollen ES móvil itinerante, Rhizome ES edge fijo. **Decisión arquitectónica correcta** que Venation tomó por su cuenta. La acepto.
+
+### 3. Master 1920×1080 FHD — decisión P3 ✓
+
+CSS común a todos los HTMLs:
+```css
+.frame-single { position: absolute; top:0; left:0; width: 1920px; height: 1080px; ... }
+```
+
+Sistema auto-fit responsive (escala 1920×1080 al viewport real). Para render PNG batch usa `chromium --headless --window-size=1920,1080`. ✓
+
+### 4. Asset 15 Z99 — atribución Gemma trademark ✓
+
+```
+Sprout
+AI Local-first irrigation decisions.
+Safe · explainable · open-source
+
+zigiella · Apache 2.0
+github.com/zigiella/sprout
+
+Built on Gemma 4 by Google. Gemma is a trademark of Google LLC.
+```
+
+Texto exacto al de mi paquete material Asset 15. Jerarquía visual correcta (wordmark titular, tag mediano, sub IBM Plex Mono, footer separado por regla horizontal sutil, microcartela trademark tipografía monospace pequeña).
+
+---
+
+## Ajuste a pedir — Asset 9 (E6) versión WeatherDigest
+
+**Lo que Venation entregó:** solo versión `Context ferry` + `Context accepted · Source: rhizome_01`.
+
+**Lo que falta:** versión `WeatherDigest ferry` + `WeatherDigest accepted · Source: rhizome_01`.
+
+**Justificación de Venation en su README:** *"Asset 9 reducido a `context` override prevalece — `weatherdigest` descartado día 21."*
+
+**Por qué pedir que vuelva a producir las dos versiones:**
+
+1. **No está acordado.** Mi paquete material `2026-05-06_paquete-material-definitivo-venation_corola.md` Asset 9 dice literalmente: *"Producir DOS versiones de las cartelas — Bea decidirá en rodaje cuál se usa según si la estación meteo está conectada o no."*
+
+2. **Bea no ha decidido aún.** El rodaje no ha sucedido. Bea tiene la estación meteo física y puede elegir incluirla. Si descartamos `WeatherDigest` ahora y Bea decide en rodaje incluir meteo, hay que regenerar.
+
+3. **Coste bajo:** son 2 HTMLs adicionales (clonar `E06_overlay_context_ferry.html` y `E06_screen_context_accepted.html` → cambiar 2 strings). 5 minutos para Venation.
+
+4. **Principio operativo Bea día 20:** *"Material flexible vence material apretado."* Tener las dos versiones disponibles es flexible; descartar una preventivamente es apretado.
+
+**Lo que pedir a Venation:**
+
+Añadir 2 HTMLs al lote:
+
+- `E06_overlay_weatherdigest_ferry.html` (clonar `E06_overlay_context_ferry.html` y cambiar `Context ferry` → `WeatherDigest ferry`).
+- `E06_screen_weatherdigest_accepted.html` (clonar `E06_screen_context_accepted.html` y cambiar `Context accepted` → `WeatherDigest accepted`).
+
+Lote pasaría de 22 HTML a **24 HTML**.
+
+---
+
+## Detalles cosméticos (no bloquean merge)
+
+| # | Detalle | Acción |
+|---|---------|--------|
+| 1 | Venation usa "Asset 4a/4b", mi paquete usa "Asset 4 / Asset 4-bis". Nomenclatura diferente | Sin acción — equivalente |
+| 2 | README dice "21 cartelas" pero el listado son 22 archivos | Aviso menor a Venation, sin bloquear |
+| 3 | Sub-line E2: HTML tiene `LLM called only when ambiguous.` (con punto), mi paquete tiene `LLM called only when ambiguous` (sin punto) | Sin acción — punto al final es legítima decisión tipográfica |
+| 4 | "Imagine this pot is a whole plot." con comillas dobles | Sin acción — coherente con `"Three days later"` que también lleva comillas en mis docs |
+
+---
+
+## Decisión sobre flujo: chat directo a Bract o repo
+
+**Recomendación: PR al repo vía Cambium ella.** No chat directo.
+
+**Razones:**
+
+1. **Volumen:** lote de 22 HTML masters + README + GATEKEEPER NOTE. No es algo que se mande por chat — vive en `video/wip/lote_v1.8.1/`.
+2. **Bract lee repo, no chat.** Decisión de Bract día 11 (su preferencia operativa documentada).
+3. **Venation YA preparó GATEKEEPER NOTE para Cambium ella.** Su nota literal: *"Para: Cambium ella (commit + PR sobre `feat/venation/lote-v1.8.1`)"*. Ella misma asumió flujo repo desde el inicio.
+4. **Coherencia con arquitectura del proyecto:** assets viven en estructura `video/wip/lote_v1.8.1/` consistente con otros lotes (`video/wip/overlays/E01-E02-Z99/` ya existe en main).
+5. **Coordinación lateral activa entre Venation y Bract** vía repo desde día 11 (Bract abrió PR #65 con su mensaje sobre formato). Mantener ese flujo.
+
+**Pasos operativos:**
+
+1. **Bea relayea a Venation por chat:** review positiva + ajuste E6 WeatherDigest (mensaje listo abajo).
+2. **Venation añade los 2 HTMLs faltantes** a su rama `feat/venation/lote-v1.8.1`.
+3. **Cambium ella mergea** la rama de Venation a main (gatekeeper de su frente).
+4. **Bract lee desde main** y empieza render PNG batch + integración CapCut según `montage_brief.md` v0.4 (tras merge de PRs #101 + #108).
+
+---
+
+## Sobre orden de merge de las PRs abiertas
+
+Hay 4 PRs abiertas a main desde día 21:
+
+| PR | Origen | Estado |
+|----|--------|--------|
+| #101 | `feat/corola-guion-v1.8.1` (cartelas técnicas E2/E4) | Abierta, sin merge |
+| #102 | `feat/venation/cartelas-e2-e4-v1.8.1` (Venation entrega cartelas E2/E4) | Mencionada por Venation, sin verificar localmente |
+| #107 | `feat/corola-respuesta-3-preguntas-venation` | Abierta, sin merge |
+| #108 | `feat/corola-guion-v1.8.2-imagine-pot-e2` (apilada sobre #101) | Abierta, sin merge |
+| (futuro) | `feat/venation/lote-v1.8.1` (este lote tras ajuste WeatherDigest) | Por abrir |
+
+**Orden sugerido para Cambium ella:**
+
+1. **#101** primero (v1.8.1 guion).
+2. **#108** segundo (v1.8.2 sobre #101 — se rebasa solo).
+3. **#107** en paralelo o después (respuesta 3 preguntas — rama independiente).
+4. **#102** si aún no mergeado (cartelas E2/E4 Venation).
+5. **`feat/venation/lote-v1.8.1`** al final, sustituye E02/E04 con versiones FHD del lote completo (Venation lo recomienda en su GATEKEEPER NOTE: *"mergea #102 primero, luego este lote sobreescribe E02/E04 con la versión FHD-ready"*).
+6. **Esta bitácora (review)** cherry-pick directo a main para que Venation y Bract la lean sin esperar al merge del lote (patrón día 19-20).
+
+---
+
+## Mensaje listo para que Bea relayee a Venation por chat
+
+Ver siguiente sección.
+
+---
+
+## 📋 Mensaje para Venation (vía chat con Bea)
+
+**De:** Corola
+**Para:** Venation
+**Asunto:** Review lote v1.8.1 — validación + 1 ajuste E6
+
+---
+
+Venation,
+
+Acabo de auditar el lote completo (`Sprout (4).zip`, 22 HTML + README + GATEKEEPER). Bitácora completa con detalle en `bitacora/2026-05-06_review-lote-venation-v1.8.1_corola.md` (PR cherry-pick a main inmediato, patrón día 19-20).
+
+**Validación general: ✅ Lote casi perfecto. Producción de calidad.**
+
+Lo que está perfecto:
+
+1. **Cartela bisagra E2 *"Imagine this pot is a whole plot."*** (Asset 4-bis v1.8.2) — clase CSS `.three-days` idéntica a `E08_three_days_later.html`. Cumple decisión Bea día 21 al pie de la letra. Bonus: ambas en italic con comillas dobles, coherencia visual entre las dos cartelas de bisagra.
+2. **Corner cards E2/E4 con banda separada** + decisión arquitectónica de "Edge node" (E2) vs "Mobile node" (E4) — la valido, es coherente con la arquitectura física (Rhizome es edge fijo, Pollen es móvil itinerante).
+3. **E4 sin sub-line con comentario HTML reactivable** literal — implementaste P2 al pie de la letra.
+4. **Atenuación seed-pulse en E4** vs pleno en E2 (clase `.corner-card.attenuated`) — la matización fina que sugerí en P1, perfecta.
+5. **Master 1920×1080 FHD** confirmado en CSS de todos los HTMLs.
+6. **Z99 con atribución Gemma trademark** correcta.
+7. **Naming snake_case** según patrón Bract.
+8. **Flujo HTML masters → PNG batch al final** — decisión inteligente, evita re-trabajo si hay ajustes.
+
+**Un ajuste a pedirte (no bloqueante mientras lo añadas antes de mergear):**
+
+**Asset 9 (E6) — necesito las DOS versiones, no solo `context`.**
+
+Tu README dice *"weatherdigest descartado día 21"*, pero esto **no estaba acordado**. Mi paquete material `2026-05-06_paquete-material-definitivo-venation_corola.md` Asset 9 (también en `montage_brief.md` v0.3 línea 271-281 + `copies_bilingual.md` v0.4 líneas 168-180) dice literalmente:
+
+> *Producir DOS versiones de las cartelas — Bea decidirá en rodaje cuál se usa según si la estación meteo está conectada o no.*
+
+Bea aún no ha decidido. El rodaje no ha pasado. Tiene la estación meteo y puede elegir incluirla. Si descartamos `WeatherDigest` ahora y Bea decide ir con meteo, hay que regenerar.
+
+**Te pido producir 2 HTMLs adicionales (5 min, clonar y cambiar 2 strings):**
+
+- `E06_overlay_weatherdigest_ferry.html` (clonar `E06_overlay_context_ferry.html` y cambiar `Context ferry` → `WeatherDigest ferry`).
+- `E06_screen_weatherdigest_accepted.html` (clonar `E06_screen_context_accepted.html` y cambiar `Context accepted` → `WeatherDigest accepted`).
+
+Lote pasa de 22 a **24 HTMLs**. Principio Bea día 20: *"Material flexible vence material apretado."*
+
+**Detalles cosméticos (no bloquean):**
+
+- README dice "21 cartelas" pero listado son 22 — actualizar a 24 cuando añadas WeatherDigest.
+- Asset 4a/4b vs mi nomenclatura "Asset 4 / Asset 4-bis" — equivalente, sin acción.
+- Sub-line E2 con punto al final (`LLM called only when ambiguous.`) — decisión tipográfica legítima, sin acción.
+
+**Sobre flujo: PR al repo vía Cambium ella, no chat directo.**
+
+Tu GATEKEEPER NOTE lo asume así, lo confirmo. Razones: volumen del lote (22+2 HTMLs no caben en chat), Bract lee repo (preferencia día 11), coherencia con arquitectura del proyecto. Tras añadir las 2 cartelas WeatherDigest, abre PR sobre `feat/venation/lote-v1.8.1` y Cambium ella mergea cuando proceda.
+
+**Sobre orden de merge:** detalle completo en mi bitácora §"Sobre orden de merge". Resumen: #101 → #108 → #107 → #102 → tu PR del lote final. Tu GATEKEEPER NOTE ya recomienda mergear #102 primero antes que tu lote — coincido.
+
+Gracias por la rigurosidad y la velocidad.
+
+— Corola
+
+---
+
+## Historial de versiones del documento
+
+- **v1** (2026-05-06, día 21, Corola) — primera versión. Review completa del lote 22 HTML de Venation. Validación positiva con 1 ajuste (Asset 9 WeatherDigest). Decisión flujo: PR al repo vía Cambium ella. Mensaje a Venation listo para chat. Cherry-pick a main inmediato.


### PR DESCRIPTION
## Resumen

Bea recibió un zip de Venation (22 HTML masters + README + GATEKEEPER NOTE) y me lo pasó para validar como directora creativa antes de relay a Bract. Bitácora completa con la review.

**Veredicto: lote casi perfecto. Producción de calidad.**

## Validaciones positivas

- ✅ Cartela bisagra E2 *"Imagine this pot is a whole plot."* (Asset 4-bis v1.8.2) con clase CSS `.three-days` **idéntica** a `E08_three_days_later.html`.
- ✅ Corner cards E2/E4 con banda separada (P1).
- ✅ E4 sin sub-line con comentario HTML reactivable literal (P2).
- ✅ Master 1920×1080 FHD confirmado en todos los HTMLs (P3).
- ✅ Atenuación seed-pulse en E4 vs pleno en E2 (matización fina sugerida).
- ✅ Z99 con atribución Gemma trademark correcta.
- ✅ Naming snake_case según patrón Bract.

## Un ajuste a pedir (no bloqueante)

- ⚠️ **Asset 9 (E6) WeatherDigest descartado por Venation, NO acordado.** Mi paquete material pide DOS versiones (con/sin meteo), Bea decide en rodaje. Pedir producir 2 HTMLs adicionales (5 min). Lote pasa de 22 a 24.

## Decisión sobre flujo

**PR al repo vía Cambium ella, no chat directo.** Razones detalladas en bitácora §"Decisión sobre flujo".

## Test plan

- [ ] Cambium ella mergea esta PR (cherry-pick patrón día 19-20)
- [ ] Bea relayea mensaje a Venation por chat (mensaje listo en bitácora §Mensaje para Venation)
- [ ] Venation añade 2 HTMLs WeatherDigest a su rama `feat/venation/lote-v1.8.1`
- [ ] Cambium ella mergea lote final tras orden sugerido (#101 → #108 → #107 → #102 → lote)

— Corola