### PR TITLE
tier 1 dia 24: writeup §7 fuera + cartelas EN-only + .mailmap (quita Claude) + CONTRIBUTING bilingue

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,31 @@
+# Sprout · .mailmap
+# ----------------------------------------------------------
+# Reescribe identidades en `git log --use-mailmap` y en la página de
+# Contributors de GitHub, sin modificar la historia del repositorio.
+#
+# Decisión Bea día 24:
+# - Trailers `Co-Authored-By: Claude Opus 4.X <noreply@anthropic.com>`
+#   añadidos automáticamente por Claude Code en algunos commits del
+#   equipo zigiella se mapean a la identidad real (zigiella) — Bea es
+#   el único humano del equipo, los agentes IA del equipo (Cambium,
+#   Floema, Meristem, Xilema, Corola, Endodermis, Bract, Venation)
+#   son herramientas de organización del trabajo, no contributors
+#   externos al proyecto.
+#
+# Sintaxis:
+#   Proper Name <commit@email.xx> Other Name <other@email.xx>
+#   Proper Name <commit@email.xx>                <other@email.xx>
+#
+# Documentación: https://git-scm.com/docs/gitmailmap
+# ----------------------------------------------------------
+
+# Mapea cualquier trailer Co-Authored-By: <noreply@anthropic.com> a zigiella
+zigiella <beatriz.m.v@gmail.com>                <noreply@anthropic.com>
+
+# Consolidación de identidades Cambium (varios sufijos de email
+# usados durante el proyecto — todos referencian al mismo agente)
+Cambium <cambium@sprout.local>                  <cambium@zigiella.local>
+Cambium <cambium@sprout.local>                  <cambium@zigiella>
+
+# Consolidación Meristem (mismo agente, dos sufijos de email)
+Meristem <meristem@sprout.local>                <meristem@zigiella.local>

--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -1,0 +1,894 @@
+<!-- Bilingual document · Spanish first, English below · See §13 for language policy -->
+
+🇪🇸 **[Español](#contributing-es)** · 🇬🇧 **[English](#contributing-en)**
+
+---
+
+<a id="contributing-es"></a>
+
+# Como trabajamos en Sprout
+
+Guia interna del **equipo zigiella** para trabajar en Sprout.
+
+---
+
+## 1. Filosofia de colaboracion
+
+Sprout es un proyecto del equipo zigiella. Durante el sprint MVP somos cuatro personas. Cada una trabaja en su area pero todo converge en una entrega coherente: **un sistema funcional + video de demostracion + documento de presentacion + repo publico**.
+
+Reglas blandas:
+- Si no aporta a los puntos de "lo que debe demostrar el video", probablemente sobra
+- Si no puedes explicar algo en una frase, probablemente esta mal formulado
+- Si algo es ambiguo en docs/, abre una entrada en bitacora/ y pregunta
+
+---
+
+## 2. Roles y zonas del repo
+
+| Rol | Zona principal | Zonas secundarias |
+|-----|---------------|-------------------|
+| Coordinacion y diseno | `docs/`, `bitacora/` | todas |
+| Dev Rhizome (Jetson) | `code/rhizome/`, `hardware/` | `docs/10_rhizome_spec.md` |
+| Dev Pollen (Android) | `code/pollen/` | `docs/11_pollen_spec.md` |
+| Dev Meristem + Fine-tune | `code/meristem/`, `code/finetune/` | `docs/12_meristem_spec.md` |
+
+Writeup, video, research y demo los cubre el core del equipo (coordinacion + project lead).
+
+---
+
+## 3. Flujo de trabajo
+
+### 3.1 Antes de empezar algo nuevo
+1. `git pull` en `main`
+2. Elegir un issue del [backlog](https://github.com/zigiella/sprout/issues) (ver §10) y asignartelo
+3. Leer la entrada mas reciente de `bitacora/`
+4. Revisar el doc relevante en `docs/`
+5. Crear rama `feat/<zona>-<tema>` o `fix/<zona>-<tema>` — **nunca** trabajar sobre `main`
+
+### 3.2 Durante el trabajo
+- Commits pequenos y frecuentes
+- Mensaje de commit: `[zona] resumen corto` (ej: `[rhizome] humedad lectura via ADS1115`)
+- En el commit que cierra el issue, incluir `Closes #N` en el cuerpo para enlace automatico
+
+### 3.3 Al terminar una pieza
+- Entrada en `bitacora/` con fecha, lo que se hizo, lo que queda, decisiones tomadas (**obligatorio antes de PR**)
+- Si hay cambio de arquitectura, actualizar el doc correspondiente en `docs/`
+- Abrir PR contra `main`. En la descripcion del PR: `Closes #N` + resumen + como probar
+- Review por Cambium antes de merge. Sin review, no hay merge
+
+### 3.4 Mensajes de coordinacion: inicio de dia, cierre y cross-frente
+
+> Convencion validada empiricamente dia 19-20 (Bea + Cambium): hacer explicitas
+> las dependencias entre miembras en los mensajes reduce overhead de
+> coordinacion y desbloquea decisiones que de otra forma quedan implicitas.
+
+**Cuando aplica esta convencion**:
+- Mensajes de inicio de dia donde varias miembras tienen dependencias cruzadas (Cambium los redacta y Bea los modula).
+- Mensajes cross-frente cuando una miembra bloquea o depende de otra.
+- Mensajes de cierre de dia cuando lo que se cerro afecta el plan del dia siguiente de otra miembra.
+
+**Plantilla obligatoria** cuando hay dependencias activas: cada mensaje incluye una seccion **"Interrelaciones"** con tres campos (omitir el que no aplique):
+
+```markdown
+### Interrelaciones [dia X o tema]
+
+- **ESPERAS DE [persona]**: [que necesitas concretamente] [cuando idealmente].
+  Sin eso, [que queda bloqueado].
+- **BLOQUEAS a [persona]**: [que le bloqueas] [hasta cuando].
+  Si no lo cierras, [coste para el otro frente].
+- **COORDINAS con [persona]**: [en que cosa] [modo: bidireccional, sincrono, asincrono].
+```
+
+**Campos opcionales** que se anaden cuando son relevantes:
+- **DESBLOQUEAS a [persona]** cuando [evento].
+- **APUNTAS a [persona]** sin urgencia, para que sepa.
+
+**Por que la plantilla**:
+1. Cada miembra ve sin esfuerzo a quien depende y a quien afecta.
+2. Las decisiones operativas pequenas que destrabar dependencias se hacen visibles y se cierran rapido.
+3. Reduce el ruido tipo "no sabia que estabas esperando esto" y los reproches retroactivos.
+4. Permite a la coordinadora (Bea) y a la tech lead (Cambium) hacer un mapa visual de bloqueos del dia con un vistazo a los mensajes.
+
+**Ejemplo real (mensaje a Floema dia 20)**:
+
+```markdown
+### Interrelaciones dia 20
+
+- **BLOQUEAS a Bea/Bract**: empaquetado release APK demo flavor + Appetize.io = live demo.
+  Sin tu APK, no hay live demo en submission. Plazo draft dia 22.
+- **ESPERAS DE Meristem**: implementacion servidor WS para que tu cliente WS pueda conectar.
+  Coordinacion bidireccional desde primera hora si quieres avanzar rapido.
+- **ESPERAS DE Endo**: que la fachada Jetson :13010 siga viva.
+  Si cae o tiene regresion, no puedes consolidar `RhizomeNetworkClient`.
+- **COORDINAS con Venation**: capturas Pollen UI bilingue en alta fidelidad para validacion copy
+  definitivo. Material pre-rodaje.
+```
+
+**Cuando NO hace falta la plantilla**:
+- Mensajes 1:1 sin dependencias cruzadas (Cambium → Bea sobre un detalle puntual).
+- Bitacoras self-contained donde la dependencia ya esta en el cuerpo y nombrarla aparte sumaria ruido.
+- Mensajes de pure-comunicacion sin acciones operativas.
+
+---
+
+## 4. Bitacora: como escribir una entrada
+
+Cada entrada es un archivo en `bitacora/` con nombre:
+
+```
+YYYY-MM-DD_<tema-corto>_<autor>.md
+```
+
+Ejemplos:
+- `2026-04-15_kickoff_cambium.md`
+- `2026-04-18_jetson-primer-arranque_ana.md`
+- `2026-04-22_pollen-sync-funcionando_maria.md`
+
+Plantilla en [bitacora/README.md](bitacora/README.md).
+
+---
+
+## 5. Convenciones de codigo
+
+### Python (Rhizome, Meristem, Simulator)
+- Python 3.11+
+- `ruff` para lint, `black` para formato
+- Type hints obligatorios en funciones publicas
+- Docstrings breves en espanol; comentarios en codigo en espanol
+- Tests minimos en `tests/` de cada subproyecto
+
+### Android (Pollen)
+- Kotlin
+- Jetpack Compose
+- Gemma 4 via Google AI Edge / LiteRT (o llama.cpp como fallback)
+
+### Schemas JSON
+- Todos los schemas en `code/shared/schemas/`
+- Validacion via `pydantic` en Python, via `kotlinx.serialization` en Android
+
+---
+
+## 6. Convenciones de naming
+
+### Archivos de docs
+- Numerados con prefijo de dos digitos (`00_`, `01_`, `10_`, etc.)
+- Kebab-case para nombres compuestos
+- Ejemplo: `docs/20_data_contracts.md`
+
+### Modelos de Gemma 4
+Seguir [guia oficial de naming de Google](https://ai.google/documents/32/External_Gemma_Model_Variant_Guidelines.pdf):
+- Formato: `sprout/sprout-<componente>-<modelo_base>-v<N>`
+- Ejemplo: `sprout/sprout-rhizome-e2b-v1`
+- Nunca poner "Gemma" en el nombre del modelo derivado (lo exige la licencia)
+
+### Branches de git
+- `main` = produccion / ultima version estable
+- `feat/<zona>-<descripcion>` = features en desarrollo
+- `fix/<zona>-<descripcion>` = bugfixes
+- Ejemplo: `feat/rhizome-audio-sensor`
+
+### Ejemplos canonicos (fixtures JSON)
+
+Viven en `code/shared/examples/`. Regla:
+
+- `<schema>.json` = fixture canonico unico por schema. Es el ejemplo de referencia,
+  el que se usa en tests y documentacion. Un solo archivo por schema.
+  Ejemplos: `rhizome_snapshot.json`, `weather_packet.json`, `policy_packet.json`.
+- `<schema>_<variante>.json` = variantes deliberadas que cubren un caso distinto
+  al canonico (estado de bloqueo, contradiccion, modo conservador, etc.).
+  Ejemplos: `decision_receipt_blocked.json`, `contradiction_alert_sensor_vs_vision.json`.
+
+**Regla dura:** si anades una variante, debe quedar claro en el nombre que varianta
+del canonico es. No metas campos nuevos al canonico solo para cubrir un caso;
+crea una variante.
+
+---
+
+## 7. Secretos y credenciales
+
+**Nunca** commitear:
+- API keys (Google AI Studio, HuggingFace, etc.)
+- Certificados o tokens
+- Archivos `.env`
+
+Usar siempre variables de entorno. Plantilla en `.env.example` si aplica.
+
+Ya existe `.gitignore` con las entradas minimas. Si dudas, pregunta antes de hacer push.
+
+---
+
+## 8. Dudas
+
+Abre una entrada en `bitacora/` con el tema `pregunta-<topic>` y etiqueta a Cambium. O en el canal que estemos usando el equipo.
+
+---
+
+## 9. Checklist antes de cada push
+
+- [ ] El codigo corre sin errores
+- [ ] No hay credenciales expuestas
+- [ ] Si cambie un contrato de datos, actualice `code/shared/schemas/`
+- [ ] Si cambie arquitectura, actualice `docs/`
+- [ ] Hice entrada en `bitacora/` con fecha
+- [ ] El PR referencia el issue con `Closes #N`
+- [ ] Si toca una zona con CI (`code/pollen/**`, futuros Rhizome/Meristem), el CI esta **verde** antes de pedir review
+
+### 9.1 Regla dura sobre CI
+
+**Ningun PR se mergea con CI en rojo.** Sin excepciones. Si el CI falla:
+1. Lee los logs del workflow en GitHub Actions (pestaña "Checks" del PR)
+2. Reproduce localmente si tienes entorno, o itera con los logs si no
+3. Corrige, commitea, push. El CI se re-ejecuta automaticamente
+4. Solo cuando este verde, avisas para review
+
+Si el fallo del CI es del propio workflow (no del codigo), se abre issue aparte para arreglar el workflow. El PR afectado queda en hold.
+
+### 9.2 Operaciones git seguras en maquina compartida
+
+**Contexto.** Varias miembras del equipo (Bea, Corola, Cambium) comparten maquina, carpeta de trabajo y cuenta de GitHub. Eso introduce riesgos especificos que NO existen cuando cada miembra tiene su propio clone aislado:
+
+- Cuando una hace `git pull`, `git checkout` o `git stash` en la carpeta compartida, las otras se ven afectadas en su working tree.
+- Es muy facil que un commit termine en la rama equivocada porque el `HEAD` cambio entre operaciones.
+- Es muy facil que cambios reales se queden en un **stash silencioso** durante operaciones cross-rama y nunca lleguen al commit que crees haber hecho.
+
+Esto se ha sufrido empiricamente: Cambium 4 veces (dia 13), Meristem 5 veces (dias 12-13), Corola 1 vez (dia 15). Patron sistemico, no error individual.
+
+**Tres puntos de verificacion antes de cada commit.**
+
+Sustituye al checklist tradicional `git status` solo. Verifica los **tres** siempre:
+
+```bash
+git status                  # 1. archivos modificados/staged
+git branch --show-current   # 2. en que rama estoy realmente
+git stash list              # 3. stashes pendientes (especialmente con tu prefijo)
+```
+
+Si los tres confirman lo que esperabas, commitea. Si alguno te sorprende, **para y resuelve antes de commitear**. Tres comandos, dos segundos cada uno.
+
+**Stash con prefijo de autor obligatorio.**
+
+Cuando uses `git stash push`, **siempre con mensaje y prefijo de autor**:
+
+```bash
+git stash push -m "[corola] WIP guion v1.4 escena 7"
+git stash push -m "[cambium] WIP bitacora dia 16"
+```
+
+Eso permite identificar de un vistazo en `git stash list` que stash es de quien:
+
+```
+stash@{0}: On main: [corola] WIP guion v1.4 escena 7
+stash@{1}: On main: [cambium] WIP bitacora dia 16
+```
+
+Si ves un stash sin prefijo, es porque alguien olvido la convencion. **No lo tocas hasta confirmar de quien es**.
+
+**Una operacion atomica por sesion.**
+
+Cuando arranques sesion de trabajo:
+1. `git status` + `git branch --show-current` + `git stash list` (verificacion inicial)
+2. Si hay stash ajeno o working tree sucio, **paras y avisas en chat comun antes de continuar**
+3. Trabajo + commit + push
+4. Antes de pasar el turno: `git checkout main` y working tree limpio
+
+**No dejas working tree modificado para que la siguiente miembra arranque.** Si tu trabajo no esta listo para commit, lo dejas en stash con tu prefijo y la siguiente sabe que hay material tuyo pendiente.
+
+**Antes de cualquier `git checkout`.**
+
+Verifica `git stash list`. Si ves stash con prefijo ajeno, **no haces checkout que pueda alterar ese contexto sin avisar primero**. Si ves stash con tu prefijo de una sesion anterior, decide explicitamente: lo aplicas, lo descartas, o lo dejas y navegas con cuidado.
+
+**Resolucion si el commit termino en rama equivocada.**
+
+Procedimiento conocido por el equipo (lo hemos usado varias veces sin perdida de datos):
+
+```bash
+git reset --soft HEAD~1     # deshace commit, mantiene cambios en staging
+git stash push -m "[nombre] commit a mover"
+git checkout main           # o la rama correcta
+git stash pop
+git commit -m "..."         # commit en rama correcta
+git push origin main
+```
+
+Si el commit ya esta pusheado a la rama equivocada, abrir issue y resolver con `git revert` (no force-push).
+
+**Fuera de scope post-hackathon.**
+
+A futuro, **`git worktree`** es la solucion tecnica correcta a esta friccion: un solo `.git/` central, varios working directories aislados, una miembra por carpeta. No lo implementamos durante el hackathon porque cambiar setup en mitad del proyecto introduce mas riesgo que el que mitiga. Apuntar para revision post-demo.
+
+---
+
+## 10. Backlog y tablero visual
+
+El backlog vive en **GitHub Issues + Projects**.
+
+### 10.1 Donde verlo
+- **Lista de issues:** https://github.com/zigiella/sprout/issues
+- **Tablero kanban "Sprout Backlog":** https://github.com/users/zigiella/projects/2 — cuatro columnas: **Backlog / In Progress / Review / Done**. Arrastrar tarjeta cambia estado.
+- **Vista Table:** el mismo proyecto con vista de spreadsheet para priorizar en bloque.
+- **GitHub Mobile** (iOS/Android): misma vista Board, desde el sofa.
+
+### 10.2 Como usar el backlog
+
+**Abrir un issue nuevo:**
+- Titulo imperativo, corto, sin jerga interna. "Implementar schemas Pydantic" > "Schemas".
+- **Zero referencias externas** al hackathon, jurado, premios, deadline. El repo es publico.
+- Body con: contexto, criterios de aceptacion (checkboxes), dependencias, referencia a docs.
+- Labels obligatorios: **uno de `node:*`** y **uno de `priority:*`**. Opcionales: `area:*`, `status:blocked`.
+
+**Asignarse un issue:**
+- Solo asignarse lo que vas a empezar esa misma sesion. Si dudas, dejalo sin asignar.
+- Si lo abandonas, quitate de asignada y deja comentario con el por que.
+
+**Cerrar un issue:**
+- Solo se cierra por merge de PR que lo referencia con `Closes #N`.
+- No cerrar "a mano" salvo duplicados o invalidos (con comentario explicativo).
+
+### 10.3 Taxonomia de labels
+
+**Nodo (uno obligatorio):**
+- `node:rhizome` — Jetson, parcela
+- `node:pollen` — Android, itinerante
+- `node:meristem` — laptop, estrategico
+- `node:cambium` — coordinacion, diseno, supervision
+
+**Area (opcional, puede haber varias):**
+- `area:docs` — documentacion de arquitectura
+- `area:infra` — repo, CI, tooling
+- `area:research` — benchmarks, evaluacion
+- `area:firmware` — ESP32, capa fisica
+
+**Prioridad (una obligatoria):**
+- `priority:P0` — critico, bloquea a alguien
+- `priority:P1` — importante, no bloqueante
+- `priority:P2` — nice to have
+
+**Estado (opcional):**
+- `status:blocked` — esperando algo externo
+
+### 10.4 Relacion PR ↔ issue
+
+Cada PR deberia cerrar al menos un issue. En el cuerpo del PR:
+
+```
+Closes #12
+Closes #15
+```
+
+Al mergear, GitHub mueve esos issues a **Done** automaticamente.
+
+---
+
+## 11. Convencion de autoria
+
+Todas las personas del equipo zigiella trabajamos bajo la **misma cuenta de GitHub** (`zigiella`). Para que en el historial del repo se pueda distinguir quien hizo que, cada dev configura **identidad local al repo** (no global, para no afectar otros proyectos tuyos):
+
+```bash
+cd <ruta-al-repo-sprout>
+git config user.name "<Nombre>"
+git config user.email "<nombre>@sprout.local"
+```
+
+**Identidades vigentes:**
+
+| Rol | `user.name` | `user.email` |
+|-----|-------------|--------------|
+| Coordinacion | `Cambium` | `cambium@sprout.local` |
+| Dev Rhizome | `Xilema` | `xilema@sprout.local` |
+| Dev Pollen | `Floema` | `floema@sprout.local` |
+| Dev Meristem | `Meristem` | `meristem@sprout.local` |
+| Project lead | `Bea` | `bea@sprout.local` |
+
+**Sobre la TLD `.local`:** es una TLD reservada por IANA (RFC 6762) para uso multicast DNS y redes internas. **No colisiona con ninguna direccion real de internet** y deja claro que son identidades ficticias del equipo.
+
+**Commits con coautoria (opcional pero recomendado para PR revisados):**
+
+```
+Co-Authored-By: Cambium <cambium@sprout.local>
+```
+
+**Reglas duras:**
+- **Nunca** reescribir historia para cambiar autoria en commits viejos. Si se subio algo con identidad equivocada, se corrige de aqui en adelante; el historial se respeta.
+- **Nunca** usar `--global` al configurar estas identidades. Son locales al repo.
+- Al clonar el repo por primera vez, configurar identidad es **el primer paso**, antes del primer commit.
+
+### 11.1 Multi-agente sobre el mismo clone
+
+Si varias agentes (p.ej. Cambium y Meristem en conversaciones separadas) comparten el mismo clone del repo, **`git config user.email` persiste en `.git/config` y una agente puede pisar la identidad de otra.**
+
+Solucion: **no persistir la identidad**, pasarla inline en cada commit con `-c`:
+
+```bash
+git -c user.name="Meristem" -c user.email="meristem@sprout.local" commit -m "..."
+```
+
+Esto solo aplica a ese comando, no toca `.git/config`. Es el modo obligatorio cuando hay mas de una agente trabajando en el mismo clone.
+
+Si solo hay una persona/agente por clone (caso tipico de dev humana), el `git config` persistente esta bien.
+
+---
+
+## 12. Flujo de asignacion en el tablero
+
+**Principio:** auto-asignacion con protocolo corto, sin asignador central.
+
+### 12.1 Ciclo diario
+
+1. **Filtrar por tu nodo.** En [el tablero](https://github.com/users/zigiella/projects/2) aplicar filtro por label `node:<tuyo>`.
+2. **Elegir la de mayor prioridad** de la columna **Backlog**. Orden: `priority:P0` (rojas) → `priority:P1` (amarillas) → `priority:P2` (grises). Empate: menos dependencias abiertas.
+3. **Auto-asignarse el issue** (boton "assign yourself" en el issue) **y arrastrar la tarjeta** de Backlog a **In Progress**. Ese doble movimiento es la señal publica de "estoy con esto ahora".
+4. **Trabajar.** Commits pequenos y frecuentes, rama `feat/<zona>-<tema>` o `fix/<zona>-<tema>`.
+5. **Abrir PR** con `Closes #N` en el cuerpo. GitHub mueve automaticamente la tarjeta a **Review**.
+6. **Review por Cambium.** Si aprueba y mergea, la tarjeta va a **Done** automaticamente. Si pide cambios, la dev la arrastra de vuelta a **In Progress** y trabaja sobre los comentarios.
+
+### 12.2 Regla dura: una tarjeta por persona en In Progress
+
+**Solo una tarjeta** por persona puede estar en In Progress al mismo tiempo. Si necesitas bloquear algo para trabajar en otra cosa:
+- Añades label `status:blocked` al issue
+- Arrastras la tarjeta de vuelta a Backlog
+- Comentas en el issue explicando que esperas
+
+Evita que el tablero se llene de "en progreso" que nadie esta tocando.
+
+### 12.3 Casos especiales
+
+- **Tarjeta que nadie coge** (suele pasar con docs aburridos): Cambium prioriza en digest o la coge ella misma pasados 3 dias.
+- **Tarjeta urgente que debe cortar la cola:** Bea o Cambium añaden/suben a `priority:P0` y comentan en el issue el por que. La dev con hueco la coge antes que su backlog normal.
+- **Dependencias:** si #A bloquea #B, en #B se pone `Blocked by #A` en el cuerpo. Solo se puede auto-asignar #B cuando #A esta en Done.
+- **Abandono de tarea:** quitarse de asignada, dejar comentario en el issue con el por que, arrastrar tarjeta de vuelta a Backlog.
+
+### 12.4 El tablero es la verdad
+
+Si una conversacion privada (canal, DM, mail) decide algo sobre una tarea, esa decision se refleja en el issue (como comentario) o en bitacora. **No hay "yo pense que tu estabas haciendo eso".** La tarjeta dice quien, la columna dice en que fase, el PR dice el que.
+
+Si una tarjeta lleva >48h en In Progress sin commits ni comentarios, Cambium pregunta en el issue (pregunta publica, no DM).
+
+---
+
+## 13. Idiomas del repo
+
+Para minimizar coste de mantenimiento sin cerrar la puerta a gente externa, tenemos dos capas de idiomas:
+
+| Zona | Idioma | Por que |
+|------|--------|---------|
+| `README.md` | **Bilingue** ES + EN | Puerta de entrada publica. Una persona externa debe poder entender el proyecto en minutos. |
+| `CONTRIBUTING.md` | **Bilingue** ES + EN | Una contribuidora externa debe poder abrir un PR sin hablar espanol. |
+| `docs/` | **Solo ES** | Specs de producto internos. Evolucionan rapido; traducirlos se desincroniza. |
+| `bitacora/` | **Solo ES** | Diario interno del equipo, en vivo. Mantener bilingue seria puro overhead. |
+| Commits, issues, PRs | Libre (ES o EN) | Claridad > consistencia. Cada persona escribe en el idioma en que piense mejor ese dia. |
+| Codigo (identifiers, comentarios) | Libre, pero consistente dentro de un modulo | Si un modulo empieza en ES, seguir en ES. No mezclar en el mismo archivo. |
+
+**Regla operacional:** al tocar `README.md` o `CONTRIBUTING.md`, actualizar **ambas** secciones de idioma en el mismo PR. Si solo se actualiza una, se abre issue para sincronizar la otra y se marca `priority:P1`.
+
+---
+---
+
+<a id="contributing-en"></a>
+
+# How we work on Sprout
+
+Internal guide of **equipo zigiella** for working on Sprout.
+
+---
+
+## 1. Collaboration philosophy
+
+Sprout is a project by equipo zigiella. During the MVP sprint we are four people. Each owns an area but everything converges on a coherent delivery: **a working system + demo video + writeup + public repo**.
+
+Soft rules:
+- If it doesn't feed into "what the video must show," it probably doesn't belong
+- If you can't explain something in one sentence, it's probably not well framed
+- If something is ambiguous in `docs/`, open a `bitacora/` entry and ask
+
+---
+
+## 2. Roles and repo zones
+
+| Role | Primary zone | Secondary |
+|------|-------------|-----------|
+| Coordination & design | `docs/`, `bitacora/` | any |
+| Dev Rhizome (Jetson) | `code/rhizome/`, `hardware/` | `docs/10_rhizome_spec.md` |
+| Dev Pollen (Android) | `code/pollen/` | `docs/11_pollen_spec.md` |
+| Dev Meristem + Fine-tune | `code/meristem/`, `code/finetune/` | `docs/12_meristem_spec.md` |
+
+Writeup, video, research, and demo are covered by the core team (coordination + project lead).
+
+---
+
+## 3. Workflow
+
+### 3.1 Before starting something new
+1. `git pull` on `main`
+2. Pick an issue from the [backlog](https://github.com/zigiella/sprout/issues) (see §10) and assign it to yourself
+3. Read the latest entry in `bitacora/`
+4. Review the relevant doc in `docs/` (Spanish)
+5. Create a branch `feat/<zone>-<topic>` or `fix/<zone>-<topic>` — **never** work directly on `main`
+
+### 3.2 While working
+- Small, frequent commits
+- Commit message: `[zone] short summary` (e.g. `[rhizome] moisture reading via ADS1115`)
+- On the commit that closes the issue, include `Closes #N` in the body for auto-link
+
+### 3.3 When a piece is done
+- Entry in `bitacora/` (in Spanish) with date, what was done, what's pending, decisions taken — **mandatory before PR**
+- If architecture changed, update the matching doc in `docs/`
+- Open a PR against `main`. PR body: `Closes #N` + summary + how to test
+- Review by Cambium before merge. No review, no merge.
+
+### 3.4 Coordination messages: day-start, day-close and cross-frontier
+
+> Convention validated empirically days 19-20 (Bea + Cambium): making
+> dependencies between team members explicit reduces coordination overhead
+> and unblocks decisions that would otherwise stay implicit.
+
+**When this convention applies**:
+- Day-start messages where several team members have cross dependencies (Cambium drafts, Bea modulates).
+- Cross-frontier messages when one team member blocks or depends on another.
+- Day-close messages when what closed affects another member's next-day plan.
+
+**Mandatory template** when active dependencies exist: each message includes an **"Interrelaciones"** (Spanish) section with three fields (omit any that don't apply):
+
+```markdown
+### Interrelaciones [day X or topic]
+
+- **ESPERAS DE [person]**: [what you need concretely] [when ideally].
+  Without it, [what stays blocked].
+- **BLOQUEAS a [person]**: [what you block them on] [until when].
+  If you don't close it, [cost to the other frontier].
+- **COORDINAS con [person]**: [on what] [mode: bidirectional, sync, async].
+```
+
+**Optional fields** added when relevant:
+- **DESBLOQUEAS a [person]** when [event].
+- **APUNTAS a [person]** without urgency, just so they know.
+
+**Why the template**:
+1. Each member sees without effort whom they depend on and whom they affect.
+2. Small operational decisions that unblock dependencies become visible and close fast.
+3. Reduces "I didn't know you were waiting on this" noise and retroactive blame.
+4. Lets the coordinator (Bea) and tech lead (Cambium) make a visual blocking map of the day at a glance.
+
+**When the template is NOT needed**:
+- 1:1 messages without cross dependencies.
+- Self-contained bitacoras where the dependency is already in the body.
+- Pure-communication messages without operational actions.
+
+(Section heading `Interrelaciones` stays in Spanish in EN messages too — it's a project term used as-is.)
+
+---
+
+## 4. Bitacora: how to write an entry
+
+Each entry is a file in `bitacora/` (Spanish-only) with the name:
+
+```
+YYYY-MM-DD_<short-topic>_<author>.md
+```
+
+Examples:
+- `2026-04-15_kickoff_cambium.md`
+- `2026-04-18_jetson-primer-arranque_ana.md`
+
+Template in [bitacora/README.md](bitacora/README.md).
+
+---
+
+## 5. Code conventions
+
+### Python (Rhizome, Meristem, Simulator)
+- Python 3.11+
+- `ruff` for lint, `black` for formatting
+- Type hints mandatory on public functions
+- Short docstrings; comments in the module's original language
+- Minimum tests in `tests/` per subproject
+
+### Android (Pollen)
+- Kotlin
+- Jetpack Compose
+- Gemma 4 via Google AI Edge / LiteRT (llama.cpp as fallback)
+
+### JSON schemas
+- All schemas live in `code/shared/schemas/`
+- Validation via `pydantic` (Python), `kotlinx.serialization` (Android)
+
+---
+
+## 6. Naming conventions
+
+### Doc filenames
+- Two-digit prefix (`00_`, `01_`, `10_`, ...)
+- Kebab-case for compound names
+- Example: `docs/20_data_contracts.md`
+
+### Gemma 4 model variants
+Follow [Google's naming guide](https://ai.google/documents/32/External_Gemma_Model_Variant_Guidelines.pdf):
+- Format: `sprout/sprout-<component>-<base_model>-v<N>`
+- Example: `sprout/sprout-rhizome-e2b-v1`
+- Never put "Gemma" in the derived model name (license requirement)
+
+### Git branches
+- `main` = production / last stable
+- `feat/<zone>-<desc>` = features
+- `fix/<zone>-<desc>` = bugfixes
+- Example: `feat/rhizome-audio-sensor`
+
+### Canonical examples (JSON fixtures)
+
+Live in `code/shared/examples/`. Rule:
+
+- `<schema>.json` = single canonical fixture per schema. The reference example used in tests and docs. Exactly one per schema. Examples: `rhizome_snapshot.json`, `weather_packet.json`.
+- `<schema>_<variant>.json` = deliberate variants covering a non-canonical case (blocked state, contradiction, conservative mode, etc.). Examples: `decision_receipt_blocked.json`.
+
+**Hard rule:** if you add a variant, its name must make the variation clear. Don't add new fields to the canonical example just to cover a case — create a variant.
+
+---
+
+## 7. Secrets and credentials
+
+**Never** commit:
+- API keys (Google AI Studio, HuggingFace, etc.)
+- Certificates or tokens
+- `.env` files
+
+Use environment variables. Template in `.env.example` when applicable.
+
+`.gitignore` already covers the basics. When in doubt, ask before pushing.
+
+---
+
+## 8. Questions
+
+Open a `bitacora/` entry with the topic `pregunta-<topic>` and tag Cambium. Or use the team's active channel.
+
+---
+
+## 9. Pre-push checklist
+
+- [ ] Code runs without errors
+- [ ] No exposed credentials
+- [ ] If a data contract changed, updated `code/shared/schemas/`
+- [ ] If architecture changed, updated `docs/`
+- [ ] Bitacora entry written (with date)
+- [ ] PR references the issue with `Closes #N`
+- [ ] If touching a zone with CI (`code/pollen/**`, future Rhizome/Meristem), CI is **green** before requesting review
+
+### 9.1 Hard rule on CI
+
+**No PR merges on red CI. No exceptions.** If CI fails:
+1. Read the workflow logs (PR's "Checks" tab in GitHub Actions)
+2. Reproduce locally if you can, or iterate from the logs if you can't
+3. Fix, commit, push. CI re-runs automatically
+4. Only when green, request review
+
+If the failure is in the workflow itself (not the code), open a separate issue for the workflow. The affected PR stays on hold.
+
+### 9.2 Safe git operations on a shared machine
+
+**Context.** Several team members (Bea, Corola, Cambium) share machine, working folder and GitHub account. This introduces specific risks that do NOT exist when each member has their own isolated clone:
+
+- When one runs `git pull`, `git checkout` or `git stash` in the shared folder, the others see their working tree affected.
+- It is very easy for a commit to land on the wrong branch because `HEAD` changed between operations.
+- It is very easy for real changes to remain in a **silent stash** during cross-branch operations and never reach the commit you thought you made.
+
+This has been suffered empirically: Cambium 4 times (day 13), Meristem 5 times (days 12-13), Corola 1 time (day 15). Systemic pattern, not individual error.
+
+**Three verification points before each commit.**
+
+Replaces the traditional `git status` only. Always verify the **three**:
+
+```bash
+git status                  # 1. modified/staged files
+git branch --show-current   # 2. which branch I am really on
+git stash list              # 3. pending stashes (especially with your prefix)
+```
+
+If all three confirm what you expected, commit. If any surprises you, **stop and resolve before committing**. Three commands, two seconds each.
+
+**Stash with author prefix mandatory.**
+
+When using `git stash push`, **always with message and author prefix**:
+
+```bash
+git stash push -m "[corola] WIP guion v1.4 escena 7"
+git stash push -m "[cambium] WIP bitacora dia 16"
+```
+
+This allows identifying at a glance in `git stash list` which stash belongs to whom:
+
+```
+stash@{0}: On main: [corola] WIP guion v1.4 escena 7
+stash@{1}: On main: [cambium] WIP bitacora dia 16
+```
+
+If you see a stash without prefix, someone forgot the convention. **Don't touch it until you confirm whose it is**.
+
+**One atomic operation per session.**
+
+When starting a work session:
+1. `git status` + `git branch --show-current` + `git stash list` (initial verification)
+2. If there is a foreign stash or dirty working tree, **stop and notify in common chat before continuing**
+3. Work + commit + push
+4. Before passing the turn: `git checkout main` and clean working tree
+
+**Don't leave a modified working tree for the next member to start.** If your work isn't ready to commit, leave it in stash with your prefix and the next member knows there's pending material from you.
+
+**Before any `git checkout`.**
+
+Verify `git stash list`. If you see a stash with foreign prefix, **don't checkout that may alter that context without notifying first**. If you see a stash with your prefix from a previous session, decide explicitly: apply it, discard it, or leave it and navigate with care.
+
+**Recovery if commit landed on wrong branch.**
+
+Procedure known by the team (we've used it several times without data loss):
+
+```bash
+git reset --soft HEAD~1     # undoes commit, keeps changes in staging
+git stash push -m "[name] commit to move"
+git checkout main           # or correct branch
+git stash pop
+git commit -m "..."         # commit on correct branch
+git push origin main
+```
+
+If the commit was already pushed to the wrong branch, open issue and resolve with `git revert` (not force-push).
+
+**Out of scope, post-hackathon.**
+
+In the future, **`git worktree`** is the correct technical solution to this friction: one central `.git/`, several isolated working directories, one member per folder. We don't implement it during the hackathon because changing setup mid-project introduces more risk than it mitigates. Earmark for post-demo review.
+
+---
+
+## 10. Backlog and visual board
+
+The backlog lives in **GitHub Issues + Projects**.
+
+### 10.1 Where to see it
+- **Issues list:** https://github.com/zigiella/sprout/issues
+- **Kanban "Sprout Backlog":** https://github.com/users/zigiella/projects/2 — four columns: **Backlog / In Progress / Review / Done**. Dragging a card changes state.
+- **Table view:** same project, spreadsheet-like, for bulk prioritization.
+- **GitHub Mobile** (iOS/Android): same Board view, from the couch.
+
+### 10.2 How to use the backlog
+
+**Open a new issue:**
+- Imperative title, short, no internal jargon. "Implement Pydantic schemas" > "Schemas".
+- **Zero external references** to hackathons, juries, prizes, deadlines. The repo is public.
+- Body with: context, acceptance criteria (checkboxes), dependencies, reference to docs.
+- Required labels: **one `node:*`** and **one `priority:*`**. Optional: `area:*`, `status:blocked`.
+
+**Assign yourself an issue:**
+- Only self-assign what you'll start in the same session. When in doubt, leave it unassigned.
+- If you drop it, un-assign and leave a comment with the reason.
+
+**Close an issue:**
+- Only by PR merge referencing it with `Closes #N`.
+- No manual closes except for duplicates or invalids (with explanatory comment).
+
+### 10.3 Label taxonomy
+
+**Node (one required):**
+- `node:rhizome`, `node:pollen`, `node:meristem`, `node:cambium`
+
+**Area (optional, multiple allowed):**
+- `area:docs`, `area:infra`, `area:research`, `area:firmware`
+
+**Priority (one required):**
+- `priority:P0` — critical, blocks someone
+- `priority:P1` — important, non-blocking
+- `priority:P2` — nice to have
+
+**State (optional):**
+- `status:blocked` — waiting on something external
+
+### 10.4 PR ↔ issue relationship
+
+Every PR should close at least one issue. In the PR body:
+
+```
+Closes #12
+Closes #15
+```
+
+On merge, GitHub auto-moves those issues to **Done**.
+
+---
+
+## 11. Authorship convention
+
+All people in equipo zigiella push under the **same GitHub account** (`zigiella`). To tell who did what in the repo history, each dev sets a **repo-local identity** (not global, so it doesn't leak into your other projects):
+
+```bash
+cd <path-to-sprout-repo>
+git config user.name "<Name>"
+git config user.email "<name>@sprout.local"
+```
+
+**Current identities:**
+
+| Role | `user.name` | `user.email` |
+|------|-------------|--------------|
+| Coordination | `Cambium` | `cambium@sprout.local` |
+| Dev Rhizome | `Xilema` | `xilema@sprout.local` |
+| Dev Pollen | `Floema` | `floema@sprout.local` |
+| Dev Meristem | `Meristem` | `meristem@sprout.local` |
+| Project lead | `Bea` | `bea@sprout.local` |
+
+**On the `.local` TLD:** reserved by IANA (RFC 6762) for multicast DNS and internal networks. **Does not collide with any real internet address** and makes it clear these are team-internal fictional identities.
+
+**Co-authorship on reviewed PRs (optional but recommended):**
+
+```
+Co-Authored-By: Cambium <cambium@sprout.local>
+```
+
+**Hard rules:**
+- **Never** rewrite history to change authorship on old commits. If something was pushed with the wrong identity, fix going forward; history is preserved.
+- **Never** use `--global` when setting these identities. Always repo-local.
+- When cloning the repo for the first time, setting identity is **the first step**, before the first commit.
+
+### 11.1 Multiple agents on the same clone
+
+If multiple agents (e.g., Cambium and Meristem in separate conversations) share the same clone, **`git config user.email` persists in `.git/config` and one agent may overwrite another's identity.**
+
+Solution: **don't persist identity** — pass it inline per commit with `-c`:
+
+```bash
+git -c user.name="Meristem" -c user.email="meristem@sprout.local" commit -m "..."
+```
+
+This applies only to that one command; `.git/config` stays untouched. Mandatory mode when more than one agent works on the same clone.
+
+If only one person/agent per clone (typical human-dev case), persistent `git config` is fine.
+
+---
+
+## 12. Board assignment flow
+
+**Principle:** self-assignment with a short protocol, no central assigner.
+
+### 12.1 Daily loop
+
+1. **Filter by your node.** On [the board](https://github.com/users/zigiella/projects/2) filter by label `node:<yours>`.
+2. **Pick the highest-priority** card from **Backlog**. Order: `priority:P0` → `P1` → `P2`. Tiebreaker: fewer open dependencies.
+3. **Self-assign the issue** and **drag the card** Backlog → In Progress. This double move is the public "I'm on this now" signal.
+4. **Work.** Small frequent commits, branch `feat/<zone>-<topic>` or `fix/<zone>-<topic>`.
+5. **Open PR** with `Closes #N` in the body. GitHub auto-moves the card to **Review**.
+6. **Review by Cambium.** Approve + merge → **Done** automatically. Requested changes → dev drags the card back to **In Progress** and works on the comments.
+
+### 12.2 Hard rule: one card per person in In Progress
+
+**Only one card** per person in In Progress at a time. If you need to block something to switch:
+- Add label `status:blocked`
+- Drag the card back to Backlog
+- Comment on the issue explaining what you're waiting on
+
+Prevents a board full of "in-progress" items nobody is touching.
+
+### 12.3 Special cases
+
+- **Nobody picks a card** (common with boring doc tasks): Cambium prioritizes it in a digest or takes it herself after 3 days.
+- **Urgent card that cuts the line:** Bea or Cambium bumps it to `priority:P0` and comments why. The next dev with capacity takes it before their normal backlog.
+- **Dependencies:** if #A blocks #B, write `Blocked by #A` in #B's body. Self-assign #B only when #A is Done.
+- **Dropping a task:** un-assign, leave a comment with the reason, drag card back to Backlog.
+
+### 12.4 The board is the truth
+
+If a private conversation (channel, DM, email) decides something about a task, that decision gets reflected in the issue (as a comment) or in `bitacora/`. **No "I thought you were doing that."** The card says who, the column says what phase, the PR says what.
+
+If a card sits >48h in In Progress with no commits or comments, Cambium asks on the issue (public question, not DM).
+
+---
+
+## 13. Repo language policy
+
+To minimize maintenance cost without closing the door to external contributors, we have two language layers:
+
+| Zone | Language | Why |
+|------|----------|-----|
+| `README.md` | **Bilingual** ES + EN | Public entry point. An outsider must understand the project in minutes. |
+| `CONTRIBUTING.md` | **Bilingual** ES + EN | An external contributor must be able to open a PR without speaking Spanish. |
+| `docs/` | **Spanish only** | Internal product specs. They move fast; translating them would go stale. |
+| `bitacora/` | **Spanish only** | Live internal journal. Bilingual would be pure overhead. |
+| Commits, issues, PRs | Free (ES or EN) | Clarity > consistency. Write in the language you think best in that day. |
+| Code (identifiers, comments) | Free, but consistent within a module | If a module starts in ES, stay in ES. Don't mix inside a file. |
+
+**Operational rule:** when editing `README.md` or `CONTRIBUTING.md`, update **both** language sections in the same PR. If only one is updated, open an issue to sync the other with `priority:P1`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,894 +1,111 @@
-<!-- Bilingual document · Spanish first, English below · See §13 for language policy -->
+<!-- Contributing guide · English first · Spanish version: CONTRIBUTING.es.md -->
 
-🇪🇸 **[Español](#contributing-es)** · 🇬🇧 **[English](#contributing-en)**
-
----
-
-<a id="contributing-es"></a>
-
-# Como trabajamos en Sprout
-
-Guia interna del **equipo zigiella** para trabajar en Sprout.
+🇬🇧 **English** · 🇪🇸 **[Español](CONTRIBUTING.es.md)**
 
 ---
 
-## 1. Filosofia de colaboracion
+# Contributing to Sprout
 
-Sprout es un proyecto del equipo zigiella. Durante el sprint MVP somos cuatro personas. Cada una trabaja en su area pero todo converge en una entrega coherente: **un sistema funcional + video de demostracion + documento de presentacion + repo publico**.
-
-Reglas blandas:
-- Si no aporta a los puntos de "lo que debe demostrar el video", probablemente sobra
-- Si no puedes explicar algo en una frase, probablemente esta mal formulado
-- Si algo es ambiguo en docs/, abre una entrada en bitacora/ y pregunta
+Thanks for your interest in Sprout. This document covers **two paths** to contribute, depending on whether you are part of the internal **zigiella** team or an external contributor.
 
 ---
 
-## 2. Roles y zonas del repo
+## Two paths to contribute
 
-| Rol | Zona principal | Zonas secundarias |
-|-----|---------------|-------------------|
-| Coordinacion y diseno | `docs/`, `bitacora/` | todas |
-| Dev Rhizome (Jetson) | `code/rhizome/`, `hardware/` | `docs/10_rhizome_spec.md` |
-| Dev Pollen (Android) | `code/pollen/` | `docs/11_pollen_spec.md` |
-| Dev Meristem + Fine-tune | `code/meristem/`, `code/finetune/` | `docs/12_meristem_spec.md` |
+### Path A — External contributors
 
-Writeup, video, research y demo los cubre el core del equipo (coordinacion + project lead).
+If you are not part of the zigiella team and you want to propose a change to the public Sprout repository:
 
----
+1. **Open an issue first** to discuss the change before you write code, especially for non-trivial features. Sprout has tight architectural invariants (see *Architectural invariants* below) that we don't want to break by accident.
+2. **Fork the repository** and create a branch from `main` (`fix/<short-topic>` or `feat/<short-topic>`).
+3. **Follow the code conventions** documented in [Code conventions](#code-conventions) below.
+4. **Run tests locally** before pushing (see *Reproducing locally* in the [README](README.md#reproduce-locally)).
+5. **Open a pull request** against `main` with a clear description of:
+   - What problem your change solves
+   - How it preserves the architectural invariants
+   - How you tested it
+6. **Be patient** — this is a small project; reviews may take a few days.
 
-## 3. Flujo de trabajo
+External pull requests are welcome but reviewed against the project's **architectural invariants** (below). We may decline contributions that introduce cloud dependencies, weaken the safety hierarchy, or break the determinism guarantees, even if they are otherwise high quality. Sprout is opinionated about *where* and *how* AI is used.
 
-### 3.1 Antes de empezar algo nuevo
-1. `git pull` en `main`
-2. Elegir un issue del [backlog](https://github.com/zigiella/sprout/issues) (ver §10) y asignartelo
-3. Leer la entrada mas reciente de `bitacora/`
-4. Revisar el doc relevante en `docs/`
-5. Crear rama `feat/<zona>-<tema>` o `fix/<zona>-<tema>` — **nunca** trabajar sobre `main`
+### Path B — Internal zigiella team
 
-### 3.2 Durante el trabajo
-- Commits pequenos y frecuentes
-- Mensaje de commit: `[zona] resumen corto` (ej: `[rhizome] humedad lectura via ADS1115`)
-- En el commit que cierra el issue, incluir `Closes #N` en el cuerpo para enlace automatico
+The internal team has a much more detailed operating manual (machine-shared workflow, identity-inline commits, three-point git verification, `Interrelaciones` template for cross-frente messages, repo-first rule, hot-file convention, etc.) that lives in [`CONTRIBUTING.es.md`](CONTRIBUTING.es.md). It's in Spanish because the team works in Spanish.
 
-### 3.3 Al terminar una pieza
-- Entrada en `bitacora/` con fecha, lo que se hizo, lo que queda, decisiones tomadas (**obligatorio antes de PR**)
-- Si hay cambio de arquitectura, actualizar el doc correspondiente en `docs/`
-- Abrir PR contra `main`. En la descripcion del PR: `Closes #N` + resumen + como probar
-- Review por Cambium antes de merge. Sin review, no hay merge
-
-### 3.4 Mensajes de coordinacion: inicio de dia, cierre y cross-frente
-
-> Convencion validada empiricamente dia 19-20 (Bea + Cambium): hacer explicitas
-> las dependencias entre miembras en los mensajes reduce overhead de
-> coordinacion y desbloquea decisiones que de otra forma quedan implicitas.
-
-**Cuando aplica esta convencion**:
-- Mensajes de inicio de dia donde varias miembras tienen dependencias cruzadas (Cambium los redacta y Bea los modula).
-- Mensajes cross-frente cuando una miembra bloquea o depende de otra.
-- Mensajes de cierre de dia cuando lo que se cerro afecta el plan del dia siguiente de otra miembra.
-
-**Plantilla obligatoria** cuando hay dependencias activas: cada mensaje incluye una seccion **"Interrelaciones"** con tres campos (omitir el que no aplique):
-
-```markdown
-### Interrelaciones [dia X o tema]
-
-- **ESPERAS DE [persona]**: [que necesitas concretamente] [cuando idealmente].
-  Sin eso, [que queda bloqueado].
-- **BLOQUEAS a [persona]**: [que le bloqueas] [hasta cuando].
-  Si no lo cierras, [coste para el otro frente].
-- **COORDINAS con [persona]**: [en que cosa] [modo: bidireccional, sincrono, asincrono].
-```
-
-**Campos opcionales** que se anaden cuando son relevantes:
-- **DESBLOQUEAS a [persona]** cuando [evento].
-- **APUNTAS a [persona]** sin urgencia, para que sepa.
-
-**Por que la plantilla**:
-1. Cada miembra ve sin esfuerzo a quien depende y a quien afecta.
-2. Las decisiones operativas pequenas que destrabar dependencias se hacen visibles y se cierran rapido.
-3. Reduce el ruido tipo "no sabia que estabas esperando esto" y los reproches retroactivos.
-4. Permite a la coordinadora (Bea) y a la tech lead (Cambium) hacer un mapa visual de bloqueos del dia con un vistazo a los mensajes.
-
-**Ejemplo real (mensaje a Floema dia 20)**:
-
-```markdown
-### Interrelaciones dia 20
-
-- **BLOQUEAS a Bea/Bract**: empaquetado release APK demo flavor + Appetize.io = live demo.
-  Sin tu APK, no hay live demo en submission. Plazo draft dia 22.
-- **ESPERAS DE Meristem**: implementacion servidor WS para que tu cliente WS pueda conectar.
-  Coordinacion bidireccional desde primera hora si quieres avanzar rapido.
-- **ESPERAS DE Endo**: que la fachada Jetson :13010 siga viva.
-  Si cae o tiene regresion, no puedes consolidar `RhizomeNetworkClient`.
-- **COORDINAS con Venation**: capturas Pollen UI bilingue en alta fidelidad para validacion copy
-  definitivo. Material pre-rodaje.
-```
-
-**Cuando NO hace falta la plantilla**:
-- Mensajes 1:1 sin dependencias cruzadas (Cambium → Bea sobre un detalle puntual).
-- Bitacoras self-contained donde la dependencia ya esta en el cuerpo y nombrarla aparte sumaria ruido.
-- Mensajes de pure-comunicacion sin acciones operativas.
+If you are reading this and you are part of the team, **please read `CONTRIBUTING.es.md` end to end**. The rules in there are the cumulative learning of 24+ days of operating in a shared machine — they exist because each one was learned the hard way.
 
 ---
 
-## 4. Bitacora: como escribir una entrada
+## Architectural invariants
 
-Cada entrada es un archivo en `bitacora/` con nombre:
+Sprout is built around five non-negotiables. Any contribution should preserve them:
 
-```
-YYYY-MM-DD_<tema-corto>_<autor>.md
-```
+1. **Local-first by design.** No node depends on the cloud to function. Internet is optional, never required for the core control loop.
+2. **Physical safety prevails.** The ESP32-S3 firmware can veto or modulate any action. No `PolicyPacket` from upper layers can reduce its hard limits — only recommend more conservative behavior.
+3. **Deterministic logic decides; the LLM only writes the rationale.** Critical decisions are auditable down to a concrete rule. Gemma 4 explains; the system decides.
+4. **Every intelligence has jurisdiction and expiry.** Every JSON contract carries explicit authority and TTL. Nothing is silently accepted forever.
+5. **Honesty over polish.** Refusal is a feature, not a failure. If the system isn't sure, it says so and asks the human to rephrase or step in.
 
-Ejemplos:
-- `2026-04-15_kickoff_cambium.md`
-- `2026-04-18_jetson-primer-arranque_ana.md`
-- `2026-04-22_pollen-sync-funcionando_maria.md`
-
-Plantilla en [bitacora/README.md](bitacora/README.md).
+A pull request that violates any of these will be discussed openly in the issue thread before being merged.
 
 ---
 
-## 5. Convenciones de codigo
+## Code conventions
 
 ### Python (Rhizome, Meristem, Simulator)
+
 - Python 3.11+
-- `ruff` para lint, `black` para formato
-- Type hints obligatorios en funciones publicas
-- Docstrings breves en espanol; comentarios en codigo en espanol
-- Tests minimos en `tests/` de cada subproyecto
+- `ruff` for linting, `black` for formatting
+- Type hints required on public functions
+- Brief docstrings (Spanish in code, English-friendly in API docs)
+- Minimal tests in `tests/` of each subproject
 
-### Android (Pollen)
-- Kotlin
+### Kotlin (Pollen Android)
+
 - Jetpack Compose
-- Gemma 4 via Google AI Edge / LiteRT (o llama.cpp como fallback)
-
-### Schemas JSON
-- Todos los schemas en `code/shared/schemas/`
-- Validacion via `pydantic` en Python, via `kotlinx.serialization` en Android
-
----
-
-## 6. Convenciones de naming
-
-### Archivos de docs
-- Numerados con prefijo de dos digitos (`00_`, `01_`, `10_`, etc.)
-- Kebab-case para nombres compuestos
-- Ejemplo: `docs/20_data_contracts.md`
-
-### Modelos de Gemma 4
-Seguir [guia oficial de naming de Google](https://ai.google/documents/32/External_Gemma_Model_Variant_Guidelines.pdf):
-- Formato: `sprout/sprout-<componente>-<modelo_base>-v<N>`
-- Ejemplo: `sprout/sprout-rhizome-e2b-v1`
-- Nunca poner "Gemma" en el nombre del modelo derivado (lo exige la licencia)
-
-### Branches de git
-- `main` = produccion / ultima version estable
-- `feat/<zona>-<descripcion>` = features en desarrollo
-- `fix/<zona>-<descripcion>` = bugfixes
-- Ejemplo: `feat/rhizome-audio-sensor`
-
-### Ejemplos canonicos (fixtures JSON)
-
-Viven en `code/shared/examples/`. Regla:
-
-- `<schema>.json` = fixture canonico unico por schema. Es el ejemplo de referencia,
-  el que se usa en tests y documentacion. Un solo archivo por schema.
-  Ejemplos: `rhizome_snapshot.json`, `weather_packet.json`, `policy_packet.json`.
-- `<schema>_<variante>.json` = variantes deliberadas que cubren un caso distinto
-  al canonico (estado de bloqueo, contradiccion, modo conservador, etc.).
-  Ejemplos: `decision_receipt_blocked.json`, `contradiction_alert_sensor_vs_vision.json`.
-
-**Regla dura:** si anades una variante, debe quedar claro en el nombre que varianta
-del canonico es. No metas campos nuevos al canonico solo para cubrir un caso;
-crea una variante.
-
----
-
-## 7. Secretos y credenciales
-
-**Nunca** commitear:
-- API keys (Google AI Studio, HuggingFace, etc.)
-- Certificados o tokens
-- Archivos `.env`
-
-Usar siempre variables de entorno. Plantilla en `.env.example` si aplica.
-
-Ya existe `.gitignore` con las entradas minimas. Si dudas, pregunta antes de hacer push.
-
----
-
-## 8. Dudas
-
-Abre una entrada en `bitacora/` con el tema `pregunta-<topic>` y etiqueta a Cambium. O en el canal que estemos usando el equipo.
-
----
-
-## 9. Checklist antes de cada push
-
-- [ ] El codigo corre sin errores
-- [ ] No hay credenciales expuestas
-- [ ] Si cambie un contrato de datos, actualice `code/shared/schemas/`
-- [ ] Si cambie arquitectura, actualice `docs/`
-- [ ] Hice entrada en `bitacora/` con fecha
-- [ ] El PR referencia el issue con `Closes #N`
-- [ ] Si toca una zona con CI (`code/pollen/**`, futuros Rhizome/Meristem), el CI esta **verde** antes de pedir review
-
-### 9.1 Regla dura sobre CI
-
-**Ningun PR se mergea con CI en rojo.** Sin excepciones. Si el CI falla:
-1. Lee los logs del workflow en GitHub Actions (pestaña "Checks" del PR)
-2. Reproduce localmente si tienes entorno, o itera con los logs si no
-3. Corrige, commitea, push. El CI se re-ejecuta automaticamente
-4. Solo cuando este verde, avisas para review
-
-Si el fallo del CI es del propio workflow (no del codigo), se abre issue aparte para arreglar el workflow. El PR afectado queda en hold.
-
-### 9.2 Operaciones git seguras en maquina compartida
-
-**Contexto.** Varias miembras del equipo (Bea, Corola, Cambium) comparten maquina, carpeta de trabajo y cuenta de GitHub. Eso introduce riesgos especificos que NO existen cuando cada miembra tiene su propio clone aislado:
-
-- Cuando una hace `git pull`, `git checkout` o `git stash` en la carpeta compartida, las otras se ven afectadas en su working tree.
-- Es muy facil que un commit termine en la rama equivocada porque el `HEAD` cambio entre operaciones.
-- Es muy facil que cambios reales se queden en un **stash silencioso** durante operaciones cross-rama y nunca lleguen al commit que crees haber hecho.
-
-Esto se ha sufrido empiricamente: Cambium 4 veces (dia 13), Meristem 5 veces (dias 12-13), Corola 1 vez (dia 15). Patron sistemico, no error individual.
-
-**Tres puntos de verificacion antes de cada commit.**
-
-Sustituye al checklist tradicional `git status` solo. Verifica los **tres** siempre:
-
-```bash
-git status                  # 1. archivos modificados/staged
-git branch --show-current   # 2. en que rama estoy realmente
-git stash list              # 3. stashes pendientes (especialmente con tu prefijo)
-```
-
-Si los tres confirman lo que esperabas, commitea. Si alguno te sorprende, **para y resuelve antes de commitear**. Tres comandos, dos segundos cada uno.
-
-**Stash con prefijo de autor obligatorio.**
-
-Cuando uses `git stash push`, **siempre con mensaje y prefijo de autor**:
-
-```bash
-git stash push -m "[corola] WIP guion v1.4 escena 7"
-git stash push -m "[cambium] WIP bitacora dia 16"
-```
-
-Eso permite identificar de un vistazo en `git stash list` que stash es de quien:
-
-```
-stash@{0}: On main: [corola] WIP guion v1.4 escena 7
-stash@{1}: On main: [cambium] WIP bitacora dia 16
-```
-
-Si ves un stash sin prefijo, es porque alguien olvido la convencion. **No lo tocas hasta confirmar de quien es**.
-
-**Una operacion atomica por sesion.**
-
-Cuando arranques sesion de trabajo:
-1. `git status` + `git branch --show-current` + `git stash list` (verificacion inicial)
-2. Si hay stash ajeno o working tree sucio, **paras y avisas en chat comun antes de continuar**
-3. Trabajo + commit + push
-4. Antes de pasar el turno: `git checkout main` y working tree limpio
-
-**No dejas working tree modificado para que la siguiente miembra arranque.** Si tu trabajo no esta listo para commit, lo dejas en stash con tu prefijo y la siguiente sabe que hay material tuyo pendiente.
-
-**Antes de cualquier `git checkout`.**
-
-Verifica `git stash list`. Si ves stash con prefijo ajeno, **no haces checkout que pueda alterar ese contexto sin avisar primero**. Si ves stash con tu prefijo de una sesion anterior, decide explicitamente: lo aplicas, lo descartas, o lo dejas y navegas con cuidado.
-
-**Resolucion si el commit termino en rama equivocada.**
-
-Procedimiento conocido por el equipo (lo hemos usado varias veces sin perdida de datos):
-
-```bash
-git reset --soft HEAD~1     # deshace commit, mantiene cambios en staging
-git stash push -m "[nombre] commit a mover"
-git checkout main           # o la rama correcta
-git stash pop
-git commit -m "..."         # commit en rama correcta
-git push origin main
-```
-
-Si el commit ya esta pusheado a la rama equivocada, abrir issue y resolver con `git revert` (no force-push).
-
-**Fuera de scope post-hackathon.**
-
-A futuro, **`git worktree`** es la solucion tecnica correcta a esta friccion: un solo `.git/` central, varios working directories aislados, una miembra por carpeta. No lo implementamos durante el hackathon porque cambiar setup en mitad del proyecto introduce mas riesgo que el que mitiga. Apuntar para revision post-demo.
-
----
-
-## 10. Backlog y tablero visual
-
-El backlog vive en **GitHub Issues + Projects**.
-
-### 10.1 Donde verlo
-- **Lista de issues:** https://github.com/zigiella/sprout/issues
-- **Tablero kanban "Sprout Backlog":** https://github.com/users/zigiella/projects/2 — cuatro columnas: **Backlog / In Progress / Review / Done**. Arrastrar tarjeta cambia estado.
-- **Vista Table:** el mismo proyecto con vista de spreadsheet para priorizar en bloque.
-- **GitHub Mobile** (iOS/Android): misma vista Board, desde el sofa.
-
-### 10.2 Como usar el backlog
-
-**Abrir un issue nuevo:**
-- Titulo imperativo, corto, sin jerga interna. "Implementar schemas Pydantic" > "Schemas".
-- **Zero referencias externas** al hackathon, jurado, premios, deadline. El repo es publico.
-- Body con: contexto, criterios de aceptacion (checkboxes), dependencias, referencia a docs.
-- Labels obligatorios: **uno de `node:*`** y **uno de `priority:*`**. Opcionales: `area:*`, `status:blocked`.
-
-**Asignarse un issue:**
-- Solo asignarse lo que vas a empezar esa misma sesion. Si dudas, dejalo sin asignar.
-- Si lo abandonas, quitate de asignada y deja comentario con el por que.
-
-**Cerrar un issue:**
-- Solo se cierra por merge de PR que lo referencia con `Closes #N`.
-- No cerrar "a mano" salvo duplicados o invalidos (con comentario explicativo).
-
-### 10.3 Taxonomia de labels
-
-**Nodo (uno obligatorio):**
-- `node:rhizome` — Jetson, parcela
-- `node:pollen` — Android, itinerante
-- `node:meristem` — laptop, estrategico
-- `node:cambium` — coordinacion, diseno, supervision
-
-**Area (opcional, puede haber varias):**
-- `area:docs` — documentacion de arquitectura
-- `area:infra` — repo, CI, tooling
-- `area:research` — benchmarks, evaluacion
-- `area:firmware` — ESP32, capa fisica
-
-**Prioridad (una obligatoria):**
-- `priority:P0` — critico, bloquea a alguien
-- `priority:P1` — importante, no bloqueante
-- `priority:P2` — nice to have
-
-**Estado (opcional):**
-- `status:blocked` — esperando algo externo
-
-### 10.4 Relacion PR ↔ issue
-
-Cada PR deberia cerrar al menos un issue. En el cuerpo del PR:
-
-```
-Closes #12
-Closes #15
-```
-
-Al mergear, GitHub mueve esos issues a **Done** automaticamente.
-
----
-
-## 11. Convencion de autoria
-
-Todas las personas del equipo zigiella trabajamos bajo la **misma cuenta de GitHub** (`zigiella`). Para que en el historial del repo se pueda distinguir quien hizo que, cada dev configura **identidad local al repo** (no global, para no afectar otros proyectos tuyos):
-
-```bash
-cd <ruta-al-repo-sprout>
-git config user.name "<Nombre>"
-git config user.email "<nombre>@sprout.local"
-```
-
-**Identidades vigentes:**
-
-| Rol | `user.name` | `user.email` |
-|-----|-------------|--------------|
-| Coordinacion | `Cambium` | `cambium@sprout.local` |
-| Dev Rhizome | `Xilema` | `xilema@sprout.local` |
-| Dev Pollen | `Floema` | `floema@sprout.local` |
-| Dev Meristem | `Meristem` | `meristem@sprout.local` |
-| Project lead | `Bea` | `bea@sprout.local` |
-
-**Sobre la TLD `.local`:** es una TLD reservada por IANA (RFC 6762) para uso multicast DNS y redes internas. **No colisiona con ninguna direccion real de internet** y deja claro que son identidades ficticias del equipo.
-
-**Commits con coautoria (opcional pero recomendado para PR revisados):**
-
-```
-Co-Authored-By: Cambium <cambium@sprout.local>
-```
-
-**Reglas duras:**
-- **Nunca** reescribir historia para cambiar autoria en commits viejos. Si se subio algo con identidad equivocada, se corrige de aqui en adelante; el historial se respeta.
-- **Nunca** usar `--global` al configurar estas identidades. Son locales al repo.
-- Al clonar el repo por primera vez, configurar identidad es **el primer paso**, antes del primer commit.
-
-### 11.1 Multi-agente sobre el mismo clone
-
-Si varias agentes (p.ej. Cambium y Meristem en conversaciones separadas) comparten el mismo clone del repo, **`git config user.email` persiste en `.git/config` y una agente puede pisar la identidad de otra.**
-
-Solucion: **no persistir la identidad**, pasarla inline en cada commit con `-c`:
-
-```bash
-git -c user.name="Meristem" -c user.email="meristem@sprout.local" commit -m "..."
-```
-
-Esto solo aplica a ese comando, no toca `.git/config`. Es el modo obligatorio cuando hay mas de una agente trabajando en el mismo clone.
-
-Si solo hay una persona/agente por clone (caso tipico de dev humana), el `git config` persistente esta bien.
-
----
-
-## 12. Flujo de asignacion en el tablero
-
-**Principio:** auto-asignacion con protocolo corto, sin asignador central.
-
-### 12.1 Ciclo diario
-
-1. **Filtrar por tu nodo.** En [el tablero](https://github.com/users/zigiella/projects/2) aplicar filtro por label `node:<tuyo>`.
-2. **Elegir la de mayor prioridad** de la columna **Backlog**. Orden: `priority:P0` (rojas) → `priority:P1` (amarillas) → `priority:P2` (grises). Empate: menos dependencias abiertas.
-3. **Auto-asignarse el issue** (boton "assign yourself" en el issue) **y arrastrar la tarjeta** de Backlog a **In Progress**. Ese doble movimiento es la señal publica de "estoy con esto ahora".
-4. **Trabajar.** Commits pequenos y frecuentes, rama `feat/<zona>-<tema>` o `fix/<zona>-<tema>`.
-5. **Abrir PR** con `Closes #N` en el cuerpo. GitHub mueve automaticamente la tarjeta a **Review**.
-6. **Review por Cambium.** Si aprueba y mergea, la tarjeta va a **Done** automaticamente. Si pide cambios, la dev la arrastra de vuelta a **In Progress** y trabaja sobre los comentarios.
-
-### 12.2 Regla dura: una tarjeta por persona en In Progress
-
-**Solo una tarjeta** por persona puede estar en In Progress al mismo tiempo. Si necesitas bloquear algo para trabajar en otra cosa:
-- Añades label `status:blocked` al issue
-- Arrastras la tarjeta de vuelta a Backlog
-- Comentas en el issue explicando que esperas
-
-Evita que el tablero se llene de "en progreso" que nadie esta tocando.
-
-### 12.3 Casos especiales
-
-- **Tarjeta que nadie coge** (suele pasar con docs aburridos): Cambium prioriza en digest o la coge ella misma pasados 3 dias.
-- **Tarjeta urgente que debe cortar la cola:** Bea o Cambium añaden/suben a `priority:P0` y comentan en el issue el por que. La dev con hueco la coge antes que su backlog normal.
-- **Dependencias:** si #A bloquea #B, en #B se pone `Blocked by #A` en el cuerpo. Solo se puede auto-asignar #B cuando #A esta en Done.
-- **Abandono de tarea:** quitarse de asignada, dejar comentario en el issue con el por que, arrastrar tarjeta de vuelta a Backlog.
-
-### 12.4 El tablero es la verdad
-
-Si una conversacion privada (canal, DM, mail) decide algo sobre una tarea, esa decision se refleja en el issue (como comentario) o en bitacora. **No hay "yo pense que tu estabas haciendo eso".** La tarjeta dice quien, la columna dice en que fase, el PR dice el que.
-
-Si una tarjeta lleva >48h en In Progress sin commits ni comentarios, Cambium pregunta en el issue (pregunta publica, no DM).
-
----
-
-## 13. Idiomas del repo
-
-Para minimizar coste de mantenimiento sin cerrar la puerta a gente externa, tenemos dos capas de idiomas:
-
-| Zona | Idioma | Por que |
-|------|--------|---------|
-| `README.md` | **Bilingue** ES + EN | Puerta de entrada publica. Una persona externa debe poder entender el proyecto en minutos. |
-| `CONTRIBUTING.md` | **Bilingue** ES + EN | Una contribuidora externa debe poder abrir un PR sin hablar espanol. |
-| `docs/` | **Solo ES** | Specs de producto internos. Evolucionan rapido; traducirlos se desincroniza. |
-| `bitacora/` | **Solo ES** | Diario interno del equipo, en vivo. Mantener bilingue seria puro overhead. |
-| Commits, issues, PRs | Libre (ES o EN) | Claridad > consistencia. Cada persona escribe en el idioma en que piense mejor ese dia. |
-| Codigo (identifiers, comentarios) | Libre, pero consistente dentro de un modulo | Si un modulo empieza en ES, seguir en ES. No mezclar en el mismo archivo. |
-
-**Regla operacional:** al tocar `README.md` o `CONTRIBUTING.md`, actualizar **ambas** secciones de idioma en el mismo PR. Si solo se actualiza una, se abre issue para sincronizar la otra y se marca `priority:P1`.
-
----
----
-
-<a id="contributing-en"></a>
-
-# How we work on Sprout
-
-Internal guide of **equipo zigiella** for working on Sprout.
-
----
-
-## 1. Collaboration philosophy
-
-Sprout is a project by equipo zigiella. During the MVP sprint we are four people. Each owns an area but everything converges on a coherent delivery: **a working system + demo video + writeup + public repo**.
-
-Soft rules:
-- If it doesn't feed into "what the video must show," it probably doesn't belong
-- If you can't explain something in one sentence, it's probably not well framed
-- If something is ambiguous in `docs/`, open a `bitacora/` entry and ask
-
----
-
-## 2. Roles and repo zones
-
-| Role | Primary zone | Secondary |
-|------|-------------|-----------|
-| Coordination & design | `docs/`, `bitacora/` | any |
-| Dev Rhizome (Jetson) | `code/rhizome/`, `hardware/` | `docs/10_rhizome_spec.md` |
-| Dev Pollen (Android) | `code/pollen/` | `docs/11_pollen_spec.md` |
-| Dev Meristem + Fine-tune | `code/meristem/`, `code/finetune/` | `docs/12_meristem_spec.md` |
-
-Writeup, video, research, and demo are covered by the core team (coordination + project lead).
-
----
-
-## 3. Workflow
-
-### 3.1 Before starting something new
-1. `git pull` on `main`
-2. Pick an issue from the [backlog](https://github.com/zigiella/sprout/issues) (see §10) and assign it to yourself
-3. Read the latest entry in `bitacora/`
-4. Review the relevant doc in `docs/` (Spanish)
-5. Create a branch `feat/<zone>-<topic>` or `fix/<zone>-<topic>` — **never** work directly on `main`
-
-### 3.2 While working
-- Small, frequent commits
-- Commit message: `[zone] short summary` (e.g. `[rhizome] moisture reading via ADS1115`)
-- On the commit that closes the issue, include `Closes #N` in the body for auto-link
-
-### 3.3 When a piece is done
-- Entry in `bitacora/` (in Spanish) with date, what was done, what's pending, decisions taken — **mandatory before PR**
-- If architecture changed, update the matching doc in `docs/`
-- Open a PR against `main`. PR body: `Closes #N` + summary + how to test
-- Review by Cambium before merge. No review, no merge.
-
-### 3.4 Coordination messages: day-start, day-close and cross-frontier
-
-> Convention validated empirically days 19-20 (Bea + Cambium): making
-> dependencies between team members explicit reduces coordination overhead
-> and unblocks decisions that would otherwise stay implicit.
-
-**When this convention applies**:
-- Day-start messages where several team members have cross dependencies (Cambium drafts, Bea modulates).
-- Cross-frontier messages when one team member blocks or depends on another.
-- Day-close messages when what closed affects another member's next-day plan.
-
-**Mandatory template** when active dependencies exist: each message includes an **"Interrelaciones"** (Spanish) section with three fields (omit any that don't apply):
-
-```markdown
-### Interrelaciones [day X or topic]
-
-- **ESPERAS DE [person]**: [what you need concretely] [when ideally].
-  Without it, [what stays blocked].
-- **BLOQUEAS a [person]**: [what you block them on] [until when].
-  If you don't close it, [cost to the other frontier].
-- **COORDINAS con [person]**: [on what] [mode: bidirectional, sync, async].
-```
-
-**Optional fields** added when relevant:
-- **DESBLOQUEAS a [person]** when [event].
-- **APUNTAS a [person]** without urgency, just so they know.
-
-**Why the template**:
-1. Each member sees without effort whom they depend on and whom they affect.
-2. Small operational decisions that unblock dependencies become visible and close fast.
-3. Reduces "I didn't know you were waiting on this" noise and retroactive blame.
-4. Lets the coordinator (Bea) and tech lead (Cambium) make a visual blocking map of the day at a glance.
-
-**When the template is NOT needed**:
-- 1:1 messages without cross dependencies.
-- Self-contained bitacoras where the dependency is already in the body.
-- Pure-communication messages without operational actions.
-
-(Section heading `Interrelaciones` stays in Spanish in EN messages too — it's a project term used as-is.)
-
----
-
-## 4. Bitacora: how to write an entry
-
-Each entry is a file in `bitacora/` (Spanish-only) with the name:
-
-```
-YYYY-MM-DD_<short-topic>_<author>.md
-```
-
-Examples:
-- `2026-04-15_kickoff_cambium.md`
-- `2026-04-18_jetson-primer-arranque_ana.md`
-
-Template in [bitacora/README.md](bitacora/README.md).
-
----
-
-## 5. Code conventions
-
-### Python (Rhizome, Meristem, Simulator)
-- Python 3.11+
-- `ruff` for lint, `black` for formatting
-- Type hints mandatory on public functions
-- Short docstrings; comments in the module's original language
-- Minimum tests in `tests/` per subproject
-
-### Android (Pollen)
-- Kotlin
-- Jetpack Compose
-- Gemma 4 via Google AI Edge / LiteRT (llama.cpp as fallback)
+- Gemma 4 via Google AI Edge / LiteRT (with `llama.cpp` as fallback)
 
 ### JSON schemas
+
 - All schemas live in `code/shared/schemas/`
-- Validation via `pydantic` (Python), `kotlinx.serialization` (Android)
+- Validated via `pydantic` in Python, `kotlinx.serialization` in Kotlin
 
----
+### Naming Gemma 4 models
 
-## 6. Naming conventions
+Follow Google's [official naming guidelines](https://ai.google/documents/32/External_Gemma_Model_Variant_Guidelines.pdf):
 
-### Doc filenames
-- Two-digit prefix (`00_`, `01_`, `10_`, ...)
-- Kebab-case for compound names
-- Example: `docs/20_data_contracts.md`
-
-### Gemma 4 model variants
-Follow [Google's naming guide](https://ai.google/documents/32/External_Gemma_Model_Variant_Guidelines.pdf):
-- Format: `sprout/sprout-<component>-<base_model>-v<N>`
+- Pattern: `sprout/sprout-<component>-<model_base>-v<N>`
 - Example: `sprout/sprout-rhizome-e2b-v1`
-- Never put "Gemma" in the derived model name (license requirement)
+- Never use "Gemma" as the prefix of a derived model name (license requirement)
 
-### Git branches
-- `main` = production / last stable
-- `feat/<zone>-<desc>` = features
-- `fix/<zone>-<desc>` = bugfixes
-- Example: `feat/rhizome-audio-sensor`
+### Branches
 
-### Canonical examples (JSON fixtures)
+- `main` = production / latest stable
+- `feat/<topic>` = features in development
+- `fix/<topic>` = bugfixes
+- `docs/<topic>` = docs-only changes
 
-Live in `code/shared/examples/`. Rule:
+### Commit messages
 
-- `<schema>.json` = single canonical fixture per schema. The reference example used in tests and docs. Exactly one per schema. Examples: `rhizome_snapshot.json`, `weather_packet.json`.
-- `<schema>_<variant>.json` = deliberate variants covering a non-canonical case (blocked state, contradiction, conservative mode, etc.). Examples: `decision_receipt_blocked.json`.
-
-**Hard rule:** if you add a variant, its name must make the variation clear. Don't add new fields to the canonical example just to cover a case — create a variant.
+- `[zone] short summary` (e.g., `[rhizome] add humidity reading via ADS1115`)
+- For commits that close an issue, include `Closes #N` in the body
 
 ---
 
-## 7. Secrets and credentials
+## Code of conduct
 
-**Never** commit:
-- API keys (Google AI Studio, HuggingFace, etc.)
-- Certificates or tokens
-- `.env` files
-
-Use environment variables. Template in `.env.example` when applicable.
-
-`.gitignore` already covers the basics. When in doubt, ask before pushing.
+Be kind, be precise, and be patient. The project is built by a small team under a tight deadline; we appreciate thoughtful contributions and we'll respond as quickly as we can.
 
 ---
 
-## 8. Questions
+## License
 
-Open a `bitacora/` entry with the topic `pregunta-<topic>` and tag Cambium. Or use the team's active channel.
+Apache 2.0 (see [`LICENSE`](LICENSE)). Same as Gemma 4.
 
----
+## Attribution
 
-## 9. Pre-push checklist
+Sprout uses Gemma 4 models by Google. **Gemma is a trademark of Google LLC.** This project is not affiliated with or endorsed by Google.
 
-- [ ] Code runs without errors
-- [ ] No exposed credentials
-- [ ] If a data contract changed, updated `code/shared/schemas/`
-- [ ] If architecture changed, updated `docs/`
-- [ ] Bitacora entry written (with date)
-- [ ] PR references the issue with `Closes #N`
-- [ ] If touching a zone with CI (`code/pollen/**`, future Rhizome/Meristem), CI is **green** before requesting review
+## Questions
 
-### 9.1 Hard rule on CI
-
-**No PR merges on red CI. No exceptions.** If CI fails:
-1. Read the workflow logs (PR's "Checks" tab in GitHub Actions)
-2. Reproduce locally if you can, or iterate from the logs if you can't
-3. Fix, commit, push. CI re-runs automatically
-4. Only when green, request review
-
-If the failure is in the workflow itself (not the code), open a separate issue for the workflow. The affected PR stays on hold.
-
-### 9.2 Safe git operations on a shared machine
-
-**Context.** Several team members (Bea, Corola, Cambium) share machine, working folder and GitHub account. This introduces specific risks that do NOT exist when each member has their own isolated clone:
-
-- When one runs `git pull`, `git checkout` or `git stash` in the shared folder, the others see their working tree affected.
-- It is very easy for a commit to land on the wrong branch because `HEAD` changed between operations.
-- It is very easy for real changes to remain in a **silent stash** during cross-branch operations and never reach the commit you thought you made.
-
-This has been suffered empirically: Cambium 4 times (day 13), Meristem 5 times (days 12-13), Corola 1 time (day 15). Systemic pattern, not individual error.
-
-**Three verification points before each commit.**
-
-Replaces the traditional `git status` only. Always verify the **three**:
-
-```bash
-git status                  # 1. modified/staged files
-git branch --show-current   # 2. which branch I am really on
-git stash list              # 3. pending stashes (especially with your prefix)
-```
-
-If all three confirm what you expected, commit. If any surprises you, **stop and resolve before committing**. Three commands, two seconds each.
-
-**Stash with author prefix mandatory.**
-
-When using `git stash push`, **always with message and author prefix**:
-
-```bash
-git stash push -m "[corola] WIP guion v1.4 escena 7"
-git stash push -m "[cambium] WIP bitacora dia 16"
-```
-
-This allows identifying at a glance in `git stash list` which stash belongs to whom:
-
-```
-stash@{0}: On main: [corola] WIP guion v1.4 escena 7
-stash@{1}: On main: [cambium] WIP bitacora dia 16
-```
-
-If you see a stash without prefix, someone forgot the convention. **Don't touch it until you confirm whose it is**.
-
-**One atomic operation per session.**
-
-When starting a work session:
-1. `git status` + `git branch --show-current` + `git stash list` (initial verification)
-2. If there is a foreign stash or dirty working tree, **stop and notify in common chat before continuing**
-3. Work + commit + push
-4. Before passing the turn: `git checkout main` and clean working tree
-
-**Don't leave a modified working tree for the next member to start.** If your work isn't ready to commit, leave it in stash with your prefix and the next member knows there's pending material from you.
-
-**Before any `git checkout`.**
-
-Verify `git stash list`. If you see a stash with foreign prefix, **don't checkout that may alter that context without notifying first**. If you see a stash with your prefix from a previous session, decide explicitly: apply it, discard it, or leave it and navigate with care.
-
-**Recovery if commit landed on wrong branch.**
-
-Procedure known by the team (we've used it several times without data loss):
-
-```bash
-git reset --soft HEAD~1     # undoes commit, keeps changes in staging
-git stash push -m "[name] commit to move"
-git checkout main           # or correct branch
-git stash pop
-git commit -m "..."         # commit on correct branch
-git push origin main
-```
-
-If the commit was already pushed to the wrong branch, open issue and resolve with `git revert` (not force-push).
-
-**Out of scope, post-hackathon.**
-
-In the future, **`git worktree`** is the correct technical solution to this friction: one central `.git/`, several isolated working directories, one member per folder. We don't implement it during the hackathon because changing setup mid-project introduces more risk than it mitigates. Earmark for post-demo review.
-
----
-
-## 10. Backlog and visual board
-
-The backlog lives in **GitHub Issues + Projects**.
-
-### 10.1 Where to see it
-- **Issues list:** https://github.com/zigiella/sprout/issues
-- **Kanban "Sprout Backlog":** https://github.com/users/zigiella/projects/2 — four columns: **Backlog / In Progress / Review / Done**. Dragging a card changes state.
-- **Table view:** same project, spreadsheet-like, for bulk prioritization.
-- **GitHub Mobile** (iOS/Android): same Board view, from the couch.
-
-### 10.2 How to use the backlog
-
-**Open a new issue:**
-- Imperative title, short, no internal jargon. "Implement Pydantic schemas" > "Schemas".
-- **Zero external references** to hackathons, juries, prizes, deadlines. The repo is public.
-- Body with: context, acceptance criteria (checkboxes), dependencies, reference to docs.
-- Required labels: **one `node:*`** and **one `priority:*`**. Optional: `area:*`, `status:blocked`.
-
-**Assign yourself an issue:**
-- Only self-assign what you'll start in the same session. When in doubt, leave it unassigned.
-- If you drop it, un-assign and leave a comment with the reason.
-
-**Close an issue:**
-- Only by PR merge referencing it with `Closes #N`.
-- No manual closes except for duplicates or invalids (with explanatory comment).
-
-### 10.3 Label taxonomy
-
-**Node (one required):**
-- `node:rhizome`, `node:pollen`, `node:meristem`, `node:cambium`
-
-**Area (optional, multiple allowed):**
-- `area:docs`, `area:infra`, `area:research`, `area:firmware`
-
-**Priority (one required):**
-- `priority:P0` — critical, blocks someone
-- `priority:P1` — important, non-blocking
-- `priority:P2` — nice to have
-
-**State (optional):**
-- `status:blocked` — waiting on something external
-
-### 10.4 PR ↔ issue relationship
-
-Every PR should close at least one issue. In the PR body:
-
-```
-Closes #12
-Closes #15
-```
-
-On merge, GitHub auto-moves those issues to **Done**.
-
----
-
-## 11. Authorship convention
-
-All people in equipo zigiella push under the **same GitHub account** (`zigiella`). To tell who did what in the repo history, each dev sets a **repo-local identity** (not global, so it doesn't leak into your other projects):
-
-```bash
-cd <path-to-sprout-repo>
-git config user.name "<Name>"
-git config user.email "<name>@sprout.local"
-```
-
-**Current identities:**
-
-| Role | `user.name` | `user.email` |
-|------|-------------|--------------|
-| Coordination | `Cambium` | `cambium@sprout.local` |
-| Dev Rhizome | `Xilema` | `xilema@sprout.local` |
-| Dev Pollen | `Floema` | `floema@sprout.local` |
-| Dev Meristem | `Meristem` | `meristem@sprout.local` |
-| Project lead | `Bea` | `bea@sprout.local` |
-
-**On the `.local` TLD:** reserved by IANA (RFC 6762) for multicast DNS and internal networks. **Does not collide with any real internet address** and makes it clear these are team-internal fictional identities.
-
-**Co-authorship on reviewed PRs (optional but recommended):**
-
-```
-Co-Authored-By: Cambium <cambium@sprout.local>
-```
-
-**Hard rules:**
-- **Never** rewrite history to change authorship on old commits. If something was pushed with the wrong identity, fix going forward; history is preserved.
-- **Never** use `--global` when setting these identities. Always repo-local.
-- When cloning the repo for the first time, setting identity is **the first step**, before the first commit.
-
-### 11.1 Multiple agents on the same clone
-
-If multiple agents (e.g., Cambium and Meristem in separate conversations) share the same clone, **`git config user.email` persists in `.git/config` and one agent may overwrite another's identity.**
-
-Solution: **don't persist identity** — pass it inline per commit with `-c`:
-
-```bash
-git -c user.name="Meristem" -c user.email="meristem@sprout.local" commit -m "..."
-```
-
-This applies only to that one command; `.git/config` stays untouched. Mandatory mode when more than one agent works on the same clone.
-
-If only one person/agent per clone (typical human-dev case), persistent `git config` is fine.
-
----
-
-## 12. Board assignment flow
-
-**Principle:** self-assignment with a short protocol, no central assigner.
-
-### 12.1 Daily loop
-
-1. **Filter by your node.** On [the board](https://github.com/users/zigiella/projects/2) filter by label `node:<yours>`.
-2. **Pick the highest-priority** card from **Backlog**. Order: `priority:P0` → `P1` → `P2`. Tiebreaker: fewer open dependencies.
-3. **Self-assign the issue** and **drag the card** Backlog → In Progress. This double move is the public "I'm on this now" signal.
-4. **Work.** Small frequent commits, branch `feat/<zone>-<topic>` or `fix/<zone>-<topic>`.
-5. **Open PR** with `Closes #N` in the body. GitHub auto-moves the card to **Review**.
-6. **Review by Cambium.** Approve + merge → **Done** automatically. Requested changes → dev drags the card back to **In Progress** and works on the comments.
-
-### 12.2 Hard rule: one card per person in In Progress
-
-**Only one card** per person in In Progress at a time. If you need to block something to switch:
-- Add label `status:blocked`
-- Drag the card back to Backlog
-- Comment on the issue explaining what you're waiting on
-
-Prevents a board full of "in-progress" items nobody is touching.
-
-### 12.3 Special cases
-
-- **Nobody picks a card** (common with boring doc tasks): Cambium prioritizes it in a digest or takes it herself after 3 days.
-- **Urgent card that cuts the line:** Bea or Cambium bumps it to `priority:P0` and comments why. The next dev with capacity takes it before their normal backlog.
-- **Dependencies:** if #A blocks #B, write `Blocked by #A` in #B's body. Self-assign #B only when #A is Done.
-- **Dropping a task:** un-assign, leave a comment with the reason, drag card back to Backlog.
-
-### 12.4 The board is the truth
-
-If a private conversation (channel, DM, email) decides something about a task, that decision gets reflected in the issue (as a comment) or in `bitacora/`. **No "I thought you were doing that."** The card says who, the column says what phase, the PR says what.
-
-If a card sits >48h in In Progress with no commits or comments, Cambium asks on the issue (public question, not DM).
-
----
-
-## 13. Repo language policy
-
-To minimize maintenance cost without closing the door to external contributors, we have two language layers:
-
-| Zone | Language | Why |
-|------|----------|-----|
-| `README.md` | **Bilingual** ES + EN | Public entry point. An outsider must understand the project in minutes. |
-| `CONTRIBUTING.md` | **Bilingual** ES + EN | An external contributor must be able to open a PR without speaking Spanish. |
-| `docs/` | **Spanish only** | Internal product specs. They move fast; translating them would go stale. |
-| `bitacora/` | **Spanish only** | Live internal journal. Bilingual would be pure overhead. |
-| Commits, issues, PRs | Free (ES or EN) | Clarity > consistency. Write in the language you think best in that day. |
-| Code (identifiers, comments) | Free, but consistent within a module | If a module starts in ES, stay in ES. Don't mix inside a file. |
-
-**Operational rule:** when editing `README.md` or `CONTRIBUTING.md`, update **both** language sections in the same PR. If only one is updated, open an issue to sync the other with `priority:P1`.
+Open an issue, or — if you are part of the zigiella team — write a `bitacora/` entry following the convention in [`CONTRIBUTING.es.md §4`](CONTRIBUTING.es.md).

--- a/video/cartelas_presentadoras_nodos.md
+++ b/video/cartelas_presentadoras_nodos.md
@@ -1,0 +1,63 @@
+# Cartelas presentadoras de nodos — EN master
+
+**Status:** firme tras decisión Bea día 24 (EN-only, sin versión castellana en cartela). El subtítulo ES dub aparece como subtitle track separado en montaje, no en la cartela.
+
+**Estructura:** 3 líneas — nombre · qué hace · detalle. Eco directo con cartela invariante E7 *"Physical layer prevails. Rhizome arbitrates. Pollen mediates. Meristem refines."* — los 3 verbos (`arbitrates / mediates / refines`) aparecen aquí también, así cuando el espectador llega a E7 los reconoce y la frase compleja golpea.
+
+**Tipografía sugerida (Bract / Venation deciden):**
+- Línea 1: nombre, peso bold, grande.
+- Línea 2: itálica o peso medio (verbo de jerarquía).
+- Línea 3: pequeña, monospace o sans-condensada (ficha técnica). Idéntica estructura las tres → sensación de paridad cross-nodo.
+- Color: paleta sobria del sistema visual Venation. **`signal.seed` (#C5F26B)** se reserva para el dato "vivo" en pantalla durante la presentación de cada nodo (LED, pulso, campo `final_action` resaltado) — no para texto.
+
+---
+
+## Cartela pre-Rhizome
+
+> **Rhizome.**
+> *Arbitrates the plot.*
+> *Edge node · Gemma 4 E2B · llama.cpp · Jetson Orin Nano + ESP32-S3 · minutes.*
+
+## Cartela pre-Pollen
+
+> **Pollen.**
+> *Mediates the visit.*
+> *Edge node · Gemma 4 E4B · LiteRT-LM · Android · visit TTL.*
+
+## Cartela pre-Meristem
+
+> **Meristem.**
+> *Refines the policy.*
+> *Domestic node · Gemma 4 E4B · llama.cpp · home laptop · days.*
+
+---
+
+## Decisiones aplicadas (resumen)
+
+| Cambio | Razón |
+|--------|-------|
+| Estructura **3 líneas** | Bea día 24: nombre · qué hace · detalle. |
+| **EN-only** en cartela | Bea día 24: el subtítulo ES dub viene en subtitle track separado del montaje, no en la cartela. |
+| **"Edge node"** para Rhizome y Pollen, **"Domestic node"** para Meristem | Distinción narrativa: Rhizome y Pollen viven en el campo / bolsillo del agricultor (edge). Meristem vive en la cocina (doméstico). Bea día 24 rechazó "Slow brain" — *"slow rebaja, no crees?"*. |
+| **+ ESP32-S3** en cartela Rhizome | Bea día 24: enfatizar que Rhizome no es solo Jetson, es Jetson **acoplado** al chip de seguridad. |
+| Verbos `arbitrates / mediates / refines` en línea 2 | Eco con cartela invariante E7 + cita Xilema día 13 (jerarquía) + writeup §3. |
+| **No repetir trademark Gemma** en cada cartela | La microcartela de cierre del video (Z99) ya lleva *"Built on Gemma 4 by Google. Gemma is a trademark of Google LLC."* Suficiente legalmente. |
+
+## Si Bea decide añadir cartela ESP32
+
+Opcional — Cambium la propone día 23 como **plan B** si Corola/Bract creen que refuerza la jerarquía visual antes del wow moment ESP32 SAFE LIMIT (E3):
+
+> **ESP32-S3.**
+> *Vetoes physically.*
+> *Safety coprocessor · ESP-IDF firmware · 5 hard rules · physical authority.*
+
+Voto Cambium: **opcional**. La cartela invariante E7 ya cubre la pieza ESP32 con la frase entera. Sumar una cartela aparte podría ser redundante. Decisión Bea + Corola.
+
+---
+
+## Atribución / Attribution
+
+Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.
+This project is not affiliated with or endorsed by Google.
+
+License: Apache 2.0 (see [`LICENSE`](../LICENSE)). Same as Gemma 4.

--- a/writeup/draft.md
+++ b/writeup/draft.md
@@ -1,8 +1,8 @@
-# Sprout — writeup (primera versión completa, día 21)
+# Sprout — writeup (día 24)
 
 > **Autores:** Cambium + Bea.
-> **Estado:** primera versión completa de §0 + §4-§10 (día 21). §1-§3 cerradas previas. §7 placeholder hasta rodaje.
-> **Word count target final:** 1500 palabras (Kaggle limit). Versión actual ~1500-1700, recorte final día 28-29.
+> **Estado:** primera versión completa de §0 + §1-§9 (día 24). §7 Demo eliminada — la landing demo es autoexplicativa.
+> **Word count target final:** 1500 palabras (Kaggle limit). Versión actual ~1700-1900, recorte final día 28-29.
 
 ---
 
@@ -148,27 +148,7 @@ Sprout usa Gemma 4 en tres formas concretas, cada una explotando una capacidad d
 
 **Honestidad arquitectural**: el patron de jurisdicciones estaba codificado desde el dia 13 — el Evaluator de Meristem (`JURISDICTION_POLLEN`) rechaza explicitamente cambios fisicos puntuales del operador, indicando que esa decision pertenece a Pollen. La feature beta del dia 20 implementa lo que el codigo predijo.
 
-## 7. Demo (90s) — placeholder hasta rodaje
-
-<!--
-Pendiente rodaje (dias 24-27). Estructura prevista del video:
-- E0 cartela Sprout + 3 nodos + tagline
-- E1 ausencia con 4 datos globales (UNCCD, gencat, ITU, COAG)
-- E2 Rhizome decide offline
-- E3 ESP32 SAFE LIMIT (wow moment)
-- E3b Meristem prepara la politica
-- E4 Llega Pollen
-- E5 Persona da una mision (voz humana real castellano)
-- E6 Ferry A→B
-- E7 Criterio modificado (climax)
-- E8 Caducidad
-- E9 Cenital federado animado
-- E9b Meristem en la mesa de casa (cierre intimo + tagline bookend)
-
-Tras rodaje, escribir aqui guion del 90s consolidado citando frases fuertes.
--->
-
-## 8. Impacto y escalado — ~120 palabras
+## 7. Impacto y escalado — ~120 palabras
 
 **Coste por nodo**: Jetson Orin Nano Super ~250€, ESP32-S3 ~10€, sensores + bomba 12V ~80€, deposito ~30€ = **~370€ por Rhizome** (mas la capa fisica). Pollen reusa el movil del agricultor (cero hardware adicional). Meristem reusa el portatil casero (cero hardware adicional).
 
@@ -178,7 +158,7 @@ Tras rodaje, escribir aqui guion del 90s consolidado citando frases fuertes.
 
 **Segmento prioritario**: explotaciones pequenas y medianas en zonas de baja poblacion (Aragon, Extremadura, Castilla-La Mancha, islas, Africa subsahariana). El **84% de las explotaciones mundiales tienen menos de 2 hectareas** (FAO 2024).
 
-## 9. Limitaciones — ~80 palabras
+## 8. Limitaciones — ~80 palabras
 
 **Honestidad sobre lo que no funciona todavia**:
 
@@ -190,7 +170,7 @@ Tras rodaje, escribir aqui guion del 90s consolidado citando frases fuertes.
 - **Tests automatizados de UI estatica**: deuda apuntada desde dia 16 — actualmente smoke manual.
 - **API docs no auto-generadas**: contratos JSON estan documentados en `docs/20_data_contracts.md` pero no hay OpenAPI publicado.
 
-## 10. Trabajo futuro — ~120 palabras
+## 9. Trabajo futuro — ~120 palabras
 
 Sprout deja explicita una hoja de ruta post-hackathon en cuatro ejes:
 


### PR DESCRIPTION
Cuatro tareas operativas Tier 1 sesion Bloque B dia 24:

1. **Writeup §7 Demo eliminada** + renumeracion §8/§9/§10 → §7/§8/§9. Decision Bea: landing demo es autoexplicativa.

2. **Cartelas presentadoras nodos EN-only firme** en video/cartelas_presentadoras_nodos.md. Bract usa solo version EN.

3. **.mailmap** quita Claude de Contributors GitHub via mapeo de Co-Authored-By trailers Anthropic → zigiella. No modifica historia (no force-push). Tambien consolida identidades Cambium/Meristem.

4. **CONTRIBUTING.md EN-master + CONTRIBUTING.es.md aparte**. Sección 'Two paths to contribute' (External vs Internal zigiella) + 'Architectural invariants' como defensa publica contra PRs que violen tesis. Mismo patron que README.