### PR TITLE
fix(rhizome): print mDNS host + network_info.sh (Endo dia 23)

### DIFF
--- a/bitacora/2026-05-08_endodermis-main-smoke-jetson-ip_endodermis.md
+++ b/bitacora/2026-05-08_endodermis-main-smoke-jetson-ip_endodermis.md
@@ -1,0 +1,88 @@
+# Endodermis — smoke main Jetson + cambio de IP WiFi
+
+**Fecha:** 2026-05-08 (dia 23)  
+**Frente:** Rhizome Jetson / fachada Pollen  
+**Jetson actual:** `192.168.1.31`
+
+---
+
+## Contexto
+
+Cambium pidio repetir desde `main`:
+
+- `start_demo_two_rhizomes.sh`
+- `smoke_policy.sh`
+
+La Jetson habia cambiado de WiFi y dejo de responder en la IP historica
+`192.168.1.60`. Bea confirmo nueva IP:
+
+```text
+192.168.1.31 172.17.0.1
+```
+
+## Validacion desde main
+
+En Jetson:
+
+```bash
+cd ~/sprout
+git checkout main
+git pull --ff-only origin main
+cd code/rhizome/jetson
+bash -n start_sync_facade.sh
+bash -n smoke_policy.sh
+bash -n start_demo_two_rhizomes.sh
+./start_demo_two_rhizomes.sh
+./smoke_policy.sh
+FACADE_URL=http://127.0.0.1:13020 TARGET_NODE_ID=rhizome_02 ./smoke_policy.sh
+```
+
+Resultado:
+
+- `main` en SHA `1cfd4f9`.
+- `rhizome_01` arranca en `:13010`.
+- `rhizome_02` simulado arranca en `:13020`.
+- Smoke lectura OK en ambos.
+- Smoke `POST /policy` OK en ambos.
+- Respuesta mantiene `hard_limits_checked_by_facade=false`.
+
+## Hallazgo pequeno
+
+`start_demo_two_rhizomes.sh` imprimia endpoints hardcodeados con
+`192.168.1.60`, que ya no era la IP actual. La fachada funcionaba bien, pero
+la cartela operativa podia confundir a Pollen o a rodaje.
+
+## Microfix propuesto
+
+Rama:
+
+```text
+feat/endodermis/demo-host-ip-output
+```
+
+Commit:
+
+```text
+60e6075 fix(rhizome): print current Jetson demo host
+```
+
+Cambio: el script calcula `DEMO_HOST` con `hostname -I`, prioriza IP
+`192.168.*` y permite override por variable de entorno.
+
+Validacion del microfix en Jetson:
+
+- la cartela ya imprime:
+
+```text
+rhizome_01 -> http://192.168.1.31:13010/
+rhizome_02 -> http://192.168.1.31:13020/
+```
+
+- `smoke_policy.sh` vuelve a pasar en `rhizome_01` y `rhizome_02`.
+- Desde maquina local, `GET /status` responde en `192.168.1.31:13010` y
+  `192.168.1.31:13020`.
+
+## Nota
+
+El microfix no cambia contrato, seguridad, politicas ni runtime de inferencia.
+Solo evita mostrar una IP obsoleta cuando cambia la WiFi.

--- a/bitacora/2026-05-08_endodermis-main-smoke-jetson-ip_endodermis.md
+++ b/bitacora/2026-05-08_endodermis-main-smoke-jetson-ip_endodermis.md
@@ -86,3 +86,39 @@ rhizome_02 -> http://192.168.1.31:13020/
 
 El microfix no cambia contrato, seguridad, politicas ni runtime de inferencia.
 Solo evita mostrar una IP obsoleta cuando cambia la WiFi.
+
+## Mejora antidrama WiFi
+
+Comprobado desde maquina local:
+
+```text
+rhizome-01-node.local -> 192.168.1.31
+```
+
+El puerto SSH responde por mDNS. Por tanto, para pruebas en otra WiFi, la
+primera URL que debe probar Pollen es:
+
+```text
+http://rhizome-01-node.local:13010/
+```
+
+Y para la demo de dos Rhizomes:
+
+```text
+http://rhizome-01-node.local:13010/
+http://rhizome-01-node.local:13020/
+```
+
+Anado `network_info.sh` para imprimir en Jetson:
+
+- hostname;
+- mDNS;
+- WiFi activa;
+- IPs;
+- URLs preferentes por mDNS;
+- URLs fallback por IP actual;
+- health local de `:13010` y `:13020`.
+
+Decision: usar `.local` como ruta preferente y IP actual como fallback. No
+intentamos fijar IP estatica, porque manana se probara en otro sitio y el
+router puede cambiar.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -190,11 +190,31 @@ Jetson:
 ./start_demo_two_rhizomes.sh
 ```
 
+Si la Jetson cambia de WiFi, no depender de recordar la IP anterior. El
+hostname estable por mDNS es:
+
+```text
+rhizome-01-node.local
+```
+
+URLs preferentes:
+
+```text
+rhizome_01 -> http://rhizome-01-node.local:13010/
+rhizome_02 -> http://rhizome-01-node.local:13020/
+```
+
+Si la red bloquea mDNS, usar la IP actual que imprime:
+
+```bash
+./network_info.sh
+```
+
 Endpoints de demo:
 
 ```text
-rhizome_01 -> http://192.168.1.60:13010/
-rhizome_02 -> http://192.168.1.60:13020/
+rhizome_01 -> http://<jetson-host-or-ip>:13010/
+rhizome_02 -> http://<jetson-host-or-ip>:13020/
 ```
 
 `rhizome_02` usa datos de `code/rhizome/demo_data/rhizome_02`. Es una

--- a/code/rhizome/jetson/network_info.sh
+++ b/code/rhizome/jetson/network_info.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOSTNAME_SHORT="$(hostname)"
+MDNS_HOST="${MDNS_HOST:-${HOSTNAME_SHORT}.local}"
+PRIMARY_IP="${PRIMARY_IP:-}"
+
+if [ -z "$PRIMARY_IP" ]; then
+  PRIMARY_IP="$(hostname -I | tr ' ' '\n' | grep -E '^192\.168\.' | head -n 1 || true)"
+fi
+
+if [ -z "$PRIMARY_IP" ]; then
+  PRIMARY_IP="$(hostname -I | tr ' ' '\n' | grep -Ev '^(127\.|172\.17\.|$)' | head -n 1 || true)"
+fi
+
+if [ -z "$PRIMARY_IP" ]; then
+  PRIMARY_IP="<jetson-ip>"
+fi
+
+active_wifi="$(
+  nmcli -t -f NAME,DEVICE,TYPE connection show --active 2>/dev/null \
+    | awk -F: '$3 == "802-11-wireless" {print $1 " (" $2 ")"; exit}'
+)"
+
+echo "Rhizome Jetson network"
+echo "Hostname: ${HOSTNAME_SHORT}"
+echo "mDNS: ${MDNS_HOST}"
+echo "Active WiFi: ${active_wifi:-unknown}"
+echo "IPs: $(hostname -I | xargs)"
+echo
+echo "Preferred stable URLs (try these first):"
+echo "  rhizome_01 -> http://${MDNS_HOST}:13010/"
+echo "  rhizome_02 -> http://${MDNS_HOST}:13020/"
+echo
+echo "Current IP fallback:"
+echo "  rhizome_01 -> http://${PRIMARY_IP}:13010/"
+echo "  rhizome_02 -> http://${PRIMARY_IP}:13020/"
+echo
+echo "Health checks from the Jetson:"
+for port in 13010 13020; do
+  if curl -fsS "http://127.0.0.1:${port}/status" >/tmp/sprout_network_info_${port}.json 2>/dev/null; then
+    echo "  :${port} OK $(cat /tmp/sprout_network_info_${port}.json)"
+  else
+    echo "  :${port} not responding locally"
+  fi
+done
+
+cat <<'TXT'
+
+If Pollen cannot reach the .local URLs on a new WiFi, use the current IP
+fallback. Some guest/mobile networks block multicast DNS even when normal HTTP
+works.
+TXT

--- a/code/rhizome/jetson/start_demo_two_rhizomes.sh
+++ b/code/rhizome/jetson/start_demo_two_rhizomes.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO_DIR="${REPO_DIR:-$HOME/sprout}"
 DEMO_HOST="${DEMO_HOST:-}"
+DEMO_MDNS_HOST="${DEMO_MDNS_HOST:-$(hostname).local}"
 
 if [ -z "$DEMO_HOST" ]; then
   DEMO_HOST="$(hostname -I | tr ' ' '\n' | grep -E '^192\.168\.' | head -n 1 || true)"
@@ -40,8 +41,13 @@ FACADE_URL=http://127.0.0.1:13020 ./smoke_sync_facade.sh
 
 cat <<TXT
 Demo endpoints:
-  rhizome_01 -> http://${DEMO_HOST}:13010/
-  rhizome_02 -> http://${DEMO_HOST}:13020/
+  stable mDNS:
+    rhizome_01 -> http://${DEMO_MDNS_HOST}:13010/
+    rhizome_02 -> http://${DEMO_MDNS_HOST}:13020/
+
+  current IP fallback:
+    rhizome_01 -> http://${DEMO_HOST}:13010/
+    rhizome_02 -> http://${DEMO_HOST}:13020/
 
 Document in video/writeup: rhizome_02 is simulated on the same Jetson to show
 multi-Rhizome sync behavior. It does not represent a second physical ESP32.

--- a/code/rhizome/jetson/start_demo_two_rhizomes.sh
+++ b/code/rhizome/jetson/start_demo_two_rhizomes.sh
@@ -2,6 +2,19 @@
 set -euo pipefail
 
 REPO_DIR="${REPO_DIR:-$HOME/sprout}"
+DEMO_HOST="${DEMO_HOST:-}"
+
+if [ -z "$DEMO_HOST" ]; then
+  DEMO_HOST="$(hostname -I | tr ' ' '\n' | grep -E '^192\.168\.' | head -n 1 || true)"
+fi
+
+if [ -z "$DEMO_HOST" ]; then
+  DEMO_HOST="$(hostname -I | awk '{print $1}')"
+fi
+
+if [ -z "$DEMO_HOST" ]; then
+  DEMO_HOST="<jetson-ip>"
+fi
 
 cd "$(dirname "$0")"
 
@@ -25,10 +38,10 @@ FACADE_URL=http://127.0.0.1:13010 ./smoke_sync_facade.sh
 echo "Smoke rhizome_02 (:13020)"
 FACADE_URL=http://127.0.0.1:13020 ./smoke_sync_facade.sh
 
-cat <<'TXT'
+cat <<TXT
 Demo endpoints:
-  rhizome_01 -> http://192.168.1.60:13010/
-  rhizome_02 -> http://192.168.1.60:13020/
+  rhizome_01 -> http://${DEMO_HOST}:13010/
+  rhizome_02 -> http://${DEMO_HOST}:13020/
 
 Document in video/writeup: rhizome_02 is simulated on the same Jetson to show
 multi-Rhizome sync behavior. It does not represent a second physical ESP32.


### PR DESCRIPTION
Cambio de WiFi expuso fragilidad de IP fija. Solucion: mDNS preferente (rhizome-01-node.local) + IP fallback. Anadido network_info.sh con hostname, IPs, URLs preferentes, health :13010 y :13020. Pollen Android ya valido .local funciona.