### PR TITLE
feat(meristem-node): sub-PR aditivo policy_origin/scope (forward-compat feature beta voz)

### DIFF
--- a/code/meristem_node/src/main.py
+++ b/code/meristem_node/src/main.py
@@ -172,6 +172,7 @@ def _build_app() -> FastAPI:
             "bundles_received_total": persistence.count_bundles(),
             "policies_emitted_total": persistence.count_policies(),
             "decisions_by_rule": persistence.count_decisions_by_rule(),
+            "policies_by_scope": persistence.count_policies_by_scope(),
             "targets_known": persistence.list_known_targets(),
             "pollen_connection": pollen_manager.state_snapshot(),
             "ws_events_by_type": persistence.count_ws_events_by_event(),

--- a/code/meristem_node/src/persistence.py
+++ b/code/meristem_node/src/persistence.py
@@ -66,11 +66,19 @@ CREATE TABLE IF NOT EXISTS policies (
     emitted_at TEXT NOT NULL,
     target_node_id TEXT NOT NULL,
     raw_json TEXT NOT NULL,
-    evidence_refs TEXT NOT NULL  -- JSON list of bundle_ids
+    evidence_refs TEXT NOT NULL,  -- JSON list of bundle_ids
+    -- Sub-PR aditivo dia 23 (forward-compat con feature beta voz->politica):
+    policy_origin TEXT NOT NULL DEFAULT 'meristem-durable',
+    policy_scope TEXT NOT NULL DEFAULT 'durable'
 );
 
 CREATE INDEX IF NOT EXISTS idx_policies_target
     ON policies(target_node_id, emitted_at DESC);
+
+-- NOTA: indice idx_policies_target_scope se crea en _run_migrations
+-- porque referencia a policy_scope, columna añadida en sub-PR día 23.
+-- El executescript del SCHEMA falla si la columna aún no existe en BBDDs
+-- antiguas; la migración aditiva crea la columna primero y luego el índice.
 
 CREATE TABLE IF NOT EXISTS decisions (
     decision_id TEXT PRIMARY KEY,
@@ -105,10 +113,41 @@ CREATE INDEX IF NOT EXISTS idx_pollen_sync_log_trace
 
 
 def init_db(db_path: Path | str = DEFAULT_DB_PATH) -> None:
-    """Crea tablas e índices si no existen. Idempotente."""
+    """Crea tablas e índices si no existen. Idempotente.
+
+    Ejecuta también migraciones aditivas para BBDDs anteriores al
+    sub-PR de día 23 (policy_origin / policy_scope columns).
+    """
     db_path = Path(db_path)
     with sqlite3.connect(db_path) as con:
         con.executescript(SCHEMA)
+        _run_migrations(con)
+
+
+def _run_migrations(con: sqlite3.Connection) -> None:
+    """Migraciones aditivas idempotentes para BBDDs ya creadas.
+
+    Día 23: añade `policy_origin` y `policy_scope` a tabla `policies`
+    si todavía no existen (BBDDs creadas antes del sub-PR aditivo).
+    Defaults preservan retrocompatibilidad — policies antiguas se
+    interpretan como meristem-durable + durable.
+    """
+    cols = {row[1] for row in con.execute("PRAGMA table_info(policies)").fetchall()}
+    if "policy_origin" not in cols:
+        con.execute(
+            "ALTER TABLE policies ADD COLUMN policy_origin TEXT NOT NULL "
+            "DEFAULT 'meristem-durable'"
+        )
+    if "policy_scope" not in cols:
+        con.execute(
+            "ALTER TABLE policies ADD COLUMN policy_scope TEXT NOT NULL "
+            "DEFAULT 'durable'"
+        )
+    # Indice puede crearse de forma idempotente independientemente.
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_policies_target_scope "
+        "ON policies(target_node_id, policy_scope, emitted_at DESC)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -174,8 +213,9 @@ def insert_policy(
         con.execute(
             """
             INSERT OR REPLACE INTO policies
-            (policy_id, emitted_at, target_node_id, raw_json, evidence_refs)
-            VALUES (?, ?, ?, ?, ?)
+            (policy_id, emitted_at, target_node_id, raw_json, evidence_refs,
+             policy_origin, policy_scope)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 record.policy_id,
@@ -183,6 +223,8 @@ def insert_policy(
                 record.target_node_id,
                 record.raw_json,
                 json.dumps(record.evidence_refs),
+                policy.policy_origin,
+                policy.policy_scope,
             ),
         )
     return record
@@ -297,6 +339,23 @@ def count_decisions_by_rule(
     return {r["rule_applied"]: int(r["c"]) for r in rows}
 
 
+def count_policies_by_scope(
+    db_path: Path | str = DEFAULT_DB_PATH,
+) -> dict[str, int]:
+    """Para `/health` y demo: distribución de policies por scope.
+
+    Sub-PR aditivo día 23. Cuando la feature beta voz→política
+    (Mini-Evaluator Pollen, PR #92) entregue policies transitorias,
+    este desglose visibiliza el reparto durable vs transient en demo
+    y writeup.
+    """
+    with _connect(db_path) as con:
+        rows = con.execute(
+            "SELECT policy_scope, COUNT(*) AS c FROM policies GROUP BY policy_scope"
+        ).fetchall()
+    return {r["policy_scope"]: int(r["c"]) for r in rows}
+
+
 # ---------------------------------------------------------------------------
 # Vista por target (para /status — demo MVP multi-Rhizome)
 # ---------------------------------------------------------------------------
@@ -353,16 +412,30 @@ def get_target_summary(
         bundles_received = int(bundle_row["c"])
         last_bundle_at = bundle_row["last_at"]
 
-        # 2. Policies count + última policy
+        # 2. Policies count + desglose por scope + última policy
         pol_count = con.execute(
             "SELECT COUNT(*) AS c FROM policies WHERE target_node_id = ?",
             (target_node_id,),
         ).fetchone()
         policies_emitted = int(pol_count["c"]) if pol_count else 0
 
+        # Desglose por scope (durable / transient) — sub-PR aditivo día 23
+        scope_rows = con.execute(
+            """
+            SELECT policy_scope, COUNT(*) AS c FROM policies
+            WHERE target_node_id = ?
+            GROUP BY policy_scope
+            """,
+            (target_node_id,),
+        ).fetchall()
+        scope_counts = {r["policy_scope"]: int(r["c"]) for r in scope_rows}
+        policies_durable_count = scope_counts.get("durable", 0)
+        policies_transient_count = scope_counts.get("transient", 0)
+
         latest_pol_row = con.execute(
             """
-            SELECT policy_id, emitted_at, raw_json FROM policies
+            SELECT policy_id, emitted_at, raw_json, policy_origin, policy_scope
+            FROM policies
             WHERE target_node_id = ?
             ORDER BY emitted_at DESC LIMIT 1
             """,
@@ -373,9 +446,13 @@ def get_target_summary(
         latest_policy_emitted_at = None
         latest_policy_mode = None
         latest_policy_valid_until = None
+        latest_policy_origin = None
+        latest_policy_scope = None
         if latest_pol_row:
             latest_policy_id = latest_pol_row["policy_id"]
             latest_policy_emitted_at = latest_pol_row["emitted_at"]
+            latest_policy_origin = latest_pol_row["policy_origin"]
+            latest_policy_scope = latest_pol_row["policy_scope"]
             try:
                 pkt = PolicyPacket.model_validate_json(latest_pol_row["raw_json"])
                 latest_policy_mode = pkt.mode_default
@@ -404,10 +481,14 @@ def get_target_summary(
         "bundles_received": bundles_received,
         "last_bundle_at": last_bundle_at,
         "policies_emitted": policies_emitted,
+        "policies_durable_count": policies_durable_count,
+        "policies_transient_count": policies_transient_count,
         "latest_policy_id": latest_policy_id,
         "latest_policy_emitted_at": latest_policy_emitted_at,
         "latest_policy_mode": latest_policy_mode,
         "latest_policy_valid_until": latest_policy_valid_until,
+        "latest_policy_origin": latest_policy_origin,
+        "latest_policy_scope": latest_policy_scope,
         "latest_reason_code": latest_reason_code,
         "latest_rule_applied": latest_rule_applied,
     }

--- a/code/meristem_node/src/schemas.py
+++ b/code/meristem_node/src/schemas.py
@@ -50,6 +50,8 @@ class Bundle(BaseModel):
 # ---------------------------------------------------------------------------
 
 ModeDefault = Literal["normal", "conservative", "alert"]
+PolicyOrigin = Literal["meristem-durable", "pollen-visit"]
+PolicyScope = Literal["durable", "transient"]
 
 
 class PolicyPacket(BaseModel):
@@ -58,6 +60,13 @@ class PolicyPacket(BaseModel):
     Día 15-16 se alinea exactamente con el schema Kotlin de
     `feat/pollen-f5-rhizome` (clase `PolicyPacket.kt`). Esto es
     placeholder para empezar a iterar.
+
+    Día 23 (sub-PR aditivo): añadidos `policy_origin` y `policy_scope`
+    opcionales para distinguir policies durables (Meristem) de las
+    transitorias (Pollen via visita) según spec Mini-Evaluator
+    (PR #92 mergeado). Defaults preservan retrocompatibilidad: bundles
+    antiguos sin estos campos siguen interpretándose como
+    meristem-durable + durable.
     """
 
     schema_version: str = "1.0"
@@ -68,6 +77,24 @@ class PolicyPacket(BaseModel):
     rules: dict[str, Any] = Field(default_factory=dict)
     rationale: str
     signature: str = "<placeholder-meristem-v0>"
+
+    # Forward-compat con feature beta voz→política (PR #92 spec):
+    policy_origin: PolicyOrigin = Field(
+        default="meristem-durable",
+        description=(
+            "Quién emitió esta policy. 'meristem-durable' es la durable "
+            "del slow brain doméstico. 'pollen-visit' es transitoria de "
+            "una visita Pollen con Mini-Evaluator (feature beta)."
+        ),
+    )
+    policy_scope: PolicyScope = Field(
+        default="durable",
+        description=(
+            "Alcance temporal. 'durable' = TTL ~7 días, autoridad "
+            "completa salvo hard limits. 'transient' = TTL ~12h, "
+            "autoridad limitada (alerta durable siempre gana)."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -202,16 +229,24 @@ class TargetStatus(BaseModel):
     Usado en el endpoint `GET /status`. Pensado para que la demo MVP
     muestre en una pantalla cómo Meristem está gestionando 2 Rhizomes
     simultáneos en el mismo hardware (rhizome_01 + rhizome_02).
+
+    Día 23: añadido desglose `policies_durable_count` +
+    `policies_transient_count` para visibilidad de la distribución
+    durable vs transitoria por target.
     """
 
     target_node_id: str
     bundles_received: int = 0
     last_bundle_at: datetime | None = None
     policies_emitted: int = 0
+    policies_durable_count: int = 0
+    policies_transient_count: int = 0
     latest_policy_id: str | None = None
     latest_policy_emitted_at: datetime | None = None
     latest_policy_mode: ModeDefault | None = None
     latest_policy_valid_until: datetime | None = None
+    latest_policy_origin: PolicyOrigin | None = None
+    latest_policy_scope: PolicyScope | None = None
     latest_reason_code: str | None = None
     latest_rule_applied: str | None = None
 

--- a/code/meristem_node/tests/test_policy_origin_scope.py
+++ b/code/meristem_node/tests/test_policy_origin_scope.py
@@ -1,0 +1,236 @@
+"""Tests del sub-PR aditivo día 23: policy_origin + policy_scope.
+
+Cubre:
+- Defaults retro-compatibles (PolicyPacket sin estos campos asume
+  meristem-durable + durable)
+- Persistencia con campos explícitos (policy_origin=pollen-visit,
+  policy_scope=transient)
+- Migración aditiva (BBDD vieja sin columnas → ALTER TABLE las añade
+  con default sin perder datos)
+- /health expone policies_by_scope con desglose
+- /status TargetStatus expone policies_durable_count +
+  policies_transient_count + latest_policy_origin/scope
+- get_target_summary correctamente
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Cliente con DB temporal aislada (mismo patrón que test_recent_endpoints)."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "test_meristem.db")
+    monkeypatch.setenv("MERISTEM_DB_PATH", db_path)
+    monkeypatch.setenv("MERISTEM_USE_LLM", "false")
+
+    for mod_name in list(sys.modules.keys()):
+        if mod_name == "src" or mod_name.startswith("src."):
+            del sys.modules[mod_name]
+
+    from src import persistence
+    from src.ws_manager import manager
+    from src import main as main_module
+
+    persistence.init_db(db_path)
+
+    manager._websocket = None
+    manager._pollen_id = None
+    manager._app_version = None
+    manager._connected_at = None
+    manager._last_heartbeat = None
+
+    return TestClient(main_module.app)
+
+
+def _bundle_payload(target: str = "rhizome_test_01"):
+    """Bundle limpio que dispara CONFIRM_POLICY."""
+    return {
+        "source_pollen_id": "pollen_test",
+        "target_rhizome_id": target,
+        "active_policy_id": "pkt_test_baseline",
+        "rhizome_snapshot": {
+            "snapshot_id": "snap_test_01",
+            "mode": "normal",
+            "alert_latched": False,
+            "pending_contradictions": [],
+            "soil_a_pct": 35,
+            "soil_b_pct": 42,
+            "tank_pct": 78,
+        },
+        "decision_receipts": [
+            {"action": "WATER_A", "duration_s": 18, "confidence": 0.92},
+        ],
+        "weather_digest": {"isStale": False, "summary": "test"},
+        "validation_stamps": [],
+    }
+
+
+def test_policy_packet_defaults_retrocompat():
+    """PolicyPacket sin policy_origin/scope explícitos asume defaults."""
+    from src.schemas import PolicyPacket
+    p = PolicyPacket(
+        policy_id="pkt_test_X",
+        target_node_id="rhizome_test",
+        valid_until=datetime.now() + timedelta(days=7),
+        rationale="test",
+    )
+    assert p.policy_origin == "meristem-durable"
+    assert p.policy_scope == "durable"
+
+
+def test_policy_packet_explicit_fields():
+    """PolicyPacket con campos explícitos los preserva."""
+    from src.schemas import PolicyPacket
+    p = PolicyPacket(
+        policy_id="pkt_test_Y",
+        target_node_id="rhizome_test",
+        valid_until=datetime.now() + timedelta(hours=12),
+        rationale="test transient",
+        policy_origin="pollen-visit",
+        policy_scope="transient",
+    )
+    assert p.policy_origin == "pollen-visit"
+    assert p.policy_scope == "transient"
+
+
+def test_persist_policy_with_default_fields(client):
+    """Tras POST /visit, la policy se persiste con defaults durable."""
+    r = client.post("/visit", json=_bundle_payload(target="rhizome_dur"))
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+    # Health debe mostrar policies_by_scope con durable >= 1
+    r = client.get("/health")
+    body = r.json()
+    assert body["policies_by_scope"].get("durable", 0) >= 1
+    assert body["policies_by_scope"].get("transient", 0) == 0
+
+
+def test_target_status_includes_scope_breakdown(client):
+    """TargetStatus expone policies_durable_count + policies_transient_count."""
+    r = client.post("/visit", json=_bundle_payload(target="rhizome_breakdown"))
+    assert r.status_code == 200
+
+    r = client.get("/status")
+    body = r.json()
+    assert len(body["targets"]) == 1
+    target = body["targets"][0]
+    assert target["target_node_id"] == "rhizome_breakdown"
+    assert target["policies_durable_count"] >= 1
+    assert target["policies_transient_count"] == 0
+    assert target["latest_policy_origin"] == "meristem-durable"
+    assert target["latest_policy_scope"] == "durable"
+
+
+def test_persist_policy_with_transient_scope_explicit():
+    """Inserción manual con scope=transient se persiste correctamente."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "test_transient.db")
+    os.environ["MERISTEM_DB_PATH"] = db_path
+
+    for mod_name in list(sys.modules.keys()):
+        if mod_name == "src" or mod_name.startswith("src."):
+            del sys.modules[mod_name]
+
+    from src import persistence
+    from src.schemas import PolicyPacket
+
+    persistence.init_db(db_path)
+
+    pol = PolicyPacket(
+        policy_id="pkt_transient_Z",
+        target_node_id="rhizome_transient",
+        valid_until=datetime.now() + timedelta(hours=12),
+        rationale="visita Pollen via Mini-Evaluator",
+        policy_origin="pollen-visit",
+        policy_scope="transient",
+    )
+    persistence.insert_policy(pol, evidence_refs=["b_test_1"])
+
+    counts = persistence.count_policies_by_scope()
+    assert counts.get("transient", 0) == 1
+    assert counts.get("durable", 0) == 0
+
+
+def test_migration_old_db_alter_table_aditive():
+    """BBDD vieja sin columnas → init_db las añade con defaults."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "test_oldschema.db")
+
+    # Crear BBDD con schema antiguo (sin policy_origin/scope) manualmente
+    con = sqlite3.connect(db_path)
+    con.executescript("""
+        CREATE TABLE policies (
+            policy_id TEXT PRIMARY KEY,
+            emitted_at TEXT NOT NULL,
+            target_node_id TEXT NOT NULL,
+            raw_json TEXT NOT NULL,
+            evidence_refs TEXT NOT NULL
+        );
+        CREATE TABLE bundles (
+            bundle_id TEXT PRIMARY KEY,
+            received_at TEXT NOT NULL,
+            source_pollen_id TEXT NOT NULL,
+            target_rhizome_id TEXT NOT NULL,
+            active_policy_id TEXT NOT NULL,
+            raw_json TEXT NOT NULL
+        );
+        CREATE TABLE decisions (
+            decision_id TEXT PRIMARY KEY,
+            bundle_id TEXT NOT NULL,
+            policy_id TEXT NOT NULL,
+            rule_applied TEXT NOT NULL,
+            reason_code TEXT NOT NULL,
+            llm_metrics TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+    """)
+    # Insertamos una policy antigua sin las columnas nuevas
+    con.execute(
+        "INSERT INTO policies (policy_id, emitted_at, target_node_id, raw_json, evidence_refs) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("pkt_old_X", datetime.now().isoformat(), "rhizome_old", '{"raw":"json"}', "[]"),
+    )
+    con.commit()
+    con.close()
+
+    # Ahora init_db ejecuta migración aditiva
+    os.environ["MERISTEM_DB_PATH"] = db_path
+    for mod_name in list(sys.modules.keys()):
+        if mod_name == "src" or mod_name.startswith("src."):
+            del sys.modules[mod_name]
+    from src import persistence
+    persistence.init_db(db_path)
+
+    # Verificar que las columnas existen y la policy antigua tiene defaults
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    row = con.execute("SELECT * FROM policies WHERE policy_id = 'pkt_old_X'").fetchone()
+    assert row["policy_origin"] == "meristem-durable"
+    assert row["policy_scope"] == "durable"
+    con.close()
+
+
+def test_health_exposes_policies_by_scope(client):
+    """/health incluye policies_by_scope (vacío al principio)."""
+    r = client.get("/health")
+    body = r.json()
+    assert "policies_by_scope" in body
+    assert body["policies_by_scope"] == {}
+
+    r = client.post("/visit", json=_bundle_payload())
+    assert r.status_code == 200
+
+    r = client.get("/health")
+    body = r.json()
+    assert body["policies_by_scope"].get("durable") == 1


### PR DESCRIPTION
Cambium dio go dia 23 al diseño documentado en spec Mini-Evaluator (PR #92 mergeado día 20, punto 5).

## Resumen

Cambios aditivos forward-compat para que el Evaluator no se rompa cuando lleguen bundles con policies aplicadas via Pollen (feature beta voz→política) en visita anterior. **Retrocompatibilidad TOTAL** vía defaults.

## Cambios

### Schemas (`schemas.py`)

- `PolicyPacket`: campos opcionales `policy_origin` (default `'meristem-durable'`) y `policy_scope` (default `'durable'`)
- `TargetStatus`: añadidos `policies_durable_count` + `policies_transient_count` + `latest_policy_origin` + `latest_policy_scope`

### Persistencia (`persistence.py`)

- Tabla `policies`: columnas nuevas con DEFAULT
- **Migración aditiva** `_run_migrations()`: ALTER TABLE idempotente para BBDDs antiguas. Si columnas ya existen, no-op. Crea índice `idx_policies_target_scope` después de garantizar columna.
- `insert_policy` persiste los nuevos campos
- `get_target_summary` devuelve desglose por scope
- Helper `count_policies_by_scope()` para `/health`

### Endpoints (`main.py`)

- `/health` expone `policies_by_scope` con desglose `{durable: N, transient: M}`
- `/status` TargetStatus extendido

## Tests

7 casos nuevos cubren:
- Defaults retrocompat
- Campos explícitos
- Persistencia con `scope='transient'`
- **Migración ALTER TABLE** sobre BBDD vieja con schema antiguo + policy preexistente (verificación que la policy antigua adquiere defaults sin pérdida de datos)
- `/health` y `/status` exponen el desglose

**36/36 PASS** suite completa (29 anteriores + 7 nuevos). Sin regresión.

## Smoke E2E PASS

- POST bundle M1 clean
- `/health`: `policies_by_scope = {'durable': 1}`
- `/status`: target durable=1 transient=0 origin=meristem-durable scope=durable

## Sin cambios al Evaluator

La regla `JURISDICTION_POLLEN` sigue rechazando bundles que pidan al Meristem aplicar cambios puntuales del operador. Coherente con código día 13 que predijo la separación de jurisdicciones (canelita writeup §3+§6).

## Test plan

- [x] Tests automatizados 36/36 PASS
- [x] Smoke E2E con bundle M1
- [x] Migración aditiva probada con BBDD antigua + policy preexistente
- [ ] Cuando Floema entregue Mini-Evaluator Kotlin: las policies via Pollen se persistirán con `scope='transient'` correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)