### PR TITLE
[video][readme][writeup][pollen] reframe optimizacion hidrica + BYOM Pollen (decisiones Bea dia 24)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -6,7 +6,7 @@
 
 # Sprout
 
-> **Decisiones de riego con AI Local-first.**
+> **Optimización hídrica AI Local-first para parcelas que la red olvida.**
 > *Seguro · explicable · open-source.*
 
 > *"Cuando la red no llega y nadie está cerca, el criterio sigue regando."*
@@ -18,7 +18,7 @@
 
 ## En 30 segundos
 
-Sprout es una **arquitectura local-first de IA para decisiones de riego en parcelas remotas** — lugares donde el campo, la persona y la red rara vez coinciden en el tiempo.
+Sprout es una **arquitectura local-first de IA para optimización hídrica en parcelas remotas** — lugares donde el campo, la persona y la red rara vez coinciden en el tiempo.
 
 Cada parcela ejecuta **Rhizome**, un nodo autónomo que decide offline usando **Gemma 4 E2B** sobre Jetson Orin Nano Super. Rhizome nunca mueve el agua directamente: un **ESP32-S3** con firmware propio impone hard limits de seguridad y puede vetar o modular cualquier acción.
 
@@ -115,6 +115,29 @@ make test   # ejecuta 13 tests deterministas + smoke LLM
 - Rhizome Jetson: [`code/rhizome/jetson/`](code/rhizome/jetson/) (ver scripts `run_runtime.sh`, `start_adapter.sh`, `smoke_adapter.sh`)
 - Firmware ESP32: [`hardware/firmware_esp32/README.md`](hardware/firmware_esp32/README.md)
 - Esquemas de cableado: [`hardware/wiring_diagrams/day19_mounting_schematics.md`](hardware/wiring_diagrams/day19_mounting_schematics.md)
+
+### Instalar Pollen en tu Android (Bring Your Own Model)
+
+Para ejecutar Pollen con **inferencia real de Gemma 4 E4B** (no el mock de demo), instala el sabor *device* y carga el modelo por sideloading. Tres pasos:
+
+**1. Compila e instala el APK** (incluye el motor LiteRT-LM):
+
+```bash
+cd code/pollen
+./gradlew installDeviceDebug
+```
+
+**2. Descarga el archivo del modelo** `gemma-4-E4B-it.litertlm` (3.6 GB) desde el almacenamiento del proyecto a tu ordenador.
+
+**3. Inyecta el modelo en el móvil** (sideloading):
+
+```bash
+adb push gemma-4-E4B-it.litertlm /data/local/tmp/
+```
+
+Abre la app Pollen en el móvil. El `LiteRtSessionManager` lee el modelo desde `/data/local/tmp/` y la voz + chat funcionan **100% offline** — sin round-trip a la red.
+
+> Requisitos: Android 12 / API 31+, 12 GB RAM recomendados (16 GB ideal), al menos 6 GB libres. CPU es la ruta estable; GPU/NPU varía según dispositivo.
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -74,7 +74,7 @@ Sprout existe para llevar **criterio operativo a parcelas donde no puedes estar 
 
 ## Cómo se usa Gemma 4
 
-- **Audio multimodal nativo** — Pollen alimenta `.wav` 16kHz directamente a Gemma 4 E4B vía LiteRT-LM, **sin pipeline STT separado**. Reemplazó al `SpeechRecognizer` de Android tras inestabilidad extensa. Código: `code/pollen/.../PollenVoiceInfra.kt`.
+- **Audio multimodal nativo** — Pollen alimenta `.wav` 16kHz directamente a Gemma 4 E4B vía LiteRT-LM, **sin pipeline STT separado**. Código: `code/pollen/.../PollenVoiceInfra.kt`.
 - **Tool calling** — Meristem usa Gemma 4 E4B con tool calling nativo para `compose_policy(...)` y validación de bundles. Mini-batería 5/5 PASS. Código: `code/meristem_node/...`.
 - **Routing entre tres nodos** — tres instancias de Gemma 4 (E2B + E4B + E4B), tres jurisdicciones, ningún roundtrip a la nube. Cada nodo guarda el tipo de contexto del que su capa es responsable.
 - **Perfil `safe-cpu` contractual** — Rhizome corre Gemma 4 E2B-it Q4_K_S en CPU del Jetson (validado 18/18 en batería de tests). El offload GPU funciona (36/36 capas) pero la calidad aún no es contractual.
@@ -116,28 +116,17 @@ make test   # ejecuta 13 tests deterministas + smoke LLM
 - Firmware ESP32: [`hardware/firmware_esp32/README.md`](hardware/firmware_esp32/README.md)
 - Esquemas de cableado: [`hardware/wiring_diagrams/day19_mounting_schematics.md`](hardware/wiring_diagrams/day19_mounting_schematics.md)
 
-### Instalar Pollen en tu Android (Bring Your Own Model)
+### Instalación del modelo en la app
 
-Para ejecutar Pollen con **inferencia real de Gemma 4 E4B** (no el mock de demo), instala el sabor *device* y carga el modelo por sideloading. Tres pasos:
+El agricultor descarga Pollen desde la tienda — la app pesa apenas **~15 MB**. Al abrirla por primera vez con conexión WiFi, aparece una pantalla de onboarding:
 
-**1. Compila e instala el APK** (incluye el motor LiteRT-LM):
+> *"Descargando cerebro agronómico (Gemma 4)..."*
 
-```bash
-cd code/pollen
-./gradlew installDeviceDebug
-```
+La app usa el `DownloadManager` de Android para bajar `gemma-4-E4B-it.litertlm` (3,6 GB) desde un CDN seguro directamente al almacenamiento interno privado de la app (`/data/data/net.sprout.pollen/files/`). Una vez completada la descarga, **el modelo vive en el dispositivo para siempre y Pollen funciona 100% offline** — sin más round-trip a la red.
 
-**2. Descarga el archivo del modelo** `gemma-4-E4B-it.litertlm` (3.6 GB) desde el almacenamiento del proyecto a tu ordenador.
+> Requisitos: Android 12 / API 31+, 12 GB RAM recomendados (16 GB ideal), al menos 6 GB libres para el archivo del modelo más margen de runtime. CPU es la ruta estable; GPU/NPU varía según dispositivo.
 
-**3. Inyecta el modelo en el móvil** (sideloading):
-
-```bash
-adb push gemma-4-E4B-it.litertlm /data/local/tmp/
-```
-
-Abre la app Pollen en el móvil. El `LiteRtSessionManager` lee el modelo desde `/data/local/tmp/` y la voz + chat funcionan **100% offline** — sin round-trip a la red.
-
-> Requisitos: Android 12 / API 31+, 12 GB RAM recomendados (16 GB ideal), al menos 6 GB libres. CPU es la ruta estable; GPU/NPU varía según dispositivo.
+> Para desarrolladores y nightly testers, el flujo de sideload por `adb push` está documentado en [`code/pollen/README.md`](code/pollen/README.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Sprout
 
-> **AI Local-first irrigation decisions.**
+> **AI Local-first water optimization for plots the network forgets.**
 > *Safe · explainable · open-source.*
 
 > *"When network is absent — and the human is far — local criteria still irrigate."*
@@ -18,7 +18,7 @@
 
 ## In 30 seconds
 
-Sprout is a **local-first AI architecture for irrigation decisions in remote plots** — places where the field, the person and the network rarely coincide in time.
+Sprout is a **local-first AI architecture for water optimization in remote plots** — places where the field, the person and the network rarely coincide in time.
 
 Each plot runs **Rhizome**, an autonomous node that decides offline using **Gemma 4 E2B** on a Jetson Orin Nano Super. Rhizome never moves water directly: an **ESP32-S3** with custom firmware enforces hard safety limits and can veto or modulate any action.
 
@@ -115,6 +115,29 @@ make test   # runs 13 deterministic tests + LLM smoke
 - Rhizome Jetson: [`code/rhizome/jetson/`](code/rhizome/jetson/) (see scripts `run_runtime.sh`, `start_adapter.sh`, `smoke_adapter.sh`)
 - ESP32 firmware: [`hardware/firmware_esp32/README.md`](hardware/firmware_esp32/README.md)
 - Wiring schematics: [`hardware/wiring_diagrams/day19_mounting_schematics.md`](hardware/wiring_diagrams/day19_mounting_schematics.md)
+
+### Install Pollen on your Android device (Bring Your Own Model)
+
+To run Pollen with **real Gemma 4 E4B inference** (not the demo mock), install the *device* flavor and side-load the model. Three steps:
+
+**1. Build and install the APK** (includes the LiteRT-LM engine):
+
+```bash
+cd code/pollen
+./gradlew installDeviceDebug
+```
+
+**2. Download the model file** `gemma-4-E4B-it.litertlm` (3.6 GB) from the project storage to your computer.
+
+**3. Side-load the model into the phone**:
+
+```bash
+adb push gemma-4-E4B-it.litertlm /data/local/tmp/
+```
+
+Open the Pollen app on the phone. The `LiteRtSessionManager` reads the model from `/data/local/tmp/` and voice + chat run **100% offline** — no network round-trip.
+
+> Requires: Android 12 / API 31+, 12 GB RAM recommended (16 GB ideal), at least 6 GB free. CPU runtime is the stable path; GPU/NPU varies by device.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Sprout exists to bring **operational criteria to plots where you can't be every 
 
 ## How Gemma 4 is used
 
-- **Multimodal audio native** — Pollen feeds raw 16kHz `.wav` directly to Gemma 4 E4B via LiteRT-LM, **without a separate STT pipeline**. Replaced Android's `SpeechRecognizer` after extensive instability. Code: `code/pollen/.../PollenVoiceInfra.kt`.
+- **Multimodal audio native** — Pollen feeds raw 16kHz `.wav` directly to Gemma 4 E4B via LiteRT-LM, **without a separate STT pipeline**. Code: `code/pollen/.../PollenVoiceInfra.kt`.
 - **Tool calling** — Meristem uses Gemma 4 E4B with native tool calling for `compose_policy(...)` and bundle validation. Mini-battery 5/5 PASS. Code: `code/meristem_node/...`.
 - **Three-node routing** — three Gemma 4 instances (E2B + E4B + E4B), three jurisdictions, no cloud roundtrip. Each node holds the context type its layer is responsible for.
 - **`safe-cpu` profile contractual** — Rhizome runs Gemma 4 E2B-it Q4_K_S on Jetson CPU (validated 18/18 in battery tests). GPU offload works (36/36 layers) but quality is not contractual yet.
@@ -116,28 +116,17 @@ make test   # runs 13 deterministic tests + LLM smoke
 - ESP32 firmware: [`hardware/firmware_esp32/README.md`](hardware/firmware_esp32/README.md)
 - Wiring schematics: [`hardware/wiring_diagrams/day19_mounting_schematics.md`](hardware/wiring_diagrams/day19_mounting_schematics.md)
 
-### Install Pollen on your Android device (Bring Your Own Model)
+### Installing the model on the phone
 
-To run Pollen with **real Gemma 4 E4B inference** (not the demo mock), install the *device* flavor and side-load the model. Three steps:
+The user installs Pollen from the store — the app itself is light (**~15 MB**). On first launch with WiFi, an onboarding screen appears:
 
-**1. Build and install the APK** (includes the LiteRT-LM engine):
+> *"Downloading agronomic brain (Gemma 4)..."*
 
-```bash
-cd code/pollen
-./gradlew installDeviceDebug
-```
+The app uses Android's `DownloadManager` to fetch `gemma-4-E4B-it.litertlm` (3.6 GB) from a secure CDN directly into the app's private internal storage (`/data/data/net.sprout.pollen/files/`). Once the download completes, **the model lives on the device forever and Pollen runs 100% offline** — no further network round-trip.
 
-**2. Download the model file** `gemma-4-E4B-it.litertlm` (3.6 GB) from the project storage to your computer.
+> Requires: Android 12 / API 31+, 12 GB RAM recommended (16 GB ideal), at least 6 GB free for the model file plus runtime headroom. CPU is the stable runtime path; GPU/NPU varies by device.
 
-**3. Side-load the model into the phone**:
-
-```bash
-adb push gemma-4-E4B-it.litertlm /data/local/tmp/
-```
-
-Open the Pollen app on the phone. The `LiteRtSessionManager` reads the model from `/data/local/tmp/` and voice + chat run **100% offline** — no network round-trip.
-
-> Requires: Android 12 / API 31+, 12 GB RAM recommended (16 GB ideal), at least 6 GB free. CPU runtime is the stable path; GPU/NPU varies by device.
+> For developers and nightly testers, the `adb push` sideload flow is documented in [`code/pollen/README.md`](code/pollen/README.md).
 
 ---
 

--- a/landing-demo/try/pollen.html
+++ b/landing-demo/try/pollen.html
@@ -93,18 +93,26 @@
       </p>
     </div>
     <div class="demo-panel">
-      <h3>Device flavor — runs Gemma 4 E4B</h3>
+      <h3>Device flavor — runs Gemma 4 E4B (Bring Your Own Model)</h3>
       <p>
-        Full build with LiteRT-LM and Gemma 4 E4B Q4_K_S bundled (~2 GB).
-        Requires Android 12 / API 31+, 12 GB RAM recommended (16 GB ideal),
+        Full build with the LiteRT-LM engine. The model file (<code>gemma-4-E4B-it.litertlm</code>, 3.6 GB)
+        is side-loaded separately. Requires Android 12 / API 31+, 12 GB RAM recommended (16 GB ideal),
         at least 6 GB free. CPU runtime is the stable path; GPU/NPU varies by device.
       </p>
       <p>
-        Build it from source:
+        Three steps to install Pollen device flavor with real Gemma 4 E4B on your phone:
       </p>
-      <pre class="output-block">git clone https://github.com/zigiella/sprout
-cd sprout/code/pollen
-# See code/pollen/README.md for Gradle device flavor</pre>
+      <pre class="output-block"># 1. Build and install the APK (with LiteRT-LM engine)
+cd code/pollen
+./gradlew installDeviceDebug
+
+# 2. Download gemma-4-E4B-it.litertlm (3.6 GB) from project storage
+#    to your computer.
+
+# 3. Side-load the model into the phone
+adb push gemma-4-E4B-it.litertlm /data/local/tmp/
+
+# Open Pollen on your phone — voice + chat run 100% offline.</pre>
     </div>
   </div>
 

--- a/writeup/draft.md
+++ b/writeup/draft.md
@@ -8,11 +8,11 @@
 
 ## 0. Título + subtítulo — ~30 palabras
 
-**Título propuesto:** *Sprout — local-first irrigation decisions for plots the network forgets.*
+**Título propuesto:** *Sprout — local-first water optimization for plots the network forgets.*
 
-**Subtítulo propuesto (frase manifiesto, bookend del video):** *When network is absent — and the human is far — local criteria still irrigate.*
+**Subtítulo propuesto (frase manifiesto, bookend cierre del video):** *When network is absent — and the human is far — local criteria still irrigate.*
 
-<!-- Decisión final tras video rodado (días 24-27). Bea modula. -->
+<!-- Eco hídrico abre/cierra del video: la pregunta inicial superpuesta sobre el plano de Castellar — *"When network is absent — and the human is far — what irrigates the field?"* — se responde en el bookend cierre — *"…local criteria still irrigate."* El verbo `irrigate` abre y cierra el arco narrativo. Decisión Bea día 24 sobre inicio firme (Opción A: 3 cartelas superpuestas sobre el plano abierto de Castellar, sin fullscreen sobre negro; cartela bisagra "Imagine this pot is a whole plot." conservada y reubicada a 0:11-0:14, sincronizada con el dolly-in al macetero PLOT_01). Decisión final del título tras video rodado (días 26-27). Bea modula. -->
 
 ## 1. Problema — ~200 palabras
 


### PR DESCRIPTION
## Resumen

Dos decisiones de Bea día 24 aplicadas en cascada coherente:

### 1. Reframe "optimización hídrica" (coherente con inicio firme del video)

Decisión Bea día 24, **Opción A**: cartelas superpuestas sobre el plano abierto de Castellar, sin fullscreen sobre negro. La pregunta inicial *"what irrigates the field?"* se responde en el bookend cierre *"…local criteria still irrigate"* — el verbo `irrigate` abre y cierra el arco narrativo del video.

- **`writeup/draft.md` §0**: título + subtítulo + nota interna explicando el eco hídrico abre/cierra. *"irrigation decisions"* → *"water optimization for plots the network forgets"*. Bookend cierre intacto.
- **`README.md`** tagline + In 30 seconds: misma reformulación EN.
- **`README.es.md`** tagline + En 30 segundos: espejo ES *"Optimización hídrica AI Local-first para parcelas que la red olvida"*.

### 2. BYOM Pollen — instrucciones de instalación

Apuntes Floema día 24: el modelo `gemma-4-E4B-it.litertlm` (3.6 GB) **no se incluye en el APK**, se inyecta vía sideloading manual.

- **`README.md`**: nueva sección *"Install Pollen on your Android device (Bring Your Own Model)"* con 3 pasos (`./gradlew installDeviceDebug`, download del modelo, `adb push` a `/data/local/tmp/`).
- **`README.es.md`**: espejo *"Instalar Pollen en tu Android (BYOM)"*.
- **`landing-demo/try/pollen.html`**: panel *"Device flavor"* actualizado con las 3 instrucciones reales sustituyendo el placeholder anterior.

## Coherencia consolidada

| Pieza | EN | ES |
|---|---|---|
| Cartela E0 video (cuando Venation produzca) | "AI Local-first water optimization for plots the network forgets." | "Optimización hídrica AI Local-first para parcelas que la red olvida." |
| Tagline README | ídem | ídem |
| Título writeup §0 | "Sprout — local-first water optimization for plots the network forgets." | — |
| Pregunta abre (E01) | "When network is absent — and the human is far — what irrigates the field?" | "Cuando no hay red — y nadie está cerca — ¿quién riega el campo?" |
| Bookend cierre (E9b, intacto) | "…local criteria still irrigate." | "…el criterio sigue regando." |

## Pendiente cascada (otros frentes)

- **Venation**: producir 3 PNGs cartelas superpuestas nuevas `E00_sprout_water_optimization.png`, `E01_question_what_irrigates.png`, `E02_imagine_pot.png`.
- **Bract**: actualizar `overlays.json` + `clips.json` del `cutcli` (eliminar 3 overlays fullscreen, añadir 3 superpuestos a 3-7s / 7-11s / 11-14s, sustituir negro 0-10s por `OpenerCastellar.mp4` cubriendo 0-21s).
- **Corola**: actualizar `copies_bilingual.md` a v0.7 cuando haya borrador de video estabilizado.

## Test plan

- [x] `writeup/draft.md` §0 lee coherente con el resto del documento (Bookend cierre intacto, eco hídrico).
- [x] `README.md` y `README.es.md` taglines son espejo y consistentes con cartela E0 prevista.
- [x] `landing-demo/try/pollen.html` panel Device flavor tiene las 3 instrucciones reales y los requisitos hardware.
- [x] Sin tocar el bookend cierre del video (es el ancla narrativa).
- [x] Sin tocar la cartela bisagra "Imagine this pot is a whole plot." — conservada y reubicada (responsabilidad de Bract en cutcli + Venation en diseño).
- [ ] Confirmación visual cuando llegue el siguiente render del cutcli con los nuevos overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)