### PR TITLE
feat(rhizome): add minimal autonomous steward

### DIFF
--- a/bitacora/2026-05-10_articulo-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_articulo-rhizome-steward-v0_endodermis.md
@@ -93,12 +93,17 @@ en Jetson con una configuracion especifica, pero tambien revelo regresiones
 contractuales en casos concretos. La decision fue correcta: rendimiento si, pero
 no a costa de estabilidad semantica.
 
-La capa mas interesante para futuro es `ShadowSkeptic`. Implementa una version
-experimental de doble agente, pero no afecta al resultado. Revisa cada decision,
-registra si habria objetado, que preocupacion detecta y que accion recomendaria,
-siempre con `affects_decision=false`. Esto permite recoger datos reales antes de
-decidir si merece evolucionar hacia un segundo agente LLM. Es una forma madura
-de innovar: abrir la puerta sin meter riesgo en el actuador.
+La capa mas ambiciosa es `ShadowSkeptic`: una primera forma experimental de
+doble agente en Rhizome. La idea no es duplicar complejidad por estetica, sino
+crear una segunda inteligencia local con una jurisdiccion distinta. El steward
+actua como criterio operativo; el skeptic actua como conciencia tecnica: revisa
+cada decision, busca contradicciones fisicas, detecta señales de exceso de
+confianza y propone una alternativa mas prudente cuando ve riesgo. Cada revision
+queda registrada con la accion revisada, sus preocupaciones, su recomendacion y
+la evidencia que la motivo. El objetivo es medir, con datos reales de maceta, si
+un segundo agente mejora seguridad, explicabilidad y estabilidad antes de
+convertirlo en autoridad efectiva. Es una ruta potente hacia agentes locales que
+no solo actuan, sino que se auditan entre si.
 
 Lo que hace fuerte esta implementacion no es una unica pieza brillante, sino la
 composicion de capas:
@@ -106,12 +111,12 @@ composicion de capas:
 - ESP32 como veto fisico independiente.
 - Rhizome Steward como bucle autonomo minimo.
 - Gates deterministas como nucleo de seguridad.
-- Gemma 4 como explicacion local y auditabilidad.
+- Gemma 4 como explicacion local, memoria sintetica y auditabilidad.
 - llama.cpp como camino de paridad con Jetson.
 - DecisionReceipt como memoria verificable.
 - Pollen como interfaz humana de visita.
 - Logs rotados como operacion real, no demo fragil.
-- ShadowSkeptic como investigacion segura de doble agente.
+- ShadowSkeptic como investigacion agencial de segundo criterio local.
 
 ## Mejoras futuras
 
@@ -119,11 +124,22 @@ La siguiente evolucion natural es convertir el steward en servicio supervisado
 con `systemd`, anadir calibracion formal de humedad, usar feedback real del
 caudalimetro en `execution_details`, instalar el SSD para modelo y retencion
 larga, y conectar `WeatherDigest` para aplazar riego si hay lluvia probable.
+Tambien entra aqui la vision: una camara de bajo coste o snapshot periodico que
+no mande sobre el agua, pero aporte señales de marchitez, crecimiento, sombra,
+plagas visibles o contradiccion sensor-planta. La regla seguiria siendo la misma:
+la vision informa; el ESP32 veta; Rhizome deja recibo.
 
-En Gemma 4, las mejoras mas prometedoras son: resumen inteligente de "que paso
-desde mi ausencia", explicaciones multilingues para Pollen, structured output
-mas estricto con llama.cpp, estabilizacion del perfil GPU y un `ShadowSkeptic`
-LLM que siga sin vetar al principio, pero aprenda a detectar inconsistencias.
+En Gemma 4, las mejoras mas prometedoras son mas profundas que "redactar mejor".
+Puede sintetizar "que paso desde mi ausencia" leyendo receipts y snapshots;
+explicar decisiones en el idioma de Pollen; comparar telemetria reciente con
+historico local; detectar patrones anormales como humedad que no sube tras
+riego, caudal erratico o deposito que cae demasiado rapido; convertir
+`WeatherDigest`, `PolicyPacket` y visitas humanas en contexto compacto con TTL;
+producir structured output mas estricto con llama.cpp; ayudar a calibrar
+umbrales raw mediante observaciones repetidas; y alimentar un `ShadowSkeptic`
+LLM experimental que aprenda a encontrar contradicciones antes de que lleguen a
+la capa fisica. La frontera importante no cambia: Gemma 4 aumenta criterio,
+memoria y explicacion; no rebaja hard limits.
 
 La ambicion de Rhizome Steward v0 es pequena en superficie y grande en
 arquitectura: riega poco, bloquea bien, explica corto y deja recibo. Eso es

--- a/bitacora/2026-05-10_articulo-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_articulo-rhizome-steward-v0_endodermis.md
@@ -1,0 +1,131 @@
+# Rhizome Steward v0: autonomia local-first con Gemma 4, Jetson y veto fisico
+
+Sprout no intenta demostrar que una IA pueda "regar una planta". Intenta
+demostrar algo bastante mas dificil: que una arquitectura local-first puede
+tomar decisiones utiles en un entorno fisico real, con conectividad incierta,
+agua limitada y seguridad verificable. La implementacion de **Rhizome Steward
+v0** convierte esa idea en un bucle minimo pero verdadero de autonomia.
+
+Rhizome corre sobre **Jetson Orin Nano Super** y actua como el nodo local de
+parcela. Su mision no es tocar actuadores directamente, sino observar, decidir
+dentro de su jurisdiccion y dejar trazabilidad. La frontera fisica pertenece al
+**ESP32**, que conserva autoridad sobre sensores criticos, bomba, caudalimetro,
+reglas duras y failsafe. En Sprout, la inteligencia propone; lo fisico veta.
+
+La nueva implementacion cierra el ciclo operativo:
+
+```text
+ESP32 heartbeat
+-> ESP32 telemetry
+-> RhizomeSnapshot
+-> safety/need gate determinista
+-> Gemma 4 rationale opcional
+-> WATER opcional via ESP32
+-> DecisionReceipt
+-> logs rotados
+-> facade_data para Pollen
+```
+
+La decision clave es que casi todo el sistema es determinista. Rhizome no espera
+que el LLM "se porte bien" para ser seguro. El steward evalua humedad, deposito,
+cooldown, presupuesto diario de riegos y estado del enlace con ESP32 antes de
+plantear cualquier accion. Si no entiende una lectura, aplaza. Si el deposito
+esta bajo, alerta. Si no hay permiso explicito, no manda agua. Si manda agua, lo
+hace siempre a traves del ESP32.
+
+Gemma 4 entra donde aporta valor sin comprometer seguridad: como inteligencia
+local de explicacion contractual. Con `--gemma-rationale-url`, Rhizome puede
+llamar al adapter compatible con Ollama/llama.cpp y pedir a **Gemma 4 E2B** que
+mejore el `rationale_short` de una decision ya tomada. No puede cambiar la
+accion, no puede autorizar agua y no puede inventar hechos. Esto hace que Gemma
+4 sea visible y util para el usuario sin convertirlo en una autoridad fisica.
+
+La configuracion tambien refleja esa filosofia. El modo por defecto es prudente:
+`WATER` queda bloqueado salvo que se pase `--execute-water`. La duracion maxima
+esta limitada a `30s`, el cooldown evita riegos repetidos por ruido de sensor y
+existe un limite de eventos autonomos diarios. Para sensores de humedad aun no
+calibrados a porcentaje, el steward acepta umbrales raw explicitos, documentados
+y visibles en el comando. Nada queda escondido.
+
+En Jetson, la capa operativa queda empaquetada en wrappers reproducibles:
+
+```bash
+./run_steward_once.sh
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./run_steward_once.sh
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 EXECUTE_WATER=1 WATER_SECONDS=8 ./run_steward_once.sh
+```
+
+Para operacion continua:
+
+```bash
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./start_steward_loop.sh
+```
+
+El steward decide cada 15 minutos por defecto y mantiene heartbeat entre
+decisiones. Ademas escribe estado para que Pollen pueda leerlo mediante la
+fachada existente. Eso permite que el movil vea snapshots, recibos y
+explicaciones sin acoplarse al mecanismo interno de Rhizome.
+
+La persistencia se diseno para sobrevivir semanas o meses sin reventar la
+microSD. Por defecto escribe en:
+
+```text
+~/.local/share/sprout/rhizome_steward/
+├── telemetry_samples/YYYY-MM-DD.jsonl
+├── decision_receipts/YYYY-MM-DD.jsonl
+├── shadow_skeptic/YYYY-MM-DD.jsonl
+├── current_snapshot.json
+├── last_decision_receipt.json
+└── facade_data/
+```
+
+El store aplica retencion por dias y presupuesto total de bytes. No sustituye al
+SSD, que sigue siendo recomendable para operacion larga y modelos, pero evita la
+trampa clasica de los pilotos edge: dejar logs creciendo indefinidamente hasta
+romper el sistema.
+
+La integracion con **llama.cpp** es estrategica. Sprout ha mantenido un adapter
+comun compatible con el estilo Ollama para poder mover inferencia entre
+desarrollo local, Ollama provisional y `llama-server` en Jetson. En las pruebas
+previas, el perfil `safe-cpu` conserva contrato y por eso sigue siendo el perfil
+demo. El perfil GPU experimental demostro que Gemma 4 E2B Q4_K_S puede cargar
+en Jetson con una configuracion especifica, pero tambien revelo regresiones
+contractuales en casos concretos. La decision fue correcta: rendimiento si, pero
+no a costa de estabilidad semantica.
+
+La capa mas interesante para futuro es `ShadowSkeptic`. Implementa una version
+experimental de doble agente, pero no afecta al resultado. Revisa cada decision,
+registra si habria objetado, que preocupacion detecta y que accion recomendaria,
+siempre con `affects_decision=false`. Esto permite recoger datos reales antes de
+decidir si merece evolucionar hacia un segundo agente LLM. Es una forma madura
+de innovar: abrir la puerta sin meter riesgo en el actuador.
+
+Lo que hace fuerte esta implementacion no es una unica pieza brillante, sino la
+composicion de capas:
+
+- ESP32 como veto fisico independiente.
+- Rhizome Steward como bucle autonomo minimo.
+- Gates deterministas como nucleo de seguridad.
+- Gemma 4 como explicacion local y auditabilidad.
+- llama.cpp como camino de paridad con Jetson.
+- DecisionReceipt como memoria verificable.
+- Pollen como interfaz humana de visita.
+- Logs rotados como operacion real, no demo fragil.
+- ShadowSkeptic como investigacion segura de doble agente.
+
+## Mejoras futuras
+
+La siguiente evolucion natural es convertir el steward en servicio supervisado
+con `systemd`, anadir calibracion formal de humedad, usar feedback real del
+caudalimetro en `execution_details`, instalar el SSD para modelo y retencion
+larga, y conectar `WeatherDigest` para aplazar riego si hay lluvia probable.
+
+En Gemma 4, las mejoras mas prometedoras son: resumen inteligente de "que paso
+desde mi ausencia", explicaciones multilingues para Pollen, structured output
+mas estricto con llama.cpp, estabilizacion del perfil GPU y un `ShadowSkeptic`
+LLM que siga sin vetar al principio, pero aprenda a detectar inconsistencias.
+
+La ambicion de Rhizome Steward v0 es pequena en superficie y grande en
+arquitectura: riega poco, bloquea bien, explica corto y deja recibo. Eso es
+exactamente lo que un nodo edge deberia hacer cuando el agua, el hardware y la
+confianza importan.

--- a/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
@@ -190,6 +190,28 @@ Decision linguistica adicional:
   de Pollen para idiomas minoritarios africanos como Pular, sin sobrecargar a
   Rhizome ni tocar la frontera fisica.
 
+## Narrador Gemma 4 para ausencia
+
+Decision posterior: empezar a usar Gemma 4 de forma mas completa en Rhizome sin
+cederle autoridad operacional.
+
+Implementacion:
+
+- `GET /summary/since` puede activar un narrador Gemma 4 mediante
+  `--narrator-url` / `GEMMA_VISIT_NARRATOR_URL`.
+- Gemma solo reescribe `headline`, `summary`, `highlights` y `recommendation`.
+- La fuente de verdad permanece en `DecisionReceipt`, `RhizomeSnapshot`,
+  `counts`, `severity`, `executed`, `blocked_reason`, `simulation` y codigos de
+  seguridad.
+- Si Gemma falla, devuelve texto fuera de schema o tarda demasiado, se conserva
+  el resumen determinista.
+- Trazabilidad nueva: `source="deterministic_visit_summary"`,
+  `narrative_source="gemma_visit_narrator"` cuando se usa, y
+  `gemma_narrator.used=true`.
+
+Esta capa da mas valor demo a Gemma 4: no decide agua, pero convierte eventos
+tecnicos auditables en una explicacion humana de ausencia.
+
 ## Validacion
 
 Comandos:
@@ -203,7 +225,7 @@ bash -n code/rhizome/jetson/start_steward_loop.sh
 
 Resultado:
 
-- 21 tests OK.
+- 27 tests OK.
 - Compilacion OK.
 - Sintaxis shell OK.
 - `RhizomeSnapshot` y `DecisionReceipt` emitidos por el caso de sensor

--- a/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
@@ -178,6 +178,18 @@ Regla de producto:
 > `DecisionReceipt`. Gemma 4 puede mejorar el rationale, pero no convierte una
 > propuesta no ejecutada en riego real.
 
+Decision linguistica adicional:
+
+- El sistema puede "pensar" internamente en el idioma que el equipo elija, pero
+  su autoridad vive en contratos JSON, no en frases.
+- Los codigos, acciones, cantidades, timestamps y flags de ejecucion permanecen
+  estables y sin traducir.
+- Pollen, con Gemma 4 local, es responsable de adaptar la experiencia al idioma
+  de la interfaz y de traducir solo lo que no llegue ya localizado.
+- Esto deja abierta una via fuerte de impacto: fine-tuning o adaptacion futura
+  de Pollen para idiomas minoritarios africanos como Pular, sin sobrecargar a
+  Rhizome ni tocar la frontera fisica.
+
 ## Validacion
 
 Comandos:

--- a/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
@@ -158,6 +158,26 @@ ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 \
 Decision: por defecto falta de deposito aplaza. El perfil minimo exige flag
 explicito y deja `tank_level_unavailable`/`flow_sensor_unavailable` en trazas.
 
+## Contrato Pollen bilingue
+
+Ajuste posterior a conversacion con Bea: Pollen no debe leer una propuesta
+`WATER_A` como riego real si `executed=false`.
+
+Cambios:
+
+- `/explain/decision/<id>?locale=en|es` distingue riego ejecutado de propuesta
+  no ejecutada.
+- `/summary/since?locale=en|es` cuenta `water` como riegos ejecutados, y anade
+  `water_proposed` + `water_not_executed`.
+- `simulation` ahora depende del origen de datos: demo/examples => `true`;
+  `facade_data` real del steward => `false`.
+
+Regla de producto:
+
+> Pollen muestra narrativa bilingue; Rhizome conserva verdad operacional en
+> `DecisionReceipt`. Gemma 4 puede mejorar el rationale, pero no convierte una
+> propuesta no ejecutada en riego real.
+
 ## Validacion
 
 Comandos:

--- a/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
@@ -1,0 +1,174 @@
+# Endodermis — Rhizome Steward v0
+
+**Fecha:** 2026-05-10 (dia 24)
+**Rama:** `feat/endodermis/rhizome-steward-v0`
+**Frente:** Rhizome Jetson / autonomia minima de maceta
+
+---
+
+## Pregunta de Bea
+
+Necesitamos pasar de fachada + demo a autonomia minima verdadera:
+
+- que Rhizome pueda controlar una maceta;
+- que recoja datos;
+- que rote logs para semanas/meses sin rebosar microSD;
+- que use mejor Gemma 4;
+- que explore doble agente sin afectar aun al resultado.
+
+## Decision
+
+Implemento `Rhizome Steward v0`, un bucle host-side pequeno y testeable:
+
+```text
+ESP32 heartbeat -> ESP32 telemetry -> snapshot -> deterministic gate
+-> optional Gemma rationale -> optional WATER -> DecisionReceipt
+-> bounded JSONL store -> facade_data para Pollen
+```
+
+## Alcance
+
+El steward:
+
+- lee telemetria de ESP32 real por serie o de `FakeESP32Client`;
+- envia heartbeat antes de decidir y antes de `WATER`;
+- decide con gates deterministas;
+- por defecto no manda agua salvo `--execute-water`;
+- respeta maximo firmware MVP `30s`;
+- aplica cooldown;
+- limita riegos autonomos por dia;
+- aplaza si no entiende humedad;
+- escribe `DecisionReceipt`;
+- escribe `telemetry_samples/YYYY-MM-DD.jsonl`;
+- escribe `shadow_skeptic/YYYY-MM-DD.jsonl`;
+- escribe `current_snapshot.json`;
+- escribe `facade_data/` compatible con `rhizome_sync_facade`;
+- aplica retencion por dias y presupuesto total de bytes.
+- mantiene `RhizomeSnapshot` compatible con schema compartido incluso cuando
+  una lectura falta: no inventa riego, marca `pending_contradictions` y aplaza.
+
+## Persistencia
+
+Default:
+
+```text
+~/.local/share/sprout/rhizome_steward/
+```
+
+Default de retencion:
+
+- `retention_days=120`
+- `max_total_bytes=64 MiB`
+
+Esto no sustituye al SSD, pero permite correr dias/semanas/meses de piloto de
+maceta sin escribir sin control sobre microSD.
+
+## Gemma 4
+
+Gemma 4 E2B puede entrar por `--gemma-rationale-url`, apuntando al adapter
+Ollama-compatible/llama.cpp:
+
+```bash
+--gemma-rationale-url http://127.0.0.1:12000
+```
+
+Regla de seguridad:
+
+- Gemma no cambia la accion;
+- Gemma no autoriza agua;
+- Gemma no inventa facts;
+- Gemma solo mejora `rationale_short` sobre decision ya cerrada.
+
+Esto hace a Gemma mas visible y util sin romper la arquitectura: inteligencia
+local para explicacion contractual, no actuacion fisica.
+
+## Doble agente experimental
+
+Activo por defecto:
+
+```text
+ShadowSkeptic deterministic_shadow_skeptic_v0
+```
+
+Registra:
+
+- accion revisada;
+- si objetaria;
+- concerns;
+- accion recomendada;
+- `affects_decision=false`.
+
+No puede cambiar el resultado. Sirve para recoger datos y decidir despues si
+un `ShadowSkeptic` LLM merece pasar a produccion.
+
+## Comandos
+
+Sin hardware:
+
+```bash
+cd code/rhizome
+python -m src.rhizome_steward run-once --esp32 fake
+```
+
+ESP32 real sin agua:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0
+```
+
+ESP32 real con permiso explicito de agua:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0 \
+  --execute-water \
+  --water-seconds 8
+```
+
+Wrappers Jetson:
+
+```bash
+cd ~/sprout/code/rhizome/jetson
+./run_steward_once.sh
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./run_steward_once.sh
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./start_steward_loop.sh
+```
+
+## Validacion
+
+Comandos:
+
+```bash
+python -m unittest tests.test_rhizome_steward tests.test_sync_facade
+python -m py_compile code/rhizome/src/rhizome_steward.py
+bash -n code/rhizome/jetson/run_steward_once.sh
+bash -n code/rhizome/jetson/start_steward_loop.sh
+```
+
+Resultado:
+
+- 21 tests OK.
+- Compilacion OK.
+- Sintaxis shell OK.
+- `RhizomeSnapshot` y `DecisionReceipt` emitidos por el caso de sensor
+  desconocido validan contra `code/shared/schemas`.
+- CLI directo `run-once --esp32 fake` escribe estado, receipts, shadow y
+  `facade_data`.
+
+## Limites honestos
+
+- No he cambiado firmware ESP32.
+- No he tocado actuadores.
+- El riego real requiere `--execute-water`.
+- Si la humedad llega como raw sin calibrar, hay que pasar umbrales raw.
+- El SSD sigue recomendado para operacion larga y modelo, pero no bloquea un
+  piloto de maceta con logs rotados.
+
+## Veredicto
+
+Esta pieza convierte Rhizome de "fachada de demo + runtime de inferencia" en
+"steward minimo de parcela". Sigue siendo prudente, pero ya tiene ciclo,
+memoria, receipts y experimento de doble agente no vinculante.

--- a/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
@@ -226,6 +226,40 @@ Ajuste de Rhizome:
   no autoriza `WATER` desde raw; fuera de la banda humeda, aplaza;
 - esto evita interpretar `1265` como porcentaje o como seco por error.
 
+## Prueba ESP32 real desde Jetson
+
+ESP32 conectado a Jetson en `192.168.1.60`, puerto `/dev/ttyACM0`.
+
+Observaciones:
+
+- `STATUS_REPORT`: firmware `1cfd4f9-dirty`, `pump_relay_gpio=16`,
+  `pump_relay_active_low=true`, `pump_relay_state=OFF`.
+- `TELEMETRY_REPORT`: `soil_a_raw` en torno a `1957-1963`, `soil_a_source=ADC`,
+  `tank_level_pct=-1`, `flow_pulses=0`.
+- `PUMP_STATUS`: `state=OFF`.
+- `Rhizome Steward` en observe mode con `run_steward_serial_observe_minimal.sh`
+  produjo `DEFER`, `executed=false`, `blocked_reason=AMBIGUOUS_MOISTURE_BAND`,
+  `heartbeat_ok=true`.
+- `facade_data/decision_receipt.json` queda actualizado al ultimo receipt real,
+  no a un fake anterior.
+
+Intento de pulso:
+
+- `PUMP_ON` devuelve `REJECT reason=UNKNOWN_COMMAND`.
+- `WATER A 1` devuelve `ACK ... execution=DRY_RUN ... tank_level_pct=-1`.
+- `STOP` y `PUMP_OFF` devuelven `ACK`.
+- `PUMP_STATUS` final: `state=OFF`.
+
+Resultado: ruta serie y semantica `WATER A 1` verificadas, pero sin pulso fisico
+real porque el firmware responde en `DRY_RUN`.
+
+Preguntas para Xilema:
+
+1. Confirmar umbral seco raw para esta sonda (`SOIL_DRY_ABOVE_RAW`) antes de
+   permitir riego autonomo por Rhizome.
+2. Confirmar comando/escenario/firmware exacto para pulso fisico real de 1s,
+   dado que `PUMP_ON` no existe en esta build y `WATER A 1` sigue en `DRY_RUN`.
+
 ## Validacion
 
 Comandos:

--- a/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
@@ -212,6 +212,20 @@ Implementacion:
 Esta capa da mas valor demo a Gemma 4: no decide agua, pero convierte eventos
 tecnicos auditables en una explicacion humana de ausencia.
 
+## Handoff Xilema: sonda raw humeda
+
+Xilema reporta ESP32 con bomba + humedad de suelo casi listo y lectura actual
+`soil_a_raw=1263-1267`, interpretada como suelo muy humedo (`soil_a_raw < 1300`).
+
+Ajuste de Rhizome:
+
+- se anade polaridad raw explicita: `low_is_dry` o `low_is_wet`;
+- el perfil `run_steward_serial_observe_minimal.sh` usa `low_is_wet` y
+  `SOIL_WET_BELOW_RAW=1300`;
+- sin `SOIL_DRY_ABOVE_RAW`, Rhizome puede hacer `SKIP` por suelo humedo, pero
+  no autoriza `WATER` desde raw; fuera de la banda humeda, aplaza;
+- esto evita interpretar `1265` como porcentaje o como seco por error.
+
 ## Validacion
 
 Comandos:
@@ -225,7 +239,7 @@ bash -n code/rhizome/jetson/start_steward_loop.sh
 
 Resultado:
 
-- 27 tests OK.
+- 29 tests OK.
 - Compilacion OK.
 - Sintaxis shell OK.
 - `RhizomeSnapshot` y `DecisionReceipt` emitidos por el caso de sensor

--- a/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
+++ b/bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md
@@ -46,6 +46,8 @@ El steward:
 - aplica retencion por dias y presupuesto total de bytes.
 - mantiene `RhizomeSnapshot` compatible con schema compartido incluso cuando
   una lectura falta: no inventa riego, marca `pending_contradictions` y aplaza.
+- soporta perfil hardware minimo de maceta: ESP32 con bomba + humedad, mientras
+  deposito y caudalimetro quedan previstos como sensores futuros.
 
 ## Persistencia
 
@@ -136,6 +138,25 @@ cd ~/sprout/code/rhizome/jetson
 ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./run_steward_once.sh
 ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./start_steward_loop.sh
 ```
+
+Perfil minimo sin sensor de deposito instalado:
+
+```bash
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 \
+  ALLOW_MISSING_TANK_SENSOR=1 \
+  ./run_steward_once.sh
+```
+
+Si la firmware inicial solo expone encender/apagar bomba:
+
+```bash
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 \
+  SERIAL_WATER_COMMAND_MODE=pump-toggle \
+  ./run_steward_once.sh
+```
+
+Decision: por defecto falta de deposito aplaza. El perfil minimo exige flag
+explicito y deja `tank_level_unavailable`/`flow_sensor_unavailable` en trazas.
 
 ## Validacion
 

--- a/bitacora/2026-05-10_reflexion-pollen-rhizome-jurisdiccion_endodermis.md
+++ b/bitacora/2026-05-10_reflexion-pollen-rhizome-jurisdiccion_endodermis.md
@@ -1,0 +1,138 @@
+# Reflexion Endodermis — Pollen, Rhizome y jurisdiccion de la visita
+
+**Fecha:** 2026-05-10 (dia 24)
+**Frente:** arquitectura Rhizome/Pollen
+**Contexto:** conversacion con Bea sobre si Pollen debe seguir siendo nodo
+inteligente o podria reducirse a interfaz de Rhizome.
+
+---
+
+## Pregunta
+
+Si Pollen no tuviera Gemma 4 y fuese solo una app que pone interfaz a Rhizome,
+¿que podria hacer Rhizome? ¿Que debe hacerse necesariamente en Pollen? ¿Como se
+justifica mantener Pollen como nodo inteligente?
+
+## Tesis corta
+
+Una Pollen minima podria ser solo interfaz, grabadora y transporte hacia
+Rhizome. Pero una Pollen inteligente sigue teniendo sentido porque su
+jurisdiccion natural no es el agua, sino la visita humana.
+
+Rhizome entiende la parcela. Pollen entiende la visita.
+
+## Lo que Rhizome podria asumir si Pollen fuese tonta
+
+Con Gemma 4 E2B en Jetson, Rhizome podria hacer mas de lo que parecia al
+principio:
+
+- recibir un WAV grabado por Pollen;
+- transcribir o interpretar la intencion humana;
+- convertir voz en una intencion estructurada;
+- generar `MissionPatch`, `PolicyPacket` de visita o equivalente;
+- explicar decisiones a traves de Pollen;
+- resumir "que paso desde mi ausencia";
+- leer snapshots, receipts e historico local;
+- detectar anomalias locales;
+- preparar texto multilingue para que Pollen solo lo renderice.
+
+Esto es tecnicamente viable porque Gemma 4 E2B en Rhizome puede actuar como
+cerebro local multimodal y Pollen podria ser solo microfono, pantalla y cliente.
+
+## Por que no deberia ser el camino principal
+
+Que Rhizome pueda hacerlo no significa que deba cargar con todo.
+
+Rhizome ya tiene una jurisdiccion critica:
+
+- observar parcela;
+- hablar con ESP32;
+- decidir riego en escala de minutos;
+- mantener heartbeat;
+- escribir `DecisionReceipt`;
+- explicar decisiones;
+- sobrevivir offline;
+- no volverse peligroso.
+
+Si ademas asume conversacion humana, multilinguismo, notas de voz, comparacion
+entre parcelas, UX de visita y mediacion cultural, Rhizome deja de ser nodo de
+parcela y empieza a ser cerebro total del sistema. Eso debilita una de las
+fortalezas de Sprout: jurisdicciones claras.
+
+## Lo que si pertenece naturalmente a Pollen
+
+Pollen vive donde vive la persona: en el movil, durante la visita, cerca de la
+voz, la camara, la pantalla y el contexto humano.
+
+Por eso Pollen debe asumir, o al menos es el mejor lugar para asumir:
+
+- capturar intencion humana;
+- recoger notas de voz y observaciones;
+- conversar sobre lo observado;
+- mostrar estado y explicaciones de forma comprensible;
+- comparar varios Rhizomes durante una ruta;
+- transportar conocimiento entre parcelas sin internet;
+- convertir la visita en contratos caducables;
+- emitir intenciones con TTL o `valid_until`;
+- adaptar idioma, tono, accesibilidad y confianza a la agricultora;
+- mediar consentimiento humano sin tocar actuadores.
+
+Una frase util:
+
+> Rhizome cuida el agua; Pollen cuida la relacion entre persona, conocimiento y
+> territorio.
+
+## Pollen como inteligencia federada
+
+Pollen no es solo pantalla. Es el nodo que recorre parcelas y reparte
+conocimiento entre ellas. Al visitar varios Rhizomes, puede comparar estados,
+detectar diferencias, llevar observaciones de una parcela a otra y devolver a la
+agricultora una vision de conjunto.
+
+Esto justifica la frase:
+
+> Pollen convierte cada visita humana en inteligencia federada: recoge
+> observaciones locales, las estructura, las transporta entre parcelas y devuelve
+> explicaciones comprensibles en el idioma de la agricultora.
+
+## Idiomas minoritarios y adaptacion local
+
+El argumento mas fuerte para mantener Gemma 4 en Pollen es el lenguaje humano.
+
+En el futuro, Pollen podria recibir fine-tuning, adaptacion o prompt packs para
+entender mejor idiomas minoritarios o infrarrepresentados: suahili, pular,
+wolof, bambara, quechua u otras lenguas locales. Ese trabajo encaja mejor en el
+nodo que escucha a la persona que en el nodo que protege la frontera fisica.
+
+¿Podria hacerse en Rhizome? Si. Pero seria pedir demasiado a Rhizome: agricultor,
+interprete, operador, memoria local, juez de riego y puente entre parcelas. En
+una arquitectura segura, esa carga se reparte.
+
+## Formulacion para writeup
+
+Propuesta de parrafo:
+
+> Una version minima de Pollen podria ser solo una interfaz hacia Rhizome. Pero
+> mantener Gemma 4 en Pollen separa dos inteligencias distintas: Rhizome entiende
+> la parcela; Pollen entiende la visita. Esa separacion permite adaptar lenguaje,
+> voz y contexto humano sin cargar al nodo fisico ni comprometer la frontera de
+> seguridad.
+
+Y una version mas emocional:
+
+> Rhizome cuida el agua. Pollen cuida la conversacion. Entre ambas, Sprout no
+> solo automatiza riego: convierte visitas intermitentes en conocimiento local
+> que viaja.
+
+## Decision recomendada
+
+Mantener dos niveles posibles:
+
+1. **Pollen simple viable:** interfaz, microfono, pantalla, transporte y cliente
+   de Rhizome. Sirve como fallback y reduce riesgo.
+2. **Pollen inteligente aspiracional/MVP fuerte:** nodo Gemma 4 de visita que
+   entiende voz, observaciones, comparacion multi-parcela e intencion humana.
+
+Arquitectonicamente, la version inteligente es mas poderosa porque evita que
+Rhizome se convierta en monolito. Pollen no debe decidir agua. Debe convertir
+presencia humana en contexto estructurado, caducable y transportable.

--- a/bitacora/2026-05-11_dia26-rhizome-pump-pulse-umbrales_endodermis.md
+++ b/bitacora/2026-05-11_dia26-rhizome-pump-pulse-umbrales_endodermis.md
@@ -1,0 +1,43 @@
+# Dia 26 - Puente Rhizome a PUMP_PULSE y aviso Gemma E2B
+
+**Autora:** Endodermis  
+**Fecha:** 2026-05-11  
+**Proyecto:** Sprout / Rhizome Jetson
+
+## Entradas recibidas
+
+Xilema confirma umbrales para la sonda raw:
+
+```text
+SOIL_RAW_POLARITY=low_is_wet
+SOIL_WET_BELOW_RAW=1300
+SOIL_DRY_ABOVE_RAW=2200
+```
+
+Interpretacion operacional:
+
+- `<1300`: suelo muy humedo, no regar.
+- `1300..2199`: banda ambigua, `DEFER`/observe.
+- `>=2200`: seco para MVP, candidato a riego si pasan las demas barandillas.
+
+Xilema confirma tambien que `WATER A 1` sigue siendo `DRY_RUN` en la build
+actual. La ruta fisica segura es `PUMP_PULSE <ms>`; para smoke supervisado:
+`PUMP_PULSE 3000`. No usar `pump-toggle`, porque intenta `PUMP_ON/PUMP_OFF` y
+`PUMP_ON` no esta expuesto por seguridad.
+
+Meristem avisa que Gemma E2B puede caer a fallback si hereda `num_predict=256`.
+Rhizome no usa SQL de decisiones en Steward v0; usa JSONL. Aun asi, los dos usos
+Gemma de Rhizome suben `num_predict` a `1024` para evitar truncamiento:
+
+- rationale del Steward;
+- narrador Gemma de `summary/since`.
+
+## Decision
+
+Se incorpora `serial-water-command-mode=pump-pulse` en Rhizome. El Steward solo
+emitira `PUMP_PULSE <seconds*1000>` si la decision determinista llega a
+`WATER_A`, `EXECUTE_WATER=1` esta activo, y el ESP32 responde `ACK`.
+
+Para el sistema estable de maceta, el observe mode permanece como default hasta
+que Bea/Xilema confirmen condiciones fisicas: bomba sumergida, electronica seca,
+manguera colocada, `PUMP_STATUS state=OFF` y `soil_a_raw >= 2200`.

--- a/bitacora/2026-05-11_dia26-rhizome-pump-pulse-umbrales_endodermis.md
+++ b/bitacora/2026-05-11_dia26-rhizome-pump-pulse-umbrales_endodermis.md
@@ -41,3 +41,26 @@ emitira `PUMP_PULSE <seconds*1000>` si la decision determinista llega a
 Para el sistema estable de maceta, el observe mode permanece como default hasta
 que Bea/Xilema confirmen condiciones fisicas: bomba sumergida, electronica seca,
 manguera colocada, `PUMP_STATUS state=OFF` y `soil_a_raw >= 2200`.
+
+## Verificacion
+
+Local:
+
+```text
+python -m unittest tests.test_rhizome_steward tests.test_sync_facade
+31 tests OK
+```
+
+Jetson:
+
+```text
+git pull --ff-only origin feat/endodermis/rhizome-steward-v0
+HEAD 89a7be0
+ESP32_MODE=fake ... run_steward_once.sh
+```
+
+Resultado esperado en smoke sin hardware: Steward propuso `WATER_A` con
+telemetria fake seca, pero `executed=false` y
+`blocked_reason=OBSERVE_MODE_EXECUTE_WATER_FALSE`. Esto confirma que el modo por
+defecto sigue sin accionar agua; la ruta `PUMP_PULSE` solo queda disponible si
+se activa explicitamente `EXECUTE_WATER=1` y se usa ESP32 serial real.

--- a/bitacora/2026-05-11_shadow-skeptic-doble-agente-local_endodermis.md
+++ b/bitacora/2026-05-11_shadow-skeptic-doble-agente-local_endodermis.md
@@ -1,0 +1,21 @@
+# ShadowSkeptic como doble agente local no autoritativo
+
+**Autora:** Endodermis  
+**Fecha:** 2026-05-11  
+**Proyecto:** Sprout / Rhizome Jetson
+
+`ShadowSkeptic deterministic_shadow_skeptic_v0` es la primera forma practica de
+doble agente local dentro de Rhizome. No es todavia otro LLM decidiendo: es una
+conciencia tecnica determinista que revisa cada decision, declara si objetaria,
+lista preocupaciones y recomienda una alternativa mas prudente.
+
+La jurisdiccion es deliberadamente asimetrica. `GemmaArbiter`/Steward propone o
+explica dentro del sobre operativo; `ShadowSkeptic` observa, audita y produce
+datos. Su campo `affects_decision=false` es parte del diseno: no introduce una
+segunda autoridad fisica a cuatro dias de demo, pero empieza a medir cuantas
+veces una revision independiente habria pedido `DEFER`.
+
+Esto permite investigar doble agente sin poner agua en riesgo. La promocion
+futura seria convertir el shadow en LLM local, comparar sus objeciones contra
+receipts reales y solo despues decidir si alguna clase de objecion merece efecto
+operativo.

--- a/bitacora/2026-05-11_shadow-skeptic-doble-agente-local_endodermis.md
+++ b/bitacora/2026-05-11_shadow-skeptic-doble-agente-local_endodermis.md
@@ -5,9 +5,12 @@
 **Proyecto:** Sprout / Rhizome Jetson
 
 `ShadowSkeptic deterministic_shadow_skeptic_v0` es la primera forma practica de
-doble agente local dentro de Rhizome. No es todavia otro LLM decidiendo: es una
-conciencia tecnica determinista que revisa cada decision, declara si objetaria,
-lista preocupaciones y recomienda una alternativa mas prudente.
+doble agente local dentro de Rhizome. Su tesis es sencilla: una decision fisica
+puede ganar calidad si, ademas del agente que propone, existe una segunda
+instancia local cuya unica tarea es objetar con prudencia. No es todavia otro
+LLM decidiendo: es una conciencia tecnica determinista que revisa cada decision,
+declara si objetaria, lista preocupaciones y recomienda una alternativa mas
+prudente.
 
 La jurisdiccion es deliberadamente asimetrica. `GemmaArbiter`/Steward propone o
 explica dentro del sobre operativo; `ShadowSkeptic` observa, audita y produce
@@ -15,7 +18,12 @@ datos. Su campo `affects_decision=false` es parte del diseno: no introduce una
 segunda autoridad fisica a cuatro dias de demo, pero empieza a medir cuantas
 veces una revision independiente habria pedido `DEFER`.
 
-Esto permite investigar doble agente sin poner agua en riesgo. La promocion
-futura seria convertir el shadow en LLM local, comparar sus objeciones contra
-receipts reales y solo despues decidir si alguna clase de objecion merece efecto
-operativo.
+Esto permite investigar doble agente sin poner agua en riesgo. La evidencia vive
+en `DecisionReceipt` y en `shadow_skeptic/YYYY-MM-DD.jsonl`: no es una idea
+abstracta, es telemetria de desacuerdo. La promocion futura seria convertir el
+shadow en LLM local, comparar sus objeciones contra receipts reales y solo
+despues decidir si alguna clase de objecion merece efecto operativo.
+
+Lectura para writeup: Rhizome no solo usa Gemma 4 para decidir o explicar; esta
+preparando una arquitectura donde la inteligencia local tambien aprende a
+discutirse a si misma, con jurisdiccion limitada y sin saltarse el veto fisico.

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -284,6 +284,20 @@ facts ya decididos.
 Rhizome devuelve siempre JSON. Pollen puede elegir idioma con `?locale=en` o
 `?locale=es`; si no se indica, el fallback es `es`.
 
+Decision de arquitectura de idioma:
+
+- El sistema razona en contratos, no en el idioma de la interfaz.
+- Los campos operacionales (`action`, `executed`, `blocked_reason`, cantidades,
+  timestamps, codigos de veto) no se traducen.
+- Rhizome puede devolver narrativa localizada para el MVP, pero la fuente de
+  verdad sigue siendo el `DecisionReceipt`.
+- Pollen es la capa responsable de experiencia linguistica. Su Gemma 4 local
+  puede traducir solo la narrativa que no llegue ya localizada, segun el idioma
+  activo de la interfaz.
+- Esta separacion permite que, en el futuro, Pollen pueda usar fine-tuning o
+  adaptacion local para idiomas minoritarios (por ejemplo Pular, Swahili o
+  Wolof) sin pedir a Rhizome que cambie su logica de riego ni sus contratos.
+
 Endpoints principales:
 
 ```text

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -278,3 +278,53 @@ python -m src.rhizome_steward run-once \
 
 Gemma no cambia la accion ni autoriza agua; solo mejora la explicacion sobre
 facts ya decididos.
+
+### Datos devueltos a Pollen
+
+Rhizome devuelve siempre JSON. Pollen puede elegir idioma con `?locale=en` o
+`?locale=es`; si no se indica, el fallback es `es`.
+
+Endpoints principales:
+
+```text
+GET /snapshot/latest
+GET /receipts?since=<UTC_ZULU>
+GET /explain/decision/<decision_id>?locale=en|es
+GET /summary/since?since=<UTC_ZULU>&locale=en|es
+```
+
+`/receipts` devuelve `DecisionReceipt` casi canonico: `action`, `executed`,
+`blocked_reason`, `action_params`, `confidence`, `rationale_short`,
+`rationale_full`, `backend_used`, `contradictions`. Pollen debe tratar
+`executed=false` como propuesta no ejecutada, aunque `action` sea `WATER_A`.
+
+`/explain/decision/<id>` devuelve una explicacion localizada construida desde el
+receipt. Si Gemma 4 participo antes en el steward, esa explicacion incorpora el
+`rationale_*` escrito por Gemma en el receipt. Si no, usa rationale
+determinista.
+
+`/summary/since` devuelve el payload del boton principal de ausencia:
+
+```json
+{
+  "headline": "...",
+  "summary": "...",
+  "highlights": ["..."],
+  "recommendation": "...",
+  "counts": {
+    "total": 2,
+    "water": 1,
+    "water_proposed": 2,
+    "water_not_executed": 1,
+    "block": 0,
+    "alert": 0,
+    "executed": 1
+  },
+  "source": "deterministic_visit_summary",
+  "simulation": false
+}
+```
+
+Gemma 4 no es fuente de verdad para estos campos. Su papel correcto es redactar
+mejor `rationale_short`/`rationale_full` y, como siguiente paso, sintetizar una
+narrativa de ausencia a partir de snapshots y receipts ya validados.

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -342,3 +342,32 @@ determinista.
 Gemma 4 no es fuente de verdad para estos campos. Su papel correcto es redactar
 mejor `rationale_short`/`rationale_full` y, como siguiente paso, sintetizar una
 narrativa de ausencia a partir de snapshots y receipts ya validados.
+
+#### Narrador Gemma 4 opcional
+
+La fachada puede usar Gemma 4 E2B local como narrador del boton de ausencia:
+
+```bash
+GEMMA_VISIT_NARRATOR_URL=http://127.0.0.1:12000 \
+GEMMA_VISIT_NARRATOR_MODEL=gemma4:e2b \
+./start_sync_facade.sh
+```
+
+Cuando esta activo, Gemma solo puede reescribir `headline`, `summary`,
+`highlights` y `recommendation`. No puede cambiar `counts`, `severity`,
+`source`, `simulation`, receipts ni snapshots. Si Gemma falla, tarda demasiado o
+devuelve JSON invalido, la respuesta cae al resumen determinista.
+
+Campos de trazabilidad:
+
+```json
+{
+  "source": "deterministic_visit_summary",
+  "narrative_source": "gemma_visit_narrator",
+  "gemma_narrator": {
+    "enabled": true,
+    "used": true,
+    "model": "gemma4:e2b"
+  }
+}
+```

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -231,6 +231,12 @@ permite riego con deposito no sensorizado, el receipt conserva
 `flow_sensor_unavailable`. Cuando esos sensores existan, quitar el flag y usar
 modo estricto.
 
+Si la humedad llega como valor raw, la polaridad debe declararse. La sonda real
+del handoff de Xilema reporta `soil_a_raw < 1300` como suelo muy humedo, por lo
+que el primer observe mode usa `--soil-raw-polarity low_is_wet` y
+`--soil-wet-below-raw 1300`. Sin `--soil-dry-above-raw`, Rhizome puede hacer
+`SKIP` por suelo humedo, pero no autoriza `WATER` desde raw.
+
 Si la firmware minima expone solo encender/apagar bomba, no el comando
 temporizado `WATER A <seconds>`, usar:
 

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -153,3 +153,95 @@ rhizome_02 -> http://192.168.1.60:13020/
 
 `rhizome_02` usa `code/rhizome/demo_data/rhizome_02`. Debe documentarse como
 simulacion de interoperabilidad multi-Rhizome, no como segundo nodo fisico.
+
+## Rhizome Steward v0
+
+`src/rhizome_steward.py` cierra el bucle autonomo minimo para piloto de
+maceta supervisado:
+
+```text
+ESP32 TELEMETRY -> snapshot -> safety/need gate -> optional Gemma rationale
+-> optional WATER -> DecisionReceipt -> logs rotados -> facade_data
+```
+
+Propiedades de seguridad:
+
+- no envia `WATER` salvo que se pase `--execute-water`;
+- nunca supera `30s` por evento (`FIRMWARE_MAX_WATER_SECONDS_MVP`);
+- aplica cooldown local antes de volver a regar;
+- limita eventos autonomos por dia;
+- si no entiende la humedad, aplaza;
+- si deposito baja de minimo, emite `ALERT`;
+- si una lectura falta, el snapshot conserva schema valido y marca
+  `pending_contradictions`;
+- el `ShadowSkeptic` es experimental y no afecta la decision.
+
+Ejecucion sin hardware:
+
+```bash
+cd code/rhizome
+python -m src.rhizome_steward run-once --esp32 fake
+```
+
+Ejecucion con ESP32 real, una sola pasada, aun sin abrir agua:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0
+```
+
+Ejecucion con permiso explicito para mandar `WATER A <seconds>` al ESP32:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0 \
+  --execute-water \
+  --water-seconds 8
+```
+
+Si la sonda de humedad aun no esta calibrada a porcentaje, usar umbrales raw:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0 \
+  --soil-dry-below-raw 1500 \
+  --soil-wet-above-raw 2600
+```
+
+Persistencia por defecto:
+
+```text
+~/.local/share/sprout/rhizome_steward/
+├── telemetry_samples/YYYY-MM-DD.jsonl
+├── decision_receipts/YYYY-MM-DD.jsonl
+├── shadow_skeptic/YYYY-MM-DD.jsonl
+├── current_snapshot.json
+├── last_decision_receipt.json
+└── facade_data/
+```
+
+El store aplica retencion por dias y presupuesto total de bytes
+(`--retention-days`, `--max-total-bytes`) para poder correr semanas/meses sin
+rebosar la microSD. Para que Pollen vea el bucle real, arranca la fachada con:
+
+```bash
+python -m src.rhizome_sync_facade \
+  --host 0.0.0.0 \
+  --port 13010 \
+  --data-dir ~/.local/share/sprout/rhizome_steward/facade_data
+```
+
+Gemma 4 E2B puede entrar como redactor contractual de rationale con el adapter:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0 \
+  --gemma-rationale-url http://127.0.0.1:12000
+```
+
+Gemma no cambia la accion ni autoriza agua; solo mejora la explicacion sobre
+facts ya decididos.

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -172,6 +172,8 @@ Propiedades de seguridad:
 - limita eventos autonomos por dia;
 - si no entiende la humedad, aplaza;
 - si deposito baja de minimo, emite `ALERT`;
+- si no hay sensor de deposito, por defecto aplaza salvo permiso explicito de
+  perfil minimo;
 - si una lectura falta, el snapshot conserva schema valido y marca
   `pending_contradictions`;
 - el `ShadowSkeptic` es experimental y no afecta la decision.
@@ -210,6 +212,37 @@ python -m src.rhizome_steward run-once \
   --soil-dry-below-raw 1500 \
   --soil-wet-above-raw 2600
 ```
+
+Perfil hardware minimo de maceta:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0 \
+  --allow-missing-tank-sensor \
+  --soil-dry-below-raw 1500 \
+  --soil-wet-above-raw 2600
+```
+
+Este perfil existe para una ESP32 minima con bomba y sensor de humedad, mientras
+caudalimetro y nivel de deposito quedan previstos pero aun no instalados. Si se
+permite riego con deposito no sensorizado, el receipt conserva
+`tank_level_unavailable`; si falta caudalimetro, conserva
+`flow_sensor_unavailable`. Cuando esos sensores existan, quitar el flag y usar
+modo estricto.
+
+Si la firmware minima expone solo encender/apagar bomba, no el comando
+temporizado `WATER A <seconds>`, usar:
+
+```bash
+python -m src.rhizome_steward run-once \
+  --esp32 serial \
+  --serial-port /dev/ttyACM0 \
+  --serial-water-command-mode pump-toggle
+```
+
+El modo preferido sigue siendo `water-duration`, porque mantiene la duracion del
+evento bajo control de la frontera ESP32.
 
 Persistencia por defecto:
 

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -234,21 +234,34 @@ modo estricto.
 Si la humedad llega como valor raw, la polaridad debe declararse. La sonda real
 del handoff de Xilema reporta `soil_a_raw < 1300` como suelo muy humedo, por lo
 que el primer observe mode usa `--soil-raw-polarity low_is_wet` y
-`--soil-wet-below-raw 1300`. Sin `--soil-dry-above-raw`, Rhizome puede hacer
-`SKIP` por suelo humedo, pero no autoriza `WATER` desde raw.
+`--soil-wet-below-raw 1300`. Xilema fija para el MVP:
 
-Si la firmware minima expone solo encender/apagar bomba, no el comando
-temporizado `WATER A <seconds>`, usar:
+```text
+SOIL_RAW_POLARITY=low_is_wet
+SOIL_WET_BELOW_RAW=1300
+SOIL_DRY_ABOVE_RAW=2200
+```
+
+Interpretacion:
+
+- `<1300`: muy humedo, `SKIP`;
+- `1300..2199`: banda ambigua, `DEFER`;
+- `>=2200`: seco para MVP, candidato a `WATER_A` si pasan las demas
+  barandillas.
+
+Si la firmware minima expone el pulso fisico seguro `PUMP_PULSE <ms>`, usar:
 
 ```bash
 python -m src.rhizome_steward run-once \
   --esp32 serial \
   --serial-port /dev/ttyACM0 \
-  --serial-water-command-mode pump-toggle
+  --serial-water-command-mode pump-pulse
 ```
 
-El modo preferido sigue siendo `water-duration`, porque mantiene la duracion del
-evento bajo control de la frontera ESP32.
+No usar `pump-toggle` con el firmware de dia 26: esta build no expone
+`PUMP_ON`, y Xilema autoriza la ruta `PUMP_PULSE`. `water-duration` sigue siendo
+valido para builds que ejecuten `WATER A <seconds>` fisicamente en la frontera
+ESP32; en la build actual `WATER A 1` responde `execution=DRY_RUN`.
 
 Persistencia por defecto:
 
@@ -363,6 +376,9 @@ Cuando esta activo, Gemma solo puede reescribir `headline`, `summary`,
 `highlights` y `recommendation`. No puede cambiar `counts`, `severity`,
 `source`, `simulation`, receipts ni snapshots. Si Gemma falla, tarda demasiado o
 devuelve JSON invalido, la respuesta cae al resumen determinista.
+
+Configuracion E2B: los usos Gemma de Rhizome usan `num_predict=1024` para evitar
+fallbacks silenciosos por respuestas truncadas en E2B.
 
 Campos de trazabilidad:
 

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -253,8 +253,15 @@ SERIAL_WATER_COMMAND_MODE=pump-toggle \
 ALLOW_MISSING_TANK_SENSOR=1 \
 REQUIRE_FLOW_SENSOR_FOR_WATER=0 \
 EXECUTE_WATER=0 \
+SOIL_RAW_POLARITY=low_is_wet \
+SOIL_WET_BELOW_RAW=1300 \
 ./run_steward_once.sh
 ```
+
+La lectura actual documentada por Xilema (`soil_a_raw=1263-1267`) cae por
+debajo de `1300`, asi que Rhizome debe tratarla como suelo humedo y no proponer
+riego. En este perfil no se define `SOIL_DRY_ABOVE_RAW`: fuera de la banda
+humeda, Rhizome aplaza en vez de regar porque aun no hay calibracion seca.
 
 El primer riego real debe ser manual, corto y supervisado por Xilema/Bea,
 cambiando explicitamente `EXECUTE_WATER=1` y un `WATER_SECONDS` bajo.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -147,6 +147,20 @@ adapter Ollama-compatible (`:12000`). Es una fachada separada en `:13010`:
 ./smoke_sync_facade.sh
 ```
 
+Para activar el narrador Gemma 4 del boton de ausencia, primero debe estar vivo
+el adapter Ollama-compatible en `:12000`:
+
+```bash
+GEMMA_VISIT_NARRATOR_URL=http://127.0.0.1:12000 \
+GEMMA_VISIT_NARRATOR_MODEL=gemma4:e2b \
+./start_sync_facade.sh
+
+./smoke_gemma_visit_narrator.sh
+```
+
+El narrador solo reescribe narrativa humana. Los counts, receipts, flags
+`executed`, `simulation` y codigos de seguridad siguen siendo deterministas.
+
 Endpoints servidos:
 
 ```text
@@ -220,6 +234,30 @@ rhizome_02 -> http://<jetson-host-or-ip>:13020/
 `rhizome_02` usa datos de `code/rhizome/demo_data/rhizome_02`. Es una
 simulacion host-side de interoperabilidad multi-Rhizome: no hay segundo ESP32,
 no hay segunda bomba y no se toca hardware fisico.
+
+## Primer observe mode con ESP32 minimo
+
+Cuando el ESP32 exponga bomba on/off + humedad de tierra, probar primero sin
+ejecucion de agua:
+
+```bash
+./run_steward_serial_observe_minimal.sh
+```
+
+Equivale a:
+
+```bash
+ESP32_MODE=serial \
+ESP32_PORT=/dev/ttyACM0 \
+SERIAL_WATER_COMMAND_MODE=pump-toggle \
+ALLOW_MISSING_TANK_SENSOR=1 \
+REQUIRE_FLOW_SENSOR_FOR_WATER=0 \
+EXECUTE_WATER=0 \
+./run_steward_once.sh
+```
+
+El primer riego real debe ser manual, corto y supervisado por Xilema/Bea,
+cambiando explicitamente `EXECUTE_WATER=1` y un `WATER_SECONDS` bajo.
 
 Baseline operativo:
 

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -284,6 +284,20 @@ Una pasada contra ESP32 real sin permitir agua:
 ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./run_steward_once.sh
 ```
 
+Perfil minimo de maceta, previsto para ESP32 con bomba y sensor de humedad pero
+sin caudalimetro ni sensor de nivel todavia:
+
+```bash
+ESP32_MODE=serial \
+ESP32_PORT=/dev/ttyACM0 \
+ALLOW_MISSING_TANK_SENSOR=1 \
+./run_steward_once.sh
+```
+
+En este perfil Rhizome sigue escribiendo `tank_level_unavailable` y
+`flow_sensor_unavailable` cuando corresponda. No se oculta que esos sensores son
+previstos/futuros.
+
 Una pasada contra ESP32 real permitiendo agua. Usar solo con Xilema/Bea en la
 frontera fisica y con duraciones pequenas:
 
@@ -294,6 +308,19 @@ EXECUTE_WATER=1 \
 WATER_SECONDS=8 \
 ./run_steward_once.sh
 ```
+
+Si la firmware minima aun no tiene `WATER A <seconds>` y solo ofrece encender y
+apagar bomba:
+
+```bash
+ESP32_MODE=serial \
+ESP32_PORT=/dev/ttyACM0 \
+SERIAL_WATER_COMMAND_MODE=pump-toggle \
+./run_steward_once.sh
+```
+
+Usar `pump-toggle` solo como puente de bring-up. El modo preferido para demo
+fisica es `water-duration`, con temporizacion y failsafe en ESP32.
 
 Si la humedad llega como raw no calibrado, declarar umbrales raw:
 

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -263,3 +263,78 @@ quede alineado con el contrato.
 
 Si `gpu-experimental` falla durante el arranque, no depurar en caliente durante
 un rehearsal. Restaurar `safe-cpu` y documentar el log.
+
+## Steward autonomo minimo
+
+Para el piloto de maceta, `rhizome_steward.py` ejecuta el bucle minimo:
+
+```text
+heartbeat -> telemetry -> decision -> optional WATER -> receipt -> logs rotados
+```
+
+Smoke sin hardware real:
+
+```bash
+./run_steward_once.sh
+```
+
+Una pasada contra ESP32 real sin permitir agua:
+
+```bash
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./run_steward_once.sh
+```
+
+Una pasada contra ESP32 real permitiendo agua. Usar solo con Xilema/Bea en la
+frontera fisica y con duraciones pequenas:
+
+```bash
+ESP32_MODE=serial \
+ESP32_PORT=/dev/ttyACM0 \
+EXECUTE_WATER=1 \
+WATER_SECONDS=8 \
+./run_steward_once.sh
+```
+
+Si la humedad llega como raw no calibrado, declarar umbrales raw:
+
+```bash
+ESP32_MODE=serial \
+ESP32_PORT=/dev/ttyACM0 \
+SOIL_DRY_BELOW_RAW=1500 \
+SOIL_WET_ABOVE_RAW=2600 \
+./run_steward_once.sh
+```
+
+Loop autonomo:
+
+```bash
+ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./start_steward_loop.sh
+```
+
+Por defecto el loop decide cada 15 minutos, mantiene heartbeat entre
+decisiones, rota logs y escribe en:
+
+```text
+$HOME/.local/share/sprout/rhizome_steward/
+```
+
+El wrapper deriva `SYNC_FACADE_STATE_DIR` de `NODE_ID`, de modo que
+`NODE_ID=rhizome_02` buscara politica activa en
+`/tmp/sprout_rhizome_sync_facade/rhizome_02` salvo override explicito.
+
+Para que Pollen lea el estado real del steward:
+
+```bash
+FACADE_DATA_DIR=$HOME/.local/share/sprout/rhizome_steward/facade_data \
+./start_sync_facade.sh
+```
+
+Gemma 4 E2B puede mejorar la explicacion sin cambiar accion:
+
+```bash
+GEMMA_RATIONALE_URL=http://127.0.0.1:12000 ./run_steward_once.sh
+```
+
+El `ShadowSkeptic` se ejecuta por defecto como experimento de doble agente
+no vinculante. Sus observaciones se guardan en `shadow_skeptic/YYYY-MM-DD.jsonl`
+y siempre llevan `affects_decision=false`.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -263,6 +263,20 @@ debajo de `1300`, asi que Rhizome debe tratarla como suelo humedo y no proponer
 riego. En este perfil no se define `SOIL_DRY_ABOVE_RAW`: fuera de la banda
 humeda, Rhizome aplaza en vez de regar porque aun no hay calibracion seca.
 
+Umbrales autorizados por Xilema para el MVP:
+
+```text
+SOIL_RAW_POLARITY=low_is_wet
+SOIL_WET_BELOW_RAW=1300
+SOIL_DRY_ABOVE_RAW=2200
+```
+
+Interpretacion:
+
+- `<1300`: muy humedo, no regar.
+- `1300..2199`: banda ambigua, `DEFER`/observe.
+- `>=2200`: seco para MVP, candidato a riego si pasan las demas barandillas.
+
 El primer riego real debe ser manual, corto y supervisado por Xilema/Bea,
 cambiando explicitamente `EXECUTE_WATER=1` y un `WATER_SECONDS` bajo.
 
@@ -354,18 +368,23 @@ WATER_SECONDS=8 \
 ./run_steward_once.sh
 ```
 
-Si la firmware minima aun no tiene `WATER A <seconds>` y solo ofrece encender y
-apagar bomba:
+Si la firmware minima expone `PUMP_PULSE <ms>` como ruta segura:
 
 ```bash
 ESP32_MODE=serial \
 ESP32_PORT=/dev/ttyACM0 \
-SERIAL_WATER_COMMAND_MODE=pump-toggle \
+SERIAL_WATER_COMMAND_MODE=pump-pulse \
+SOIL_RAW_POLARITY=low_is_wet \
+SOIL_WET_BELOW_RAW=1300 \
+SOIL_DRY_ABOVE_RAW=2200 \
+EXECUTE_WATER=1 \
+WATER_SECONDS=3 \
 ./run_steward_once.sh
 ```
 
-Usar `pump-toggle` solo como puente de bring-up. El modo preferido para demo
-fisica es `water-duration`, con temporizacion y failsafe en ESP32.
+Esto emite `PUMP_PULSE 3000` solo si Rhizome decide `WATER_A`. No usar
+`pump-toggle` con la build de dia 26: `PUMP_ON` no esta expuesto por seguridad.
+`WATER A 1` sigue siendo `DRY_RUN` en esta build.
 
 Si la humedad llega como raw no calibrado, declarar umbrales raw:
 

--- a/code/rhizome/jetson/run_steward_once.sh
+++ b/code/rhizome/jetson/run_steward_once.sh
@@ -21,6 +21,9 @@ SOIL_DRY_BELOW_PCT="${SOIL_DRY_BELOW_PCT:-35}"
 SOIL_WET_ABOVE_PCT="${SOIL_WET_ABOVE_PCT:-55}"
 SOIL_DRY_BELOW_RAW="${SOIL_DRY_BELOW_RAW:-}"
 SOIL_WET_ABOVE_RAW="${SOIL_WET_ABOVE_RAW:-}"
+SOIL_RAW_POLARITY="${SOIL_RAW_POLARITY:-low_is_dry}"
+SOIL_WET_BELOW_RAW="${SOIL_WET_BELOW_RAW:-}"
+SOIL_DRY_ABOVE_RAW="${SOIL_DRY_ABOVE_RAW:-}"
 GEMMA_RATIONALE_URL="${GEMMA_RATIONALE_URL:-}"
 STEWARD_COMMAND="${STEWARD_COMMAND:-run-once}"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
@@ -39,6 +42,7 @@ ARGS=(
   --retention-days "$RETENTION_DAYS"
   --soil-dry-below-pct "$SOIL_DRY_BELOW_PCT"
   --soil-wet-above-pct "$SOIL_WET_ABOVE_PCT"
+  --soil-raw-polarity "$SOIL_RAW_POLARITY"
 )
 
 if [ "$ESP32_MODE" = "serial" ]; then
@@ -63,6 +67,14 @@ fi
 
 if [ -n "$SOIL_WET_ABOVE_RAW" ]; then
   ARGS+=(--soil-wet-above-raw "$SOIL_WET_ABOVE_RAW")
+fi
+
+if [ -n "$SOIL_WET_BELOW_RAW" ]; then
+  ARGS+=(--soil-wet-below-raw "$SOIL_WET_BELOW_RAW")
+fi
+
+if [ -n "$SOIL_DRY_ABOVE_RAW" ]; then
+  ARGS+=(--soil-dry-above-raw "$SOIL_DRY_ABOVE_RAW")
 fi
 
 if [ -n "$GEMMA_RATIONALE_URL" ]; then

--- a/code/rhizome/jetson/run_steward_once.sh
+++ b/code/rhizome/jetson/run_steward_once.sh
@@ -6,7 +6,10 @@ STEWARD_STATE_DIR="${STEWARD_STATE_DIR:-$HOME/.local/share/sprout/rhizome_stewar
 STEWARD_FACADE_DATA_DIR="${STEWARD_FACADE_DATA_DIR:-$STEWARD_STATE_DIR/facade_data}"
 ESP32_MODE="${ESP32_MODE:-fake}"
 ESP32_PORT="${ESP32_PORT:-/dev/ttyACM0}"
+SERIAL_WATER_COMMAND_MODE="${SERIAL_WATER_COMMAND_MODE:-water-duration}"
 EXECUTE_WATER="${EXECUTE_WATER:-0}"
+ALLOW_MISSING_TANK_SENSOR="${ALLOW_MISSING_TANK_SENSOR:-0}"
+REQUIRE_FLOW_SENSOR_FOR_WATER="${REQUIRE_FLOW_SENSOR_FOR_WATER:-0}"
 NODE_ID="${NODE_ID:-rhizome_01}"
 SYNC_FACADE_STATE_DIR="${SYNC_FACADE_STATE_DIR:-/tmp/sprout_rhizome_sync_facade/$NODE_ID}"
 DECISION_INTERVAL_S="${DECISION_INTERVAL_S:-900}"
@@ -39,11 +42,19 @@ ARGS=(
 )
 
 if [ "$ESP32_MODE" = "serial" ]; then
-  ARGS+=(--serial-port "$ESP32_PORT")
+  ARGS+=(--serial-port "$ESP32_PORT" --serial-water-command-mode "$SERIAL_WATER_COMMAND_MODE")
 fi
 
 if [ "$EXECUTE_WATER" = "1" ]; then
   ARGS+=(--execute-water)
+fi
+
+if [ "$ALLOW_MISSING_TANK_SENSOR" = "1" ]; then
+  ARGS+=(--allow-missing-tank-sensor)
+fi
+
+if [ "$REQUIRE_FLOW_SENSOR_FOR_WATER" = "1" ]; then
+  ARGS+=(--require-flow-sensor-for-water)
 fi
 
 if [ -n "$SOIL_DRY_BELOW_RAW" ]; then

--- a/code/rhizome/jetson/run_steward_once.sh
+++ b/code/rhizome/jetson/run_steward_once.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$HOME/sprout}"
+STEWARD_STATE_DIR="${STEWARD_STATE_DIR:-$HOME/.local/share/sprout/rhizome_steward}"
+STEWARD_FACADE_DATA_DIR="${STEWARD_FACADE_DATA_DIR:-$STEWARD_STATE_DIR/facade_data}"
+ESP32_MODE="${ESP32_MODE:-fake}"
+ESP32_PORT="${ESP32_PORT:-/dev/ttyACM0}"
+EXECUTE_WATER="${EXECUTE_WATER:-0}"
+NODE_ID="${NODE_ID:-rhizome_01}"
+SYNC_FACADE_STATE_DIR="${SYNC_FACADE_STATE_DIR:-/tmp/sprout_rhizome_sync_facade/$NODE_ID}"
+DECISION_INTERVAL_S="${DECISION_INTERVAL_S:-900}"
+COOLDOWN_S="${COOLDOWN_S:-7200}"
+WATER_SECONDS="${WATER_SECONDS:-8}"
+MAX_TOTAL_BYTES="${MAX_TOTAL_BYTES:-67108864}"
+RETENTION_DAYS="${RETENTION_DAYS:-120}"
+SOIL_DRY_BELOW_PCT="${SOIL_DRY_BELOW_PCT:-35}"
+SOIL_WET_ABOVE_PCT="${SOIL_WET_ABOVE_PCT:-55}"
+SOIL_DRY_BELOW_RAW="${SOIL_DRY_BELOW_RAW:-}"
+SOIL_WET_ABOVE_RAW="${SOIL_WET_ABOVE_RAW:-}"
+GEMMA_RATIONALE_URL="${GEMMA_RATIONALE_URL:-}"
+STEWARD_COMMAND="${STEWARD_COMMAND:-run-once}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+ARGS=(
+  "$STEWARD_COMMAND"
+  --node-id "$NODE_ID"
+  --state-dir "$STEWARD_STATE_DIR"
+  --facade-data-dir "$STEWARD_FACADE_DATA_DIR"
+  --sync-facade-state-dir "$SYNC_FACADE_STATE_DIR"
+  --esp32 "$ESP32_MODE"
+  --decision-interval-s "$DECISION_INTERVAL_S"
+  --cooldown-s "$COOLDOWN_S"
+  --water-seconds "$WATER_SECONDS"
+  --max-total-bytes "$MAX_TOTAL_BYTES"
+  --retention-days "$RETENTION_DAYS"
+  --soil-dry-below-pct "$SOIL_DRY_BELOW_PCT"
+  --soil-wet-above-pct "$SOIL_WET_ABOVE_PCT"
+)
+
+if [ "$ESP32_MODE" = "serial" ]; then
+  ARGS+=(--serial-port "$ESP32_PORT")
+fi
+
+if [ "$EXECUTE_WATER" = "1" ]; then
+  ARGS+=(--execute-water)
+fi
+
+if [ -n "$SOIL_DRY_BELOW_RAW" ]; then
+  ARGS+=(--soil-dry-below-raw "$SOIL_DRY_BELOW_RAW")
+fi
+
+if [ -n "$SOIL_WET_ABOVE_RAW" ]; then
+  ARGS+=(--soil-wet-above-raw "$SOIL_WET_ABOVE_RAW")
+fi
+
+if [ -n "$GEMMA_RATIONALE_URL" ]; then
+  ARGS+=(--gemma-rationale-url "$GEMMA_RATIONALE_URL")
+fi
+
+cd "$REPO_DIR/code/rhizome"
+"$PYTHON_BIN" -m src.rhizome_steward "${ARGS[@]}"

--- a/code/rhizome/jetson/run_steward_serial_observe_minimal.sh
+++ b/code/rhizome/jetson/run_steward_serial_observe_minimal.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal ESP32 profile for the first physical smoke:
+# - serial ESP32
+# - pump-toggle command mode
+# - missing tank sensor allowed but traceable
+# - missing flow sensor allowed for MVP observe mode
+# - no water execution
+
+export ESP32_MODE="${ESP32_MODE:-serial}"
+export ESP32_PORT="${ESP32_PORT:-/dev/ttyACM0}"
+export SERIAL_WATER_COMMAND_MODE="${SERIAL_WATER_COMMAND_MODE:-pump-toggle}"
+export ALLOW_MISSING_TANK_SENSOR="${ALLOW_MISSING_TANK_SENSOR:-1}"
+export REQUIRE_FLOW_SENSOR_FOR_WATER="${REQUIRE_FLOW_SENSOR_FOR_WATER:-0}"
+export EXECUTE_WATER=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/run_steward_once.sh"

--- a/code/rhizome/jetson/run_steward_serial_observe_minimal.sh
+++ b/code/rhizome/jetson/run_steward_serial_observe_minimal.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # - pump-toggle command mode
 # - missing tank sensor allowed but traceable
 # - missing flow sensor allowed for MVP observe mode
+# - raw soil polarity from Xilema handoff: lower raw currently means wetter soil
 # - no water execution
 
 export ESP32_MODE="${ESP32_MODE:-serial}"
@@ -13,6 +14,8 @@ export ESP32_PORT="${ESP32_PORT:-/dev/ttyACM0}"
 export SERIAL_WATER_COMMAND_MODE="${SERIAL_WATER_COMMAND_MODE:-pump-toggle}"
 export ALLOW_MISSING_TANK_SENSOR="${ALLOW_MISSING_TANK_SENSOR:-1}"
 export REQUIRE_FLOW_SENSOR_FOR_WATER="${REQUIRE_FLOW_SENSOR_FOR_WATER:-0}"
+export SOIL_RAW_POLARITY="${SOIL_RAW_POLARITY:-low_is_wet}"
+export SOIL_WET_BELOW_RAW="${SOIL_WET_BELOW_RAW:-1300}"
 export EXECUTE_WATER=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/code/rhizome/jetson/smoke_gemma_visit_narrator.sh
+++ b/code/rhizome/jetson/smoke_gemma_visit_narrator.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FACADE_URL="${FACADE_URL:-http://127.0.0.1:13010}"
+
+python3 - "$FACADE_URL" <<'PY'
+import json
+import sys
+import urllib.request
+
+base_url = sys.argv[1].rstrip("/")
+
+with urllib.request.urlopen(f"{base_url}/summary/since?locale=en", timeout=180) as response:
+    payload = json.loads(response.read().decode("utf-8"))
+
+if payload.get("source") != "deterministic_visit_summary":
+    raise SystemExit(f"unexpected source: {payload.get('source')}")
+if payload.get("narrative_source") != "gemma_visit_narrator":
+    raise SystemExit(f"Gemma narrator not used: {payload.get('gemma_narrator')}")
+if not payload.get("gemma_narrator", {}).get("used"):
+    raise SystemExit(f"Gemma narrator disabled or fallback: {payload.get('gemma_narrator')}")
+if not isinstance(payload.get("counts"), dict):
+    raise SystemExit(f"missing deterministic counts: {payload}")
+
+print(
+    json.dumps(
+        {
+            "status": "ok",
+            "facade_url": base_url,
+            "narrative_source": payload["narrative_source"],
+            "counts": payload["counts"],
+            "headline": payload.get("headline"),
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+)
+PY

--- a/code/rhizome/jetson/start_steward_loop.sh
+++ b/code/rhizome/jetson/start_steward_loop.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$HOME/sprout}"
+STEWARD_STATE_DIR="${STEWARD_STATE_DIR:-$HOME/.local/share/sprout/rhizome_steward}"
+STEWARD_LOG_FILE="${STEWARD_LOG_FILE:-/tmp/sprout_rhizome_steward.log}"
+STEWARD_PID_FILE="${STEWARD_PID_FILE:-/tmp/sprout_rhizome_steward.pid}"
+
+if [ -f "$STEWARD_PID_FILE" ]; then
+  old_pid="$(cat "$STEWARD_PID_FILE" 2>/dev/null || true)"
+  if [ -n "$old_pid" ] && kill -0 "$old_pid" >/dev/null 2>&1; then
+    echo "Stopping previous Rhizome steward pid=$old_pid"
+    kill "$old_pid" >/dev/null 2>&1 || true
+    sleep 1
+  fi
+fi
+
+mkdir -p "$(dirname "$STEWARD_LOG_FILE")" "$STEWARD_STATE_DIR"
+
+echo "Starting Rhizome Steward v0"
+echo "Repo: $REPO_DIR"
+echo "State: $STEWARD_STATE_DIR"
+echo "Log: $STEWARD_LOG_FILE"
+echo "ESP32_MODE=${ESP32_MODE:-fake}"
+echo "EXECUTE_WATER=${EXECUTE_WATER:-0}"
+
+(
+  cd "$REPO_DIR/code/rhizome/jetson"
+  nohup env STEWARD_COMMAND=run-loop ./run_steward_once.sh >"$STEWARD_LOG_FILE" 2>&1 &
+  echo $! >"$STEWARD_PID_FILE"
+)
+
+pid="$(cat "$STEWARD_PID_FILE")"
+echo "PID: $pid"
+sleep 1
+tail -20 "$STEWARD_LOG_FILE" || true

--- a/code/rhizome/jetson/start_sync_facade.sh
+++ b/code/rhizome/jetson/start_sync_facade.sh
@@ -8,6 +8,8 @@ FACADE_PID_FILE="${FACADE_PID_FILE:-/tmp/sprout_${FACADE_NODE_ID}_sync_facade_${
 FACADE_LOG_FILE="${FACADE_LOG_FILE:-/tmp/sprout_${FACADE_NODE_ID}_sync_facade_${FACADE_PORT}.log}"
 FACADE_DATA_DIR="${FACADE_DATA_DIR:-}"
 FACADE_STATE_DIR="${FACADE_STATE_DIR:-/tmp/sprout_rhizome_sync_facade/${FACADE_NODE_ID}}"
+GEMMA_VISIT_NARRATOR_URL="${GEMMA_VISIT_NARRATOR_URL:-}"
+GEMMA_VISIT_NARRATOR_MODEL="${GEMMA_VISIT_NARRATOR_MODEL:-gemma4:e2b}"
 REPO_DIR="${REPO_DIR:-$HOME/sprout}"
 LEGACY_PID_FILE="/tmp/sprout_rhizome_sync_facade.pid"
 
@@ -39,6 +41,9 @@ echo "Node: $FACADE_NODE_ID"
 echo "Repo: $REPO_DIR"
 echo "Log: $FACADE_LOG_FILE"
 echo "State: $FACADE_STATE_DIR"
+if [ -n "$GEMMA_VISIT_NARRATOR_URL" ]; then
+  echo "Gemma visit narrator: $GEMMA_VISIT_NARRATOR_URL ($GEMMA_VISIT_NARRATOR_MODEL)"
+fi
 
 FACADE_ARGS=(
   --host "$FACADE_HOST"
@@ -49,6 +54,10 @@ FACADE_ARGS=(
 
 if [ -n "$FACADE_DATA_DIR" ]; then
   FACADE_ARGS+=(--data-dir "$FACADE_DATA_DIR")
+fi
+
+if [ -n "$GEMMA_VISIT_NARRATOR_URL" ]; then
+  FACADE_ARGS+=(--narrator-url "$GEMMA_VISIT_NARRATOR_URL" --narrator-model "$GEMMA_VISIT_NARRATOR_MODEL")
 fi
 
 (

--- a/code/rhizome/src/rhizome_steward.py
+++ b/code/rhizome/src/rhizome_steward.py
@@ -256,18 +256,19 @@ class SerialESP32Client:
             self.serial = TermiosSerialPort(port=port, baud=baud, timeout_s=timeout_s)
         else:
             self.serial = serial.Serial(port=port, baudrate=baud, timeout=timeout_s)
-        if water_command_mode not in {"water-duration", "pump-toggle"}:
-            raise ValueError("water_command_mode debe ser water-duration o pump-toggle")
+        if water_command_mode not in {"water-duration", "pump-toggle", "pump-pulse"}:
+            raise ValueError("water_command_mode debe ser water-duration, pump-toggle o pump-pulse")
         self.quiet_s = quiet_s
         self.max_wait_s = max_wait_s
         self.water_command_mode = water_command_mode
         self.serial.reset_input_buffer()
         self.serial.reset_output_buffer()
 
-    def _collect(self) -> list[str]:
+    def _collect(self, max_wait_s: float | None = None) -> list[str]:
         lines: list[str] = []
         started_at = time.monotonic()
         last_payload_at: float | None = None
+        max_wait_s = max_wait_s if max_wait_s is not None else self.max_wait_s
         while True:
             raw = self.serial.readline()
             current = time.monotonic()
@@ -283,10 +284,10 @@ class SerialESP32Client:
                 break
         return lines
 
-    def command(self, command: str) -> ESP32CommandResult:
+    def command(self, command: str, max_wait_s: float | None = None) -> ESP32CommandResult:
         sent_at = zulu(utc_now())
         self.serial.write(f"{command}\n".encode("utf-8"))
-        lines = self._collect()
+        lines = self._collect(max_wait_s=max_wait_s)
         received_at = zulu(utc_now())
         combined = "\n".join(lines)
         if "REJECT reason=" in combined:
@@ -313,6 +314,9 @@ class SerialESP32Client:
     def water(self, plot: str, seconds: int) -> ESP32CommandResult:
         if self.water_command_mode == "water-duration":
             return self.command(f"WATER {plot} {seconds}")
+        if self.water_command_mode == "pump-pulse":
+            pulse_ms = max(1, int(seconds * 1000))
+            return self.command(f"PUMP_PULSE {pulse_ms}", max_wait_s=max(self.max_wait_s, seconds + 2.0))
         started = self.command("PUMP_ON")
         if not started.ok:
             return started
@@ -723,7 +727,7 @@ class GemmaRationaleClient:
             ],
             "stream": False,
             "think": False,
-            "options": {"temperature": 0.1, "num_ctx": 2048, "num_predict": 160},
+            "options": {"temperature": 0.1, "num_ctx": 2048, "num_predict": 1024},
         }
         request = urllib.request.Request(
             f"{self.adapter_url}/api/chat",
@@ -1017,7 +1021,7 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--esp32", choices=["fake", "serial"], default="fake")
     parser.add_argument("--serial-port")
     parser.add_argument("--baud", type=int, default=115200)
-    parser.add_argument("--serial-water-command-mode", choices=["water-duration", "pump-toggle"], default="water-duration")
+    parser.add_argument("--serial-water-command-mode", choices=["water-duration", "pump-toggle", "pump-pulse"], default="water-duration")
     parser.add_argument("--execute-water", action="store_true", help="Permite enviar WATER al ESP32. Sin esto, WATER queda bloqueado como observe mode.")
     parser.add_argument("--decision-interval-s", type=int, default=900)
     parser.add_argument("--heartbeat-interval-s", type=int, default=2)

--- a/code/rhizome/src/rhizome_steward.py
+++ b/code/rhizome/src/rhizome_steward.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import select
 import time
 import urllib.error
 import urllib.request
@@ -193,18 +194,75 @@ class FakeESP32Client:
         return
 
 
+class TermiosSerialPort:
+    """Small Linux serial fallback for Jetson when pyserial is unavailable."""
+
+    def __init__(self, port: str, baud: int, timeout_s: float) -> None:
+        if baud != 115200:
+            raise RuntimeError("TermiosSerialPort fallback solo soporta 115200 baud en MVP.")
+        import termios
+
+        self.termios = termios
+        self.timeout = timeout_s
+        self.fd = os.open(port, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+        attrs = termios.tcgetattr(self.fd)
+        attrs[0] = 0
+        attrs[1] = 0
+        attrs[2] = termios.CS8 | termios.CREAD | termios.CLOCAL
+        attrs[3] = 0
+        attrs[4] = termios.B115200
+        attrs[5] = termios.B115200
+        termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
+
+    def write(self, data: bytes) -> int:
+        return os.write(self.fd, data)
+
+    def readline(self) -> bytes:
+        deadline = time.monotonic() + self.timeout
+        chunks: list[bytes] = []
+        while time.monotonic() < deadline:
+            remaining = max(0.0, deadline - time.monotonic())
+            ready, _, _ = select.select([self.fd], [], [], min(remaining, self.timeout))
+            if not ready:
+                break
+            try:
+                chunk = os.read(self.fd, 1)
+            except BlockingIOError:
+                continue
+            if not chunk:
+                break
+            chunks.append(chunk)
+            if chunk == b"\n":
+                break
+        return b"".join(chunks)
+
+    def reset_input_buffer(self) -> None:
+        self.termios.tcflush(self.fd, self.termios.TCIFLUSH)
+
+    def reset_output_buffer(self) -> None:
+        self.termios.tcflush(self.fd, self.termios.TCOFLUSH)
+
+    def close(self) -> None:
+        os.close(self.fd)
+
+
 class SerialESP32Client:
     def __init__(self, port: str, baud: int = 115200, timeout_s: float = 0.1, quiet_s: float = 0.35, max_wait_s: float = 3.0, water_command_mode: str = "water-duration") -> None:
         try:
             import serial  # type: ignore
         except ModuleNotFoundError as exc:
-            raise RuntimeError("pyserial no esta instalado. Instala hardware/host_tools/requirements.txt") from exc
+            if os.name != "posix":
+                raise RuntimeError("pyserial no esta instalado. Instala hardware/host_tools/requirements.txt") from exc
+            self.serial = TermiosSerialPort(port=port, baud=baud, timeout_s=timeout_s)
+        else:
+            self.serial = serial.Serial(port=port, baudrate=baud, timeout=timeout_s)
         if water_command_mode not in {"water-duration", "pump-toggle"}:
             raise ValueError("water_command_mode debe ser water-duration o pump-toggle")
-        self.serial = serial.Serial(port=port, baudrate=baud, timeout=timeout_s)
         self.quiet_s = quiet_s
         self.max_wait_s = max_wait_s
         self.water_command_mode = water_command_mode
+        self.serial.reset_input_buffer()
+        self.serial.reset_output_buffer()
 
     def _collect(self) -> list[str]:
         lines: list[str] = []

--- a/code/rhizome/src/rhizome_steward.py
+++ b/code/rhizome/src/rhizome_steward.py
@@ -107,13 +107,13 @@ class Telemetry:
             soil_b_raw = _int_or_none(values.get("soil_b_raw"))
             tank_level_pct = _float_or_none(values.get("tank_level_pct"))
             flow_pulses = _int_or_none(values.get("flow_pulses"))
-            telemetry.soil_a_raw = soil_a_raw if soil_a_raw is not None else telemetry.soil_a_raw
-            telemetry.soil_b_raw = soil_b_raw if soil_b_raw is not None else telemetry.soil_b_raw
-            telemetry.tank_level_pct = tank_level_pct if tank_level_pct is not None else telemetry.tank_level_pct
-            telemetry.flow_pulses = flow_pulses if flow_pulses is not None else telemetry.flow_pulses
+            telemetry.soil_a_raw = soil_a_raw if soil_a_raw is not None and soil_a_raw >= 0 else telemetry.soil_a_raw
+            telemetry.soil_b_raw = soil_b_raw if soil_b_raw is not None and soil_b_raw >= 0 else telemetry.soil_b_raw
+            telemetry.tank_level_pct = tank_level_pct if tank_level_pct is not None and tank_level_pct >= 0 else telemetry.tank_level_pct
+            telemetry.flow_pulses = flow_pulses if flow_pulses is not None and flow_pulses >= 0 else telemetry.flow_pulses
             telemetry.host_link = values.get("host_link", telemetry.host_link)
             host_age_ms = _int_or_none(values.get("host_age_ms"))
-            telemetry.host_age_ms = host_age_ms if host_age_ms is not None else telemetry.host_age_ms
+            telemetry.host_age_ms = host_age_ms if host_age_ms is not None and host_age_ms >= 0 else telemetry.host_age_ms
             telemetry.bme280 = values.get("bme280", telemetry.bme280)
             temp_x100 = _float_or_none(values.get("bme280_temp_c_x100"))
             if temp_x100 is not None and temp_x100 >= -10000:
@@ -177,7 +177,7 @@ class FakeESP32Client:
             f"soil_a_raw={self.current_telemetry.soil_a_raw if self.current_telemetry.soil_a_raw is not None else -1} "
             f"soil_b_raw={self.current_telemetry.soil_b_raw if self.current_telemetry.soil_b_raw is not None else -1} "
             f"tank_level_pct={self.current_telemetry.tank_level_pct if self.current_telemetry.tank_level_pct is not None else -1} "
-            f"flow_pulses={self.current_telemetry.flow_pulses if self.current_telemetry.flow_pulses is not None else 0} "
+            f"flow_pulses={self.current_telemetry.flow_pulses if self.current_telemetry.flow_pulses is not None else -1} "
             f"host_link={self.current_telemetry.host_link} host_age_ms={self.current_telemetry.host_age_ms if self.current_telemetry.host_age_ms is not None else -1} "
             "source=fake"
         )
@@ -194,14 +194,17 @@ class FakeESP32Client:
 
 
 class SerialESP32Client:
-    def __init__(self, port: str, baud: int = 115200, timeout_s: float = 0.1, quiet_s: float = 0.35, max_wait_s: float = 3.0) -> None:
+    def __init__(self, port: str, baud: int = 115200, timeout_s: float = 0.1, quiet_s: float = 0.35, max_wait_s: float = 3.0, water_command_mode: str = "water-duration") -> None:
         try:
             import serial  # type: ignore
         except ModuleNotFoundError as exc:
             raise RuntimeError("pyserial no esta instalado. Instala hardware/host_tools/requirements.txt") from exc
+        if water_command_mode not in {"water-duration", "pump-toggle"}:
+            raise ValueError("water_command_mode debe ser water-duration o pump-toggle")
         self.serial = serial.Serial(port=port, baudrate=baud, timeout=timeout_s)
         self.quiet_s = quiet_s
         self.max_wait_s = max_wait_s
+        self.water_command_mode = water_command_mode
 
     def _collect(self) -> list[str]:
         lines: list[str] = []
@@ -250,7 +253,24 @@ class SerialESP32Client:
         return telemetry
 
     def water(self, plot: str, seconds: int) -> ESP32CommandResult:
-        return self.command(f"WATER {plot} {seconds}")
+        if self.water_command_mode == "water-duration":
+            return self.command(f"WATER {plot} {seconds}")
+        started = self.command("PUMP_ON")
+        if not started.ok:
+            return started
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            time.sleep(min(0.25, max(0.0, deadline - time.monotonic())))
+        stopped = self.command("PUMP_OFF")
+        return ESP32CommandResult(
+            ok=stopped.ok,
+            command=f"PUMP_ON/PUMP_OFF {seconds}",
+            sent_at=started.sent_at,
+            received_at=stopped.received_at,
+            lines=[*started.lines, *stopped.lines],
+            ack_status=stopped.ack_status,
+            reject_reason=stopped.reject_reason,
+        )
 
     def close(self) -> None:
         self.serial.close()
@@ -273,6 +293,8 @@ class StewardConfig:
     tank_minimum_pct: float = FIRMWARE_TANK_MINIMUM_PCT
     max_water_seconds: int = FIRMWARE_MAX_WATER_SECONDS_MVP
     max_autonomous_waters_per_day: int = 2
+    allow_missing_tank_sensor: bool = False
+    allow_missing_flow_sensor: bool = True
     execute_water: bool = False
     shadow_skeptic_enabled: bool = True
     gemma_rationale_url: str | None = None
@@ -425,6 +447,18 @@ class DeterministicDecisionEngine:
                 blocked_reason="TANK_LOW",
                 policy_refs=[str(active_policy_id), "firmware.tank_minimum_pct"],
             )
+        if tank is None and not config.allow_missing_tank_sensor:
+            return Decision(
+                action="DEFER",
+                action_params={"defer_until": zulu(now + timedelta(seconds=config.decision_interval_s)), "reason": "TANK_SENSOR_UNAVAILABLE"},
+                mode="safety_block",
+                rationale_short="No hay lectura de deposito. Se aplaza hasta sensor o verificacion manual explicita.",
+                rationale_full="Gate determinista: por defecto Rhizome no riega si falta el sensor de deposito previsto por la arquitectura.",
+                confidence=0.90,
+                blocked_reason="TANK_SENSOR_UNAVAILABLE",
+                policy_refs=[str(active_policy_id), "config.allow_missing_tank_sensor"],
+                contradictions=["tank_level_unavailable"],
+            )
 
         if telemetry.host_link not in {"FRESH", "UNKNOWN"}:
             return Decision(
@@ -491,17 +525,43 @@ class DeterministicDecisionEngine:
             )
 
         if soil_value <= dry_below:
+            if telemetry.flow_pulses is None and not config.allow_missing_flow_sensor:
+                return Decision(
+                    action="DEFER",
+                    action_params={"defer_until": zulu(now + timedelta(seconds=config.decision_interval_s)), "reason": "FLOW_SENSOR_UNAVAILABLE"},
+                    mode="safety_block",
+                    rationale_short="No hay caudalimetro disponible para verificar riego. Se aplaza.",
+                    rationale_full="Gate determinista: en modo estricto, Rhizome no ejecuta WATER sin sensor de caudal previsto por la arquitectura.",
+                    confidence=0.88,
+                    blocked_reason="FLOW_SENSOR_UNAVAILABLE",
+                    policy_refs=[str(active_policy_id), "config.allow_missing_flow_sensor"],
+                    contradictions=["flow_sensor_unavailable"],
+                )
             duration_s = max(1, min(config.requested_water_seconds, config.max_water_seconds, FIRMWARE_MAX_WATER_SECONDS_MVP))
             expected_liters = round(duration_s * 0.05, 3)
             unit = "%" if metric_kind == "pct" else "raw"
+            contradictions: list[str] = []
+            policy_refs = [str(active_policy_id), *refs, "firmware.max_water_seconds_mvp"]
+            confidence = 0.84
+            rationale_full = "Gate determinista: suelo seco, deposito aceptable, cooldown cumplido y duracion dentro del limite firmware MVP."
+            if tank is None:
+                contradictions.append("tank_level_unavailable")
+                policy_refs.append("config.allow_missing_tank_sensor")
+                confidence = min(confidence, 0.72)
+                rationale_full = "Gate determinista: suelo seco y cooldown cumplido. En perfil minimo, deposito no sensorizado se permite solo por flag explicito."
+            if telemetry.flow_pulses is None:
+                contradictions.append("flow_sensor_unavailable")
+                policy_refs.append("config.allow_missing_flow_sensor")
+                confidence = min(confidence, 0.74)
             return Decision(
                 action="WATER_A",
                 action_params={"duration_s": duration_s, "expected_liters": expected_liters},
                 mode="fast_path",
                 rationale_short=f"Humedad A {soil_value:.0f}{unit}, por debajo de {dry_below:.0f}{unit}. Riego corto dentro de sobre seguro.",
-                rationale_full="Gate determinista: suelo seco, deposito aceptable, cooldown cumplido y duracion dentro del limite firmware MVP.",
-                confidence=0.84,
-                policy_refs=[str(active_policy_id), *refs, "firmware.max_water_seconds_mvp"],
+                rationale_full=rationale_full,
+                confidence=confidence,
+                policy_refs=policy_refs,
+                contradictions=contradictions,
             )
 
         return Decision(
@@ -601,6 +661,8 @@ def build_snapshot(config: StewardConfig, telemetry: Telemetry, policy: dict[str
         pending_contradictions.append("soil_b_unavailable_or_uncalibrated")
     if telemetry.tank_level_pct is None:
         pending_contradictions.append("tank_level_unavailable")
+    if telemetry.flow_pulses is None:
+        pending_contradictions.append("flow_sensor_unavailable")
     sensors = {
         "soil_moisture_a_pct": soil_a_pct if soil_a_pct is not None else 0.0,
         "soil_moisture_b_pct": soil_b_pct if soil_b_pct is not None else (soil_a_pct if soil_a_pct is not None else 0.0),
@@ -757,6 +819,7 @@ class RhizomeSteward:
         }
         if executed and execution is not None:
             duration = float(action_params.get("duration_s", 0))
+            flow_sensor_present = "flow_sensor_unavailable" not in receipt["contradictions"]
             receipt["execution_details"] = {
                 "sent_to_esp32_at": execution.sent_at,
                 "esp32_ack_at": execution.received_at,
@@ -764,6 +827,7 @@ class RhizomeSteward:
                 "actual_duration_s": duration,
                 "flow_observed_lpm": 0.0,
                 "estimated_liters_actual": action_params.get("expected_liters", 0.0),
+                "flow_sensor_present": flow_sensor_present,
                 "esp32_lines": execution.lines,
             }
         return receipt
@@ -798,7 +862,7 @@ def build_client(args: argparse.Namespace) -> ESP32Client:
         return FakeESP32Client(telemetry=telemetry, reject_water_reason=args.fake_reject_water)
     if not args.serial_port:
         raise SystemExit("--serial-port es obligatorio con --esp32 serial")
-    return SerialESP32Client(args.serial_port, baud=args.baud)
+    return SerialESP32Client(args.serial_port, baud=args.baud, water_command_mode=args.serial_water_command_mode)
 
 
 def build_config(args: argparse.Namespace) -> StewardConfig:
@@ -818,6 +882,8 @@ def build_config(args: argparse.Namespace) -> StewardConfig:
         tank_minimum_pct=args.tank_minimum_pct,
         max_water_seconds=args.max_water_seconds,
         max_autonomous_waters_per_day=args.max_autonomous_waters_per_day,
+        allow_missing_tank_sensor=args.allow_missing_tank_sensor,
+        allow_missing_flow_sensor=not args.require_flow_sensor_for_water,
         execute_water=args.execute_water,
         shadow_skeptic_enabled=not args.disable_shadow_skeptic,
         gemma_rationale_url=args.gemma_rationale_url,
@@ -835,6 +901,7 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--esp32", choices=["fake", "serial"], default="fake")
     parser.add_argument("--serial-port")
     parser.add_argument("--baud", type=int, default=115200)
+    parser.add_argument("--serial-water-command-mode", choices=["water-duration", "pump-toggle"], default="water-duration")
     parser.add_argument("--execute-water", action="store_true", help="Permite enviar WATER al ESP32. Sin esto, WATER queda bloqueado como observe mode.")
     parser.add_argument("--decision-interval-s", type=int, default=900)
     parser.add_argument("--heartbeat-interval-s", type=int, default=2)
@@ -847,6 +914,8 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--tank-minimum-pct", type=float, default=FIRMWARE_TANK_MINIMUM_PCT)
     parser.add_argument("--max-water-seconds", type=int, default=FIRMWARE_MAX_WATER_SECONDS_MVP)
     parser.add_argument("--max-autonomous-waters-per-day", type=int, default=2)
+    parser.add_argument("--allow-missing-tank-sensor", action="store_true", help="Perfil minimo: permite WATER con deposito no sensorizado, registrando tank_level_unavailable.")
+    parser.add_argument("--require-flow-sensor-for-water", action="store_true", help="Bloquea/promociona futuro modo estricto cuando caudalimetro exista.")
     parser.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS)
     parser.add_argument("--max-total-bytes", type=int, default=DEFAULT_MAX_TOTAL_BYTES)
     parser.add_argument("--disable-shadow-skeptic", action="store_true")

--- a/code/rhizome/src/rhizome_steward.py
+++ b/code/rhizome/src/rhizome_steward.py
@@ -1,0 +1,889 @@
+"""Minimal autonomous Rhizome steward loop.
+
+This module closes the smallest real loop for a supervised plant pilot:
+
+ESP32 telemetry -> deterministic decision -> optional Gemma rationale ->
+optional ESP32 WATER command -> bounded local receipts.
+
+It deliberately keeps physical authority outside the LLM. Gemma may explain a
+decision, but hard gates and ESP32 ACK/REJECT decide what reaches water.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+VERSION = "0.1.0"
+FIRMWARE_MAX_WATER_SECONDS_MVP = 30
+FIRMWARE_TANK_MINIMUM_PCT = 20.0
+DEFAULT_RETENTION_DAYS = 120
+DEFAULT_MAX_TOTAL_BYTES = 64 * 1024 * 1024
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def zulu(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_zulu(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def default_state_dir() -> Path:
+    return Path(os.environ.get("RHIZOME_STEWARD_STATE_DIR", "~/.local/share/sprout/rhizome_steward")).expanduser()
+
+
+def parse_kv_line(line: str) -> tuple[str, dict[str, str]]:
+    parts = line.strip().split()
+    if not parts:
+        return "", {}
+    tag = parts[0]
+    values: dict[str, str] = {}
+    for token in parts[1:]:
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        values[key] = value
+    return tag, values
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass
+class Telemetry:
+    collected_at: str
+    soil_a_raw: int | None = None
+    soil_b_raw: int | None = None
+    tank_level_pct: float | None = None
+    flow_pulses: int | None = None
+    host_link: str = "UNKNOWN"
+    host_age_ms: int | None = None
+    bme280: str | None = None
+    bme280_temp_c: float | None = None
+    raw_lines: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_esp32_lines(cls, lines: list[str], now: datetime | None = None) -> "Telemetry":
+        now = now or utc_now()
+        telemetry = cls(collected_at=zulu(now), raw_lines=lines)
+        for line in lines:
+            tag, values = parse_kv_line(line)
+            if tag not in {"TELEMETRY_REPORT", "STATUS_REPORT"}:
+                continue
+            soil_a_raw = _int_or_none(values.get("soil_a_raw"))
+            soil_b_raw = _int_or_none(values.get("soil_b_raw"))
+            tank_level_pct = _float_or_none(values.get("tank_level_pct"))
+            flow_pulses = _int_or_none(values.get("flow_pulses"))
+            telemetry.soil_a_raw = soil_a_raw if soil_a_raw is not None else telemetry.soil_a_raw
+            telemetry.soil_b_raw = soil_b_raw if soil_b_raw is not None else telemetry.soil_b_raw
+            telemetry.tank_level_pct = tank_level_pct if tank_level_pct is not None else telemetry.tank_level_pct
+            telemetry.flow_pulses = flow_pulses if flow_pulses is not None else telemetry.flow_pulses
+            telemetry.host_link = values.get("host_link", telemetry.host_link)
+            host_age_ms = _int_or_none(values.get("host_age_ms"))
+            telemetry.host_age_ms = host_age_ms if host_age_ms is not None else telemetry.host_age_ms
+            telemetry.bme280 = values.get("bme280", telemetry.bme280)
+            temp_x100 = _float_or_none(values.get("bme280_temp_c_x100"))
+            if temp_x100 is not None and temp_x100 >= -10000:
+                telemetry.bme280_temp_c = temp_x100 / 100.0
+        return telemetry
+
+    def soil_a_pct(self) -> float | None:
+        if self.soil_a_raw is None:
+            return None
+        if 0 <= self.soil_a_raw <= 100:
+            return float(self.soil_a_raw)
+        return None
+
+
+@dataclass
+class ESP32CommandResult:
+    ok: bool
+    command: str
+    sent_at: str
+    received_at: str
+    lines: list[str]
+    ack_status: str
+    reject_reason: str | None = None
+
+
+class ESP32Client(Protocol):
+    def heartbeat(self) -> ESP32CommandResult: ...
+
+    def telemetry(self) -> Telemetry: ...
+
+    def water(self, plot: str, seconds: int) -> ESP32CommandResult: ...
+
+    def close(self) -> None: ...
+
+
+class FakeESP32Client:
+    def __init__(self, telemetry: Telemetry | None = None, reject_water_reason: str | None = None) -> None:
+        self.current_telemetry = telemetry or Telemetry(
+            collected_at=zulu(utc_now()),
+            soil_a_raw=32,
+            soil_b_raw=40,
+            tank_level_pct=70.0,
+            flow_pulses=0,
+            host_link="FRESH",
+            host_age_ms=0,
+        )
+        self.reject_water_reason = reject_water_reason
+
+    def _result(self, command: str, lines: list[str], ok: bool = True, reason: str | None = None) -> ESP32CommandResult:
+        now = zulu(utc_now())
+        return ESP32CommandResult(ok=ok, command=command, sent_at=now, received_at=now, lines=lines, ack_status="OK" if ok else "REJECT", reject_reason=reason)
+
+    def heartbeat(self) -> ESP32CommandResult:
+        self.current_telemetry.host_link = "FRESH"
+        self.current_telemetry.host_age_ms = 0
+        return self._result("HOST_HEARTBEAT", ["ACK command=HOST_HEARTBEAT state=SAFE_IDLE host_link=FRESH host_age_ms=0"])
+
+    def telemetry(self) -> Telemetry:
+        line = (
+            "TELEMETRY_REPORT "
+            f"soil_a_raw={self.current_telemetry.soil_a_raw if self.current_telemetry.soil_a_raw is not None else -1} "
+            f"soil_b_raw={self.current_telemetry.soil_b_raw if self.current_telemetry.soil_b_raw is not None else -1} "
+            f"tank_level_pct={self.current_telemetry.tank_level_pct if self.current_telemetry.tank_level_pct is not None else -1} "
+            f"flow_pulses={self.current_telemetry.flow_pulses if self.current_telemetry.flow_pulses is not None else 0} "
+            f"host_link={self.current_telemetry.host_link} host_age_ms={self.current_telemetry.host_age_ms if self.current_telemetry.host_age_ms is not None else -1} "
+            "source=fake"
+        )
+        return Telemetry.from_esp32_lines([line])
+
+    def water(self, plot: str, seconds: int) -> ESP32CommandResult:
+        command = f"WATER {plot} {seconds}"
+        if self.reject_water_reason:
+            return self._result(command, [f"REJECT reason={self.reject_water_reason} cmd={command}"], ok=False, reason=self.reject_water_reason)
+        return self._result(command, [f"ACK command=WATER plot={plot} seconds={seconds} execution=DRY_RUN state=SAFE_IDLE host_link=FRESH tank_level_pct={self.current_telemetry.tank_level_pct}"])
+
+    def close(self) -> None:
+        return
+
+
+class SerialESP32Client:
+    def __init__(self, port: str, baud: int = 115200, timeout_s: float = 0.1, quiet_s: float = 0.35, max_wait_s: float = 3.0) -> None:
+        try:
+            import serial  # type: ignore
+        except ModuleNotFoundError as exc:
+            raise RuntimeError("pyserial no esta instalado. Instala hardware/host_tools/requirements.txt") from exc
+        self.serial = serial.Serial(port=port, baudrate=baud, timeout=timeout_s)
+        self.quiet_s = quiet_s
+        self.max_wait_s = max_wait_s
+
+    def _collect(self) -> list[str]:
+        lines: list[str] = []
+        started_at = time.monotonic()
+        last_payload_at: float | None = None
+        while True:
+            raw = self.serial.readline()
+            current = time.monotonic()
+            if raw:
+                decoded = raw.decode("utf-8", errors="replace").strip()
+                if decoded:
+                    lines.append(decoded)
+                    last_payload_at = current
+                continue
+            if last_payload_at is not None and current - last_payload_at >= self.quiet_s:
+                break
+            if current - started_at >= self.max_wait_s:
+                break
+        return lines
+
+    def command(self, command: str) -> ESP32CommandResult:
+        sent_at = zulu(utc_now())
+        self.serial.write(f"{command}\n".encode("utf-8"))
+        lines = self._collect()
+        received_at = zulu(utc_now())
+        combined = "\n".join(lines)
+        if "REJECT reason=" in combined:
+            reason = None
+            for line in lines:
+                if line.startswith("REJECT "):
+                    _, values = parse_kv_line(line)
+                    reason = values.get("reason")
+                    break
+            return ESP32CommandResult(False, command, sent_at, received_at, lines, "REJECT", reason)
+        ok = any(line.startswith("ACK ") for line in lines)
+        return ESP32CommandResult(ok, command, sent_at, received_at, lines, "OK" if ok else "NO_ACK")
+
+    def heartbeat(self) -> ESP32CommandResult:
+        return self.command("HOST_HEARTBEAT")
+
+    def telemetry(self) -> Telemetry:
+        result = self.command("TELEMETRY")
+        telemetry = Telemetry.from_esp32_lines(result.lines)
+        if telemetry.host_link == "UNKNOWN":
+            telemetry.host_link = "FRESH" if result.ok else "UNKNOWN"
+        return telemetry
+
+    def water(self, plot: str, seconds: int) -> ESP32CommandResult:
+        return self.command(f"WATER {plot} {seconds}")
+
+    def close(self) -> None:
+        self.serial.close()
+
+
+@dataclass
+class StewardConfig:
+    node_id: str = "rhizome_01"
+    state_dir: Path = field(default_factory=default_state_dir)
+    facade_data_dir: Path | None = None
+    sync_facade_state_dir: Path = Path("/tmp/sprout_rhizome_sync_facade/rhizome_01")
+    decision_interval_s: int = 900
+    heartbeat_interval_s: int = 2
+    cooldown_s: int = 7200
+    requested_water_seconds: int = 8
+    soil_dry_below_pct: float = 35.0
+    soil_wet_above_pct: float = 55.0
+    soil_dry_below_raw: int | None = None
+    soil_wet_above_raw: int | None = None
+    tank_minimum_pct: float = FIRMWARE_TANK_MINIMUM_PCT
+    max_water_seconds: int = FIRMWARE_MAX_WATER_SECONDS_MVP
+    max_autonomous_waters_per_day: int = 2
+    execute_water: bool = False
+    shadow_skeptic_enabled: bool = True
+    gemma_rationale_url: str | None = None
+    gemma_model: str = "gemma4:e2b"
+    retention_days: int = DEFAULT_RETENTION_DAYS
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES
+
+
+class BoundedJsonlStore:
+    def __init__(self, root: Path, *, retention_days: int, max_total_bytes: int) -> None:
+        self.root = root
+        self.retention_days = retention_days
+        self.max_total_bytes = max_total_bytes
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def append(self, stream: str, payload: dict[str, Any], now: datetime | None = None) -> Path:
+        now = now or utc_now()
+        path = self.root / stream / f"{now.date().isoformat()}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+        self.enforce_limits(now)
+        return path
+
+    def write_json(self, relative_path: str, payload: dict[str, Any]) -> Path:
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with tmp_path.open("w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        tmp_path.replace(path)
+        return path
+
+    def load_json(self, relative_path: str) -> dict[str, Any] | None:
+        path = self.root / relative_path
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def iter_jsonl(self, stream: str) -> list[dict[str, Any]]:
+        records: list[dict[str, Any]] = []
+        for path in sorted((self.root / stream).glob("*.jsonl")):
+            with path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if line:
+                        records.append(json.loads(line))
+        return records
+
+    def enforce_limits(self, now: datetime | None = None) -> None:
+        now = now or utc_now()
+        cutoff = now - timedelta(days=self.retention_days)
+        jsonl_files = sorted(self.root.glob("*/*.jsonl"), key=lambda p: p.stat().st_mtime)
+        for path in list(jsonl_files):
+            try:
+                if datetime.fromtimestamp(path.stat().st_mtime, timezone.utc) < cutoff:
+                    path.unlink(missing_ok=True)
+            except FileNotFoundError:
+                continue
+        jsonl_files = sorted(self.root.glob("*/*.jsonl"), key=lambda p: p.stat().st_mtime)
+        total = sum(path.stat().st_size for path in jsonl_files)
+        for path in jsonl_files:
+            if total <= self.max_total_bytes:
+                break
+            size = path.stat().st_size
+            path.unlink(missing_ok=True)
+            total -= size
+
+
+def load_active_policy(config: StewardConfig) -> dict[str, Any] | None:
+    path = config.sync_facade_state_dir / "active_policy.json"
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8") as handle:
+        record = json.load(handle)
+    policy = record.get("policy", record)
+    valid_until = parse_zulu(policy.get("valid_until"))
+    if valid_until is not None and valid_until <= utc_now():
+        return None
+    return policy
+
+
+@dataclass
+class Decision:
+    action: str
+    action_params: dict[str, Any]
+    mode: str
+    rationale_short: str
+    rationale_full: str
+    confidence: float
+    blocked_reason: str | None = None
+    policy_refs: list[str] = field(default_factory=list)
+    contradictions: list[str] = field(default_factory=list)
+
+
+def _policy_threshold(policy: dict[str, Any] | None, key: str) -> float | None:
+    if not policy:
+        return None
+    thresholds = policy.get("rules", {}).get("soil_moisture_thresholds", {})
+    parcel_a = thresholds.get("parcel_a") or thresholds.get("single_zone") or {}
+    return _float_or_none(parcel_a.get(key))
+
+
+def _soil_metric(telemetry: Telemetry, config: StewardConfig) -> tuple[str, float | None, float, float, list[str]]:
+    soil_pct = telemetry.soil_a_pct()
+    if soil_pct is not None:
+        return "pct", soil_pct, config.soil_dry_below_pct, config.soil_wet_above_pct, ["config.soil_pct_thresholds"]
+    if telemetry.soil_a_raw is not None and config.soil_dry_below_raw is not None and config.soil_wet_above_raw is not None:
+        return "raw", float(telemetry.soil_a_raw), float(config.soil_dry_below_raw), float(config.soil_wet_above_raw), ["config.soil_raw_thresholds"]
+    return "unknown", None, 0.0, 0.0, []
+
+
+def _todays_water_count(store: BoundedJsonlStore, now: datetime) -> int:
+    today = now.date().isoformat()
+    count = 0
+    for receipt in store.iter_jsonl("decision_receipts"):
+        if not str(receipt.get("created_at", "")).startswith(today):
+            continue
+        if receipt.get("action") == "WATER_A" and receipt.get("executed") is True:
+            count += 1
+    return count
+
+
+def _last_executed_water_at(store: BoundedJsonlStore) -> datetime | None:
+    latest: datetime | None = None
+    for receipt in store.iter_jsonl("decision_receipts"):
+        if receipt.get("action") != "WATER_A" or receipt.get("executed") is not True:
+            continue
+        created_at = parse_zulu(receipt.get("created_at"))
+        if created_at and (latest is None or created_at > latest):
+            latest = created_at
+    return latest
+
+
+class DeterministicDecisionEngine:
+    def decide(self, telemetry: Telemetry, config: StewardConfig, store: BoundedJsonlStore, policy: dict[str, Any] | None, now: datetime | None = None) -> Decision:
+        now = now or utc_now()
+        active_policy_id = policy.get("policy_id") if policy else "local_default_policy"
+        tank = telemetry.tank_level_pct
+        if tank is not None and tank < config.tank_minimum_pct:
+            return Decision(
+                action="ALERT",
+                action_params={"alert_id": f"alert_{config.node_id}_{now.strftime('%Y%m%dT%H%M%SZ')}"},
+                mode="safety_block",
+                rationale_short=f"Deposito al {tank:.0f}%, por debajo del minimo {config.tank_minimum_pct:.0f}%. No se riega.",
+                rationale_full="Gate determinista: deposito bajo tiene prioridad sobre cualquier politica o propuesta del modelo.",
+                confidence=0.99,
+                blocked_reason="TANK_LOW",
+                policy_refs=[str(active_policy_id), "firmware.tank_minimum_pct"],
+            )
+
+        if telemetry.host_link not in {"FRESH", "UNKNOWN"}:
+            return Decision(
+                action="BLOCK",
+                action_params={"blocked_action": "WATER_A", "reason": "JETSON_HEARTBEAT_NOT_FRESH"},
+                mode="safety_block",
+                rationale_short="El enlace con ESP32 no esta fresco. No se riega.",
+                rationale_full="Gate determinista: Rhizome exige host_link fresco antes de proponer riego.",
+                confidence=0.95,
+                blocked_reason="JETSON_HEARTBEAT_NOT_FRESH",
+                policy_refs=[str(active_policy_id), "firmware.host_heartbeat_timeout_ms"],
+            )
+
+        metric_kind, soil_value, dry_below, wet_above, refs = _soil_metric(telemetry, config)
+        if soil_value is None:
+            return Decision(
+                action="DEFER",
+                action_params={"defer_until": zulu(now + timedelta(seconds=config.decision_interval_s)), "reason": "SOIL_UNKNOWN"},
+                mode="fast_path",
+                rationale_short="No hay lectura calibrada de humedad de suelo. Se aplaza.",
+                rationale_full="Rhizome no riega si no puede interpretar la humedad de suelo como porcentaje o raw calibrado.",
+                confidence=0.80,
+                blocked_reason="SOIL_UNKNOWN",
+                policy_refs=[str(active_policy_id)],
+            )
+
+        last_water_at = _last_executed_water_at(store)
+        if last_water_at and (now - last_water_at).total_seconds() < config.cooldown_s:
+            remaining = int(config.cooldown_s - (now - last_water_at).total_seconds())
+            return Decision(
+                action="DEFER",
+                action_params={"defer_until": zulu(now + timedelta(seconds=remaining)), "reason": "COOLDOWN_NOT_MET"},
+                mode="fast_path",
+                rationale_short=f"Cooldown activo tras el ultimo riego. Reintento en {remaining}s.",
+                rationale_full="Gate determinista: el cooldown evita riegos repetidos ante ruido de sensor.",
+                confidence=0.92,
+                blocked_reason="COOLDOWN_NOT_MET",
+                policy_refs=[str(active_policy_id), "config.cooldown_s"],
+            )
+
+        daily_count = _todays_water_count(store, now)
+        if daily_count >= config.max_autonomous_waters_per_day:
+            return Decision(
+                action="DEFER",
+                action_params={"defer_until": zulu(now + timedelta(days=1)), "reason": "DAILY_AUTONOMY_BUDGET_USED"},
+                mode="fast_path",
+                rationale_short="Presupuesto diario de riegos autonomos agotado. Se aplaza.",
+                rationale_full="Gate determinista: limite de eventos autonomos por dia para piloto de maceta.",
+                confidence=0.90,
+                blocked_reason="DAILY_AUTONOMY_BUDGET_USED",
+                policy_refs=[str(active_policy_id), "config.max_autonomous_waters_per_day"],
+            )
+
+        if soil_value >= wet_above:
+            unit = "%" if metric_kind == "pct" else "raw"
+            return Decision(
+                action="SKIP",
+                action_params={"next_check_in_s": config.decision_interval_s},
+                mode="fast_path",
+                rationale_short=f"Humedad A {soil_value:.0f}{unit}; suficiente. No se riega.",
+                rationale_full="Gate determinista: la lectura supera el umbral de suelo suficiente.",
+                confidence=0.88,
+                policy_refs=[str(active_policy_id), *refs],
+            )
+
+        if soil_value <= dry_below:
+            duration_s = max(1, min(config.requested_water_seconds, config.max_water_seconds, FIRMWARE_MAX_WATER_SECONDS_MVP))
+            expected_liters = round(duration_s * 0.05, 3)
+            unit = "%" if metric_kind == "pct" else "raw"
+            return Decision(
+                action="WATER_A",
+                action_params={"duration_s": duration_s, "expected_liters": expected_liters},
+                mode="fast_path",
+                rationale_short=f"Humedad A {soil_value:.0f}{unit}, por debajo de {dry_below:.0f}{unit}. Riego corto dentro de sobre seguro.",
+                rationale_full="Gate determinista: suelo seco, deposito aceptable, cooldown cumplido y duracion dentro del limite firmware MVP.",
+                confidence=0.84,
+                policy_refs=[str(active_policy_id), *refs, "firmware.max_water_seconds_mvp"],
+            )
+
+        return Decision(
+            action="DEFER",
+            action_params={"defer_until": zulu(now + timedelta(seconds=config.decision_interval_s)), "reason": "AMBIGUOUS_MOISTURE_BAND"},
+            mode="fast_path",
+            rationale_short="Humedad en banda intermedia. Se aplaza para evitar riego innecesario.",
+            rationale_full="Gate determinista: la lectura no es claramente seca ni claramente suficiente.",
+            confidence=0.76,
+            blocked_reason="AMBIGUOUS_MOISTURE_BAND",
+            policy_refs=[str(active_policy_id), *refs],
+        )
+
+
+class GemmaRationaleClient:
+    def __init__(self, adapter_url: str, model: str) -> None:
+        self.adapter_url = adapter_url.rstrip("/")
+        self.model = model
+
+    def refine(self, decision: Decision, telemetry: Telemetry) -> tuple[str | None, str | None]:
+        prompt = {
+            "task": "rhizome_rationale",
+            "rules": [
+                "Return only JSON.",
+                "Do not change the action.",
+                "Do not add facts absent from input.",
+                "No chain-of-thought.",
+                "Keep rationale_short <= 180 chars.",
+            ],
+            "decision": asdict(decision),
+            "telemetry": asdict(telemetry),
+            "output_schema": {"rationale_short": "string", "risk_note": "string"},
+        }
+        body = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": "You are Gemma 4 E2B inside Rhizome. Explain decisions briefly and contractually. You cannot authorize water."},
+                {"role": "user", "content": json.dumps(prompt, ensure_ascii=False)},
+            ],
+            "stream": False,
+            "think": False,
+            "options": {"temperature": 0.1, "num_ctx": 2048, "num_predict": 160},
+        }
+        request = urllib.request.Request(
+            f"{self.adapter_url}/api/chat",
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                response_body = json.loads(response.read().decode("utf-8"))
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            return None, f"gemma_error:{exc.__class__.__name__}"
+        content = response_body.get("message", {}).get("content", "")
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            return None, "gemma_invalid_json"
+        rationale = parsed.get("rationale_short")
+        if isinstance(rationale, str) and 0 < len(rationale) <= 180:
+            return rationale, None
+        return None, "gemma_bad_rationale"
+
+
+class ShadowSkeptic:
+    def review(self, decision: Decision, telemetry: Telemetry, config: StewardConfig) -> dict[str, Any]:
+        concerns: list[str] = []
+        if decision.action == "WATER_A":
+            duration = decision.action_params.get("duration_s")
+            if not isinstance(duration, int) or duration <= 0 or duration > FIRMWARE_MAX_WATER_SECONDS_MVP:
+                concerns.append("duration_outside_firmware_limit")
+            if telemetry.tank_level_pct is None:
+                concerns.append("tank_unknown")
+            elif telemetry.tank_level_pct < config.tank_minimum_pct:
+                concerns.append("tank_below_minimum")
+            if telemetry.soil_a_pct() is None and config.soil_dry_below_raw is None:
+                concerns.append("soil_not_calibrated")
+        return {
+            "shadow_id": f"shadow_{utc_now().strftime('%Y%m%dT%H%M%SZ')}",
+            "reviewed_action": decision.action,
+            "would_object": bool(concerns),
+            "concerns": concerns,
+            "recommended_action": "DEFER" if concerns else decision.action,
+            "affects_decision": False,
+            "mode": "deterministic_shadow_skeptic_v0",
+        }
+
+
+def build_snapshot(config: StewardConfig, telemetry: Telemetry, policy: dict[str, Any] | None, now: datetime) -> dict[str, Any]:
+    soil_a_pct = telemetry.soil_a_pct()
+    soil_b_pct = float(telemetry.soil_b_raw) if telemetry.soil_b_raw is not None and 0 <= telemetry.soil_b_raw <= 100 else soil_a_pct
+    pending_contradictions: list[str] = []
+    if soil_a_pct is None:
+        pending_contradictions.append("soil_a_unavailable_or_uncalibrated")
+    if soil_b_pct is None:
+        pending_contradictions.append("soil_b_unavailable_or_uncalibrated")
+    if telemetry.tank_level_pct is None:
+        pending_contradictions.append("tank_level_unavailable")
+    sensors = {
+        "soil_moisture_a_pct": soil_a_pct if soil_a_pct is not None else 0.0,
+        "soil_moisture_b_pct": soil_b_pct if soil_b_pct is not None else (soil_a_pct if soil_a_pct is not None else 0.0),
+        "tank_level_pct": telemetry.tank_level_pct if telemetry.tank_level_pct is not None else 0.0,
+        "flow_rate_lpm": 0.0,
+        "last_reading_at": telemetry.collected_at,
+    }
+    return {
+        "schema_version": "1.0",
+        "created_at": zulu(now),
+        "origin_node_id": config.node_id,
+        "signature": None,
+        "snapshot_id": f"snap_{config.node_id}_{now.strftime('%Y%m%dT%H%M%SZ')}",
+        "mode": "normal",
+        "active_policy_id": (policy or {}).get("policy_id", "local_default_policy"),
+        "active_policy_expires_at": (policy or {}).get("valid_until", zulu(now + timedelta(hours=12))),
+        "sensors": sensors,
+        "vision": {
+            "last_capture_at": None,
+            "parcel_a_status": None,
+            "parcel_b_status": None,
+            "visual_notes": "Sensor value unavailable; snapshot keeps schema-safe 0 and decision gate must defer." if pending_contradictions else None,
+        },
+        "health": {"cpu_temp_c": 0.0, "cpu_load_pct": 0.0, "ram_used_gb": 0.0, "ram_total_gb": 1.0, "esp32_heartbeat_ok": telemetry.host_link in {"FRESH", "UNKNOWN"}, "last_esp32_ack_at": telemetry.collected_at},
+        "last_decision_id": None,
+        "pending_contradictions": pending_contradictions,
+    }
+
+
+class RhizomeSteward:
+    def __init__(self, config: StewardConfig, client: ESP32Client) -> None:
+        self.config = config
+        self.client = client
+        self.store = BoundedJsonlStore(config.state_dir, retention_days=config.retention_days, max_total_bytes=config.max_total_bytes)
+        self.facade_data_dir = config.facade_data_dir or (config.state_dir / "facade_data")
+        self.engine = DeterministicDecisionEngine()
+        self.shadow = ShadowSkeptic()
+        self.gemma = GemmaRationaleClient(config.gemma_rationale_url, config.gemma_model) if config.gemma_rationale_url else None
+
+    def run_once(self) -> dict[str, Any]:
+        now = utc_now()
+        heartbeat = self.client.heartbeat()
+        telemetry = self.client.telemetry()
+        policy = load_active_policy(self.config)
+        snapshot = build_snapshot(self.config, telemetry, policy, now)
+        decision = self.engine.decide(telemetry, self.config, self.store, policy, now)
+        gemma_error = None
+        if self.gemma is not None:
+            refined, gemma_error = self.gemma.refine(decision, telemetry)
+            if refined:
+                decision.rationale_short = refined
+                decision.mode = f"{decision.mode}+gemma_rationale"
+
+        execution: ESP32CommandResult | None = None
+        executed = False
+        blocked_reason = decision.blocked_reason
+        if decision.action == "WATER_A":
+            if self.config.execute_water:
+                self.client.heartbeat()
+                execution = self.client.water("A", int(decision.action_params["duration_s"]))
+                executed = execution.ok
+                blocked_reason = None if execution.ok else execution.reject_reason or "ESP32_REJECTED"
+            else:
+                blocked_reason = "OBSERVE_MODE_EXECUTE_WATER_FALSE"
+
+        receipt = self._receipt(now, snapshot, decision, executed, blocked_reason, execution, policy, gemma_error)
+        shadow_record = self.shadow.review(decision, telemetry, self.config) if self.config.shadow_skeptic_enabled else None
+        self.store.append("telemetry_samples", asdict(telemetry), now)
+        self.store.write_json("current_snapshot.json", snapshot)
+        self.store.append("decision_receipts", receipt, now)
+        self.store.write_json("last_decision_receipt.json", receipt)
+        self._write_facade_data(snapshot, receipt)
+        if shadow_record:
+            shadow_record["decision_id"] = receipt["decision_id"]
+            shadow_record["created_at"] = receipt["created_at"]
+            self.store.append("shadow_skeptic", shadow_record, now)
+        return {
+            "status": "ok",
+            "node_id": self.config.node_id,
+            "snapshot_id": snapshot["snapshot_id"],
+            "decision_id": receipt["decision_id"],
+            "action": receipt["action"],
+            "executed": receipt["executed"],
+            "blocked_reason": receipt["blocked_reason"],
+            "rationale_short": receipt["rationale_short"],
+            "heartbeat_ok": heartbeat.ok,
+            "shadow_skeptic": shadow_record,
+            "state_dir": str(self.config.state_dir),
+            "facade_data_dir": str(self.facade_data_dir),
+        }
+
+    def _write_facade_data(self, snapshot: dict[str, Any], receipt: dict[str, Any]) -> None:
+        self.facade_data_dir.mkdir(parents=True, exist_ok=True)
+        self._write_json_to(self.facade_data_dir / "rhizome_snapshot.json", snapshot)
+        target_name = "decision_receipt_blocked.json" if (
+            receipt["action"] in {"ALERT", "BLOCK"} or receipt["executed"] is not True
+        ) else "decision_receipt.json"
+        self._write_json_to(self.facade_data_dir / target_name, receipt)
+        if target_name == "decision_receipt.json":
+            blocked = self.facade_data_dir / "decision_receipt_blocked.json"
+            if not blocked.exists():
+                self._write_json_to(blocked, receipt)
+        else:
+            normal = self.facade_data_dir / "decision_receipt.json"
+            if not normal.exists():
+                self._write_json_to(normal, receipt)
+
+    @staticmethod
+    def _write_json_to(path: Path, payload: dict[str, Any]) -> None:
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with tmp_path.open("w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        tmp_path.replace(path)
+
+    def _receipt(self, now: datetime, snapshot: dict[str, Any], decision: Decision, executed: bool, blocked_reason: str | None, execution: ESP32CommandResult | None, policy: dict[str, Any] | None, gemma_error: str | None) -> dict[str, Any]:
+        decision_id = f"rec_{self.config.node_id}_{now.strftime('%Y%m%dT%H%M%SZ')}"
+        action_params = dict(decision.action_params)
+        if decision.action == "WATER_A" and not executed and blocked_reason:
+            # The shared schema permits WATER_* with executed=false when there is a blocked reason.
+            pass
+        if not executed and not blocked_reason:
+            if decision.action == "SKIP":
+                blocked_reason = "NO_ACTION_NEEDED"
+            elif decision.action == "DEFER":
+                blocked_reason = action_params.get("reason") or "DEFERRED"
+            elif decision.action == "ALERT":
+                blocked_reason = "ALERT_NOT_EXECUTED"
+            elif decision.action == "BLOCK":
+                blocked_reason = action_params.get("reason") or "BLOCKED"
+            else:
+                blocked_reason = "NOT_EXECUTED"
+        receipt = {
+            "schema_version": "1.0",
+            "created_at": zulu(now),
+            "origin_node_id": self.config.node_id,
+            "signature": None,
+            "decision_id": decision_id,
+            "snapshot_id": snapshot["snapshot_id"],
+            "active_policy_id": (policy or {}).get("policy_id", "local_default_policy"),
+            "action": decision.action,
+            "action_params": action_params,
+            "rationale_short": decision.rationale_short[:180],
+            "rationale_full": decision.rationale_full,
+            "policy_refs": decision.policy_refs or ["local_default_policy"],
+            "contradictions": decision.contradictions,
+            "confidence": decision.confidence,
+            "executed": executed,
+            "execution_details": None,
+            "blocked_reason": None if executed else blocked_reason,
+            "backend_used": "deterministic+gemma_rationale" if self.gemma and not gemma_error else "deterministic",
+            "gemma_error": gemma_error,
+            "mode": decision.mode,
+        }
+        if executed and execution is not None:
+            duration = float(action_params.get("duration_s", 0))
+            receipt["execution_details"] = {
+                "sent_to_esp32_at": execution.sent_at,
+                "esp32_ack_at": execution.received_at,
+                "esp32_ack_status": execution.ack_status,
+                "actual_duration_s": duration,
+                "flow_observed_lpm": 0.0,
+                "estimated_liters_actual": action_params.get("expected_liters", 0.0),
+                "esp32_lines": execution.lines,
+            }
+        return receipt
+
+    def run_loop(self) -> None:
+        while True:
+            result = self.run_once()
+            print(json.dumps(result, ensure_ascii=False, separators=(",", ":")), flush=True)
+            self._sleep_with_heartbeat(self.config.decision_interval_s)
+
+    def _sleep_with_heartbeat(self, seconds: int) -> None:
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            self.client.heartbeat()
+            time.sleep(min(self.config.heartbeat_interval_s, max(0.0, deadline - time.monotonic())))
+
+    def close(self) -> None:
+        self.client.close()
+
+
+def build_client(args: argparse.Namespace) -> ESP32Client:
+    if args.esp32 == "fake":
+        telemetry = Telemetry(
+            collected_at=zulu(utc_now()),
+            soil_a_raw=args.fake_soil_a,
+            soil_b_raw=args.fake_soil_b,
+            tank_level_pct=args.fake_tank_pct,
+            flow_pulses=0,
+            host_link="FRESH",
+            host_age_ms=0,
+        )
+        return FakeESP32Client(telemetry=telemetry, reject_water_reason=args.fake_reject_water)
+    if not args.serial_port:
+        raise SystemExit("--serial-port es obligatorio con --esp32 serial")
+    return SerialESP32Client(args.serial_port, baud=args.baud)
+
+
+def build_config(args: argparse.Namespace) -> StewardConfig:
+    return StewardConfig(
+        node_id=args.node_id,
+        state_dir=Path(args.state_dir).expanduser(),
+        facade_data_dir=Path(args.facade_data_dir).expanduser() if args.facade_data_dir else None,
+        sync_facade_state_dir=Path(args.sync_facade_state_dir).expanduser(),
+        decision_interval_s=args.decision_interval_s,
+        heartbeat_interval_s=args.heartbeat_interval_s,
+        cooldown_s=args.cooldown_s,
+        requested_water_seconds=args.water_seconds,
+        soil_dry_below_pct=args.soil_dry_below_pct,
+        soil_wet_above_pct=args.soil_wet_above_pct,
+        soil_dry_below_raw=args.soil_dry_below_raw,
+        soil_wet_above_raw=args.soil_wet_above_raw,
+        tank_minimum_pct=args.tank_minimum_pct,
+        max_water_seconds=args.max_water_seconds,
+        max_autonomous_waters_per_day=args.max_autonomous_waters_per_day,
+        execute_water=args.execute_water,
+        shadow_skeptic_enabled=not args.disable_shadow_skeptic,
+        gemma_rationale_url=args.gemma_rationale_url,
+        gemma_model=args.gemma_model,
+        retention_days=args.retention_days,
+        max_total_bytes=args.max_total_bytes,
+    )
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--node-id", default="rhizome_01")
+    parser.add_argument("--state-dir", default=str(default_state_dir()))
+    parser.add_argument("--facade-data-dir", help="Directorio JSON compatible con rhizome_sync_facade. Por defecto: <state-dir>/facade_data")
+    parser.add_argument("--sync-facade-state-dir", default="/tmp/sprout_rhizome_sync_facade/rhizome_01")
+    parser.add_argument("--esp32", choices=["fake", "serial"], default="fake")
+    parser.add_argument("--serial-port")
+    parser.add_argument("--baud", type=int, default=115200)
+    parser.add_argument("--execute-water", action="store_true", help="Permite enviar WATER al ESP32. Sin esto, WATER queda bloqueado como observe mode.")
+    parser.add_argument("--decision-interval-s", type=int, default=900)
+    parser.add_argument("--heartbeat-interval-s", type=int, default=2)
+    parser.add_argument("--cooldown-s", type=int, default=7200)
+    parser.add_argument("--water-seconds", type=int, default=8)
+    parser.add_argument("--soil-dry-below-pct", type=float, default=35.0)
+    parser.add_argument("--soil-wet-above-pct", type=float, default=55.0)
+    parser.add_argument("--soil-dry-below-raw", type=int)
+    parser.add_argument("--soil-wet-above-raw", type=int)
+    parser.add_argument("--tank-minimum-pct", type=float, default=FIRMWARE_TANK_MINIMUM_PCT)
+    parser.add_argument("--max-water-seconds", type=int, default=FIRMWARE_MAX_WATER_SECONDS_MVP)
+    parser.add_argument("--max-autonomous-waters-per-day", type=int, default=2)
+    parser.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS)
+    parser.add_argument("--max-total-bytes", type=int, default=DEFAULT_MAX_TOTAL_BYTES)
+    parser.add_argument("--disable-shadow-skeptic", action="store_true")
+    parser.add_argument("--gemma-rationale-url", help="Adapter /api/chat base URL, e.g. http://127.0.0.1:12000")
+    parser.add_argument("--gemma-model", default="gemma4:e2b")
+    parser.add_argument("--fake-soil-a", type=int, default=32)
+    parser.add_argument("--fake-soil-b", type=int, default=40)
+    parser.add_argument("--fake-tank-pct", type=float, default=70.0)
+    parser.add_argument("--fake-reject-water")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Rhizome Steward v0 autonomous loop.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    once = sub.add_parser("run-once", help="Ejecuta un ciclo medir -> decidir -> receipt.")
+    add_common_args(once)
+    loop = sub.add_parser("run-loop", help="Ejecuta el ciclo en bucle con heartbeat entre decisiones.")
+    add_common_args(loop)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = build_config(args)
+    client = build_client(args)
+    steward = RhizomeSteward(config, client)
+    try:
+        if args.command == "run-once":
+            print(json.dumps(steward.run_once(), ensure_ascii=False, separators=(",", ":")))
+            return 0
+        steward.run_loop()
+    except KeyboardInterrupt:
+        return 130
+    finally:
+        steward.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/rhizome/src/rhizome_steward.py
+++ b/code/rhizome/src/rhizome_steward.py
@@ -290,6 +290,9 @@ class StewardConfig:
     soil_wet_above_pct: float = 55.0
     soil_dry_below_raw: int | None = None
     soil_wet_above_raw: int | None = None
+    soil_raw_polarity: str = "low_is_dry"
+    soil_wet_below_raw: int | None = None
+    soil_dry_above_raw: int | None = None
     tank_minimum_pct: float = FIRMWARE_TANK_MINIMUM_PCT
     max_water_seconds: int = FIRMWARE_MAX_WATER_SECONDS_MVP
     max_autonomous_waters_per_day: int = 2
@@ -400,13 +403,72 @@ def _policy_threshold(policy: dict[str, Any] | None, key: str) -> float | None:
     return _float_or_none(parcel_a.get(key))
 
 
-def _soil_metric(telemetry: Telemetry, config: StewardConfig) -> tuple[str, float | None, float, float, list[str]]:
+def _soil_metric(
+    telemetry: Telemetry,
+    config: StewardConfig,
+) -> tuple[str, float | None, float | None, float | None, list[str]]:
     soil_pct = telemetry.soil_a_pct()
     if soil_pct is not None:
         return "pct", soil_pct, config.soil_dry_below_pct, config.soil_wet_above_pct, ["config.soil_pct_thresholds"]
+    if telemetry.soil_a_raw is not None and config.soil_raw_polarity == "low_is_wet" and config.soil_wet_below_raw is not None:
+        return (
+            "raw_low_is_wet",
+            float(telemetry.soil_a_raw),
+            float(config.soil_dry_above_raw) if config.soil_dry_above_raw is not None else None,
+            float(config.soil_wet_below_raw),
+            ["config.soil_raw_thresholds", "config.soil_raw_polarity"],
+        )
     if telemetry.soil_a_raw is not None and config.soil_dry_below_raw is not None and config.soil_wet_above_raw is not None:
-        return "raw", float(telemetry.soil_a_raw), float(config.soil_dry_below_raw), float(config.soil_wet_above_raw), ["config.soil_raw_thresholds"]
-    return "unknown", None, 0.0, 0.0, []
+        return (
+            "raw_low_is_dry",
+            float(telemetry.soil_a_raw),
+            float(config.soil_dry_below_raw),
+            float(config.soil_wet_above_raw),
+            ["config.soil_raw_thresholds", "config.soil_raw_polarity"],
+        )
+    return "unknown", None, None, None, []
+
+
+def _has_full_raw_soil_calibration(config: StewardConfig) -> bool:
+    if config.soil_raw_polarity == "low_is_wet":
+        return config.soil_wet_below_raw is not None and config.soil_dry_above_raw is not None
+    return config.soil_dry_below_raw is not None and config.soil_wet_above_raw is not None
+
+
+def _soil_unit(metric_kind: str) -> str:
+    return "%" if metric_kind == "pct" else "raw"
+
+
+def _soil_is_wet_enough(metric_kind: str, soil_value: float, wet_threshold: float | None) -> bool:
+    if wet_threshold is None:
+        return False
+    if metric_kind == "raw_low_is_wet":
+        return soil_value <= wet_threshold
+    return soil_value >= wet_threshold
+
+
+def _soil_is_dry(metric_kind: str, soil_value: float, dry_threshold: float | None) -> bool:
+    if dry_threshold is None:
+        return False
+    if metric_kind == "raw_low_is_wet":
+        return soil_value >= dry_threshold
+    return soil_value <= dry_threshold
+
+
+def _wet_threshold_text(metric_kind: str, wet_threshold: float | None) -> str:
+    if wet_threshold is None:
+        return "umbral de suelo suficiente"
+    unit = _soil_unit(metric_kind)
+    relation = "igual o por debajo de" if metric_kind == "raw_low_is_wet" else "igual o por encima de"
+    return f"{relation} {wet_threshold:.0f}{unit}"
+
+
+def _dry_threshold_text(metric_kind: str, dry_threshold: float | None) -> str:
+    if dry_threshold is None:
+        return "umbral de suelo seco"
+    unit = _soil_unit(metric_kind)
+    relation = "por encima de" if metric_kind == "raw_low_is_wet" else "por debajo de"
+    return f"{relation} {dry_threshold:.0f}{unit}"
 
 
 def _todays_water_count(store: BoundedJsonlStore, now: datetime) -> int:
@@ -512,19 +574,19 @@ class DeterministicDecisionEngine:
                 policy_refs=[str(active_policy_id), "config.max_autonomous_waters_per_day"],
             )
 
-        if soil_value >= wet_above:
-            unit = "%" if metric_kind == "pct" else "raw"
+        if _soil_is_wet_enough(metric_kind, soil_value, wet_above):
+            unit = _soil_unit(metric_kind)
             return Decision(
                 action="SKIP",
                 action_params={"next_check_in_s": config.decision_interval_s},
                 mode="fast_path",
                 rationale_short=f"Humedad A {soil_value:.0f}{unit}; suficiente. No se riega.",
-                rationale_full="Gate determinista: la lectura supera el umbral de suelo suficiente.",
+                rationale_full=f"Gate determinista: la lectura esta {_wet_threshold_text(metric_kind, wet_above)}.",
                 confidence=0.88,
                 policy_refs=[str(active_policy_id), *refs],
             )
 
-        if soil_value <= dry_below:
+        if _soil_is_dry(metric_kind, soil_value, dry_below):
             if telemetry.flow_pulses is None and not config.allow_missing_flow_sensor:
                 return Decision(
                     action="DEFER",
@@ -539,7 +601,7 @@ class DeterministicDecisionEngine:
                 )
             duration_s = max(1, min(config.requested_water_seconds, config.max_water_seconds, FIRMWARE_MAX_WATER_SECONDS_MVP))
             expected_liters = round(duration_s * 0.05, 3)
-            unit = "%" if metric_kind == "pct" else "raw"
+            unit = _soil_unit(metric_kind)
             contradictions: list[str] = []
             policy_refs = [str(active_policy_id), *refs, "firmware.max_water_seconds_mvp"]
             confidence = 0.84
@@ -557,7 +619,7 @@ class DeterministicDecisionEngine:
                 action="WATER_A",
                 action_params={"duration_s": duration_s, "expected_liters": expected_liters},
                 mode="fast_path",
-                rationale_short=f"Humedad A {soil_value:.0f}{unit}, por debajo de {dry_below:.0f}{unit}. Riego corto dentro de sobre seguro.",
+                rationale_short=f"Humedad A {soil_value:.0f}{unit}, {_dry_threshold_text(metric_kind, dry_below)}. Riego corto dentro de sobre seguro.",
                 rationale_full=rationale_full,
                 confidence=confidence,
                 policy_refs=policy_refs,
@@ -638,7 +700,7 @@ class ShadowSkeptic:
                 concerns.append("tank_unknown")
             elif telemetry.tank_level_pct < config.tank_minimum_pct:
                 concerns.append("tank_below_minimum")
-            if telemetry.soil_a_pct() is None and config.soil_dry_below_raw is None:
+            if telemetry.soil_a_pct() is None and not _has_full_raw_soil_calibration(config):
                 concerns.append("soil_not_calibrated")
         return {
             "shadow_id": f"shadow_{utc_now().strftime('%Y%m%dT%H%M%SZ')}",
@@ -879,6 +941,9 @@ def build_config(args: argparse.Namespace) -> StewardConfig:
         soil_wet_above_pct=args.soil_wet_above_pct,
         soil_dry_below_raw=args.soil_dry_below_raw,
         soil_wet_above_raw=args.soil_wet_above_raw,
+        soil_raw_polarity=args.soil_raw_polarity,
+        soil_wet_below_raw=args.soil_wet_below_raw,
+        soil_dry_above_raw=args.soil_dry_above_raw,
         tank_minimum_pct=args.tank_minimum_pct,
         max_water_seconds=args.max_water_seconds,
         max_autonomous_waters_per_day=args.max_autonomous_waters_per_day,
@@ -911,6 +976,9 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--soil-wet-above-pct", type=float, default=55.0)
     parser.add_argument("--soil-dry-below-raw", type=int)
     parser.add_argument("--soil-wet-above-raw", type=int)
+    parser.add_argument("--soil-raw-polarity", choices=["low_is_dry", "low_is_wet"], default="low_is_dry")
+    parser.add_argument("--soil-wet-below-raw", type=int)
+    parser.add_argument("--soil-dry-above-raw", type=int)
     parser.add_argument("--tank-minimum-pct", type=float, default=FIRMWARE_TANK_MINIMUM_PCT)
     parser.add_argument("--max-water-seconds", type=int, default=FIRMWARE_MAX_WATER_SECONDS_MVP)
     parser.add_argument("--max-autonomous-waters-per-day", type=int, default=2)

--- a/code/rhizome/src/rhizome_steward.py
+++ b/code/rhizome/src/rhizome_steward.py
@@ -868,7 +868,7 @@ class RhizomeSteward:
             "executed": receipt["executed"],
             "blocked_reason": receipt["blocked_reason"],
             "rationale_short": receipt["rationale_short"],
-            "heartbeat_ok": heartbeat.ok,
+            "heartbeat_ok": heartbeat.ok or telemetry.host_link == "FRESH",
             "shadow_skeptic": shadow_record,
             "state_dir": str(self.config.state_dir),
             "facade_data_dir": str(self.facade_data_dir),

--- a/code/rhizome/src/rhizome_steward.py
+++ b/code/rhizome/src/rhizome_steward.py
@@ -877,18 +877,11 @@ class RhizomeSteward:
     def _write_facade_data(self, snapshot: dict[str, Any], receipt: dict[str, Any]) -> None:
         self.facade_data_dir.mkdir(parents=True, exist_ok=True)
         self._write_json_to(self.facade_data_dir / "rhizome_snapshot.json", snapshot)
-        target_name = "decision_receipt_blocked.json" if (
+        self._write_json_to(self.facade_data_dir / "decision_receipt.json", receipt)
+        if (
             receipt["action"] in {"ALERT", "BLOCK"} or receipt["executed"] is not True
-        ) else "decision_receipt.json"
-        self._write_json_to(self.facade_data_dir / target_name, receipt)
-        if target_name == "decision_receipt.json":
-            blocked = self.facade_data_dir / "decision_receipt_blocked.json"
-            if not blocked.exists():
-                self._write_json_to(blocked, receipt)
-        else:
-            normal = self.facade_data_dir / "decision_receipt.json"
-            if not normal.exists():
-                self._write_json_to(normal, receipt)
+        ):
+            self._write_json_to(self.facade_data_dir / "decision_receipt_blocked.json", receipt)
 
     @staticmethod
     def _write_json_to(path: Path, payload: dict[str, Any]) -> None:

--- a/code/rhizome/src/rhizome_sync_facade.py
+++ b/code/rhizome/src/rhizome_sync_facade.py
@@ -278,7 +278,7 @@ def _gemma_visit_narrative(
         ],
         "stream": False,
         "think": False,
-        "options": {"temperature": 0.2, "num_ctx": 2048, "num_predict": 320},
+        "options": {"temperature": 0.2, "num_ctx": 2048, "num_predict": 1024},
     }
     request = urllib.request.Request(
         f"{adapter_url}/api/chat",

--- a/code/rhizome/src/rhizome_sync_facade.py
+++ b/code/rhizome/src/rhizome_sync_facade.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -24,6 +26,8 @@ POLICY_ORIGIN_POLLEN_VISIT = "pollen-visit"
 POLICY_SCOPE_TRANSIENT = "transient"
 POLICY_TTL_MAX_SECONDS = 12 * 60 * 60
 SAFE_ID_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+NARRATOR_TIMEOUT_S = 45
+NARRATOR_MAX_RECEIPTS = 8
 
 
 def _repo_root() -> Path:
@@ -136,6 +140,164 @@ def _plural_es(count: int, singular: str, plural: str) -> str:
 
 def _plural_en(count: int, singular: str, plural: str) -> str:
     return f"{count} {singular if count == 1 else plural}"
+
+
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    stripped = text.strip()
+    if not stripped:
+        return None
+    if stripped.startswith("```"):
+        first = stripped.find("{")
+        last = stripped.rfind("}")
+        if first != -1 and last > first:
+            stripped = stripped[first : last + 1]
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _bounded_string(value: Any, max_len: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = " ".join(value.strip().split())
+    if not cleaned or len(cleaned) > max_len:
+        return None
+    return cleaned
+
+
+def _validated_narrative_patch(payload: Any) -> dict[str, Any] | None:
+    obj = _require_dict_or_none(payload)
+    if obj is None:
+        return None
+
+    headline = _bounded_string(obj.get("headline"), 140)
+    summary = _bounded_string(obj.get("summary"), 700)
+    recommendation = _bounded_string(obj.get("recommendation"), 260)
+    highlights_raw = obj.get("highlights")
+    if not headline or not summary or not recommendation or not isinstance(highlights_raw, list):
+        return None
+
+    highlights: list[str] = []
+    for item in highlights_raw[:5]:
+        highlight = _bounded_string(item, 220)
+        if highlight:
+            highlights.append(highlight)
+    if not highlights:
+        return None
+
+    return {
+        "headline": headline,
+        "summary": summary,
+        "highlights": highlights,
+        "recommendation": recommendation,
+    }
+
+
+def _require_dict_or_none(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _compact_receipt_for_narrator(receipt: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "decision_id": receipt.get("decision_id"),
+        "created_at": receipt.get("created_at"),
+        "action": receipt.get("action"),
+        "executed": receipt.get("executed"),
+        "blocked_reason": receipt.get("blocked_reason"),
+        "action_params": receipt.get("action_params"),
+        "confidence": receipt.get("confidence"),
+        "rationale_short": receipt.get("rationale_short"),
+    }
+
+
+def _gemma_visit_narrative(
+    *,
+    adapter_url: str,
+    model: str,
+    locale: str,
+    node_id: str,
+    snapshot: dict[str, Any],
+    receipts: list[dict[str, Any]],
+    deterministic_summary: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    adapter_url = adapter_url.rstrip("/")
+    recent_receipts = sorted(receipts, key=_receipt_sort_key)[-NARRATOR_MAX_RECEIPTS:]
+    prompt = {
+        "task": "rhizome_visit_summary_narrator",
+        "locale": locale,
+        "node_id": node_id,
+        "rules": [
+            "Return only valid JSON.",
+            "Do not change counts, actions, timestamps, execution flags or reason codes.",
+            "Do not claim water was executed unless executed=true.",
+            "Do not invent sensor readings or events.",
+            "Write for a farmer returning after being away.",
+            "No chain-of-thought.",
+        ],
+        "truth_fields": {
+            "severity": deterministic_summary["severity"],
+            "counts": deterministic_summary["counts"],
+            "simulation": deterministic_summary["simulation"],
+            "latest_snapshot_id": deterministic_summary.get("latest_snapshot_id"),
+        },
+        "current_snapshot": {
+            "snapshot_id": snapshot.get("snapshot_id"),
+            "created_at": snapshot.get("created_at"),
+            "sensors": snapshot.get("sensors", {}),
+            "mode": snapshot.get("mode"),
+            "pending_contradictions": snapshot.get("pending_contradictions", []),
+        },
+        "recent_receipts": [_compact_receipt_for_narrator(receipt) for receipt in recent_receipts],
+        "deterministic_draft": {
+            "headline": deterministic_summary["headline"],
+            "summary": deterministic_summary["summary"],
+            "highlights": deterministic_summary["highlights"],
+            "recommendation": deterministic_summary["recommendation"],
+        },
+        "output_schema": {
+            "headline": "string",
+            "summary": "string",
+            "highlights": ["string"],
+            "recommendation": "string",
+        },
+    }
+    body = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are Gemma 4 inside Sprout Pollen/Rhizome. "
+                    "Rewrite validated irrigation receipts into a short operator summary. "
+                    "You are not a source of truth."
+                ),
+            },
+            {"role": "user", "content": json.dumps(prompt, ensure_ascii=False)},
+        ],
+        "stream": False,
+        "think": False,
+        "options": {"temperature": 0.2, "num_ctx": 2048, "num_predict": 320},
+    }
+    request = urllib.request.Request(
+        f"{adapter_url}/api/chat",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=NARRATOR_TIMEOUT_S) as response:
+            response_body = json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        return None, f"gemma_narrator_error:{exc.__class__.__name__}"
+
+    content = response_body.get("message", {}).get("content", "")
+    parsed = _extract_json_object(content) if isinstance(content, str) else None
+    patch = _validated_narrative_patch(parsed)
+    if patch is None:
+        return None, "gemma_narrator_invalid_json_or_schema"
+    return patch, None
 
 
 class PolicyValidationError(ValueError):
@@ -472,11 +634,15 @@ class RhizomeReadStore:
         data_dir: Path | None = None,
         node_id: str = "rhizome_01",
         state_dir: Path | None = None,
+        narrator_url: str | None = None,
+        narrator_model: str = "gemma4:e2b",
     ) -> None:
         self.data_dir = data_dir or default_data_dir()
         self.node_id = node_id
         self.state_dir = state_dir or default_state_dir(node_id)
         self.simulation = _is_simulation_data(self.data_dir)
+        self.narrator_url = narrator_url
+        self.narrator_model = narrator_model
 
     @property
     def active_policy_path(self) -> Path:
@@ -495,6 +661,8 @@ class RhizomeReadStore:
             payload["active_policy_id"] = active_policy["policy"]["policy_id"]
             payload["active_policy_origin"] = active_policy["policy"].get("policy_origin", "")
             payload["active_policy_scope"] = active_policy["policy"].get("policy_scope", "")
+        if self.narrator_url:
+            payload["gemma_visit_narrator"] = "configured"
         return payload
 
     def latest_snapshot(self) -> dict[str, Any]:
@@ -558,7 +726,7 @@ class RhizomeReadStore:
             counts,
             locale,
         )
-        return {
+        payload: dict[str, Any] = {
             "node_id": self.node_id,
             "locale": locale,
             "since": since,
@@ -570,8 +738,34 @@ class RhizomeReadStore:
             "counts": counts,
             "latest_snapshot_id": snapshot.get("snapshot_id"),
             "source": "deterministic_visit_summary",
+            "narrative_source": "deterministic_visit_summary",
             "simulation": self.simulation,
+            "gemma_narrator": {
+                "enabled": bool(self.narrator_url),
+                "used": False,
+                "model": self.narrator_model if self.narrator_url else None,
+            },
         }
+        if not self.narrator_url:
+            return payload
+
+        patch, error = _gemma_visit_narrative(
+            adapter_url=self.narrator_url,
+            model=self.narrator_model,
+            locale=locale,
+            node_id=self.node_id,
+            snapshot=snapshot,
+            receipts=receipts,
+            deterministic_summary=payload,
+        )
+        if patch is None:
+            payload["gemma_narrator"]["error"] = error or "gemma_narrator_unknown_error"
+            return payload
+
+        payload.update(patch)
+        payload["narrative_source"] = "gemma_visit_narrator"
+        payload["gemma_narrator"]["used"] = True
+        return payload
 
     def active_policy_record(self) -> dict[str, Any] | None:
         if not self.active_policy_path.exists():
@@ -754,9 +948,17 @@ def make_server(
     data_dir: Path | None = None,
     node_id: str = "rhizome_01",
     state_dir: Path | None = None,
+    narrator_url: str | None = None,
+    narrator_model: str = "gemma4:e2b",
 ) -> ThreadingHTTPServer:
     class Handler(RhizomeSyncHandler):
-        store = RhizomeReadStore(data_dir=data_dir, node_id=node_id, state_dir=state_dir)
+        store = RhizomeReadStore(
+            data_dir=data_dir,
+            node_id=node_id,
+            state_dir=state_dir,
+            narrator_url=narrator_url,
+            narrator_model=narrator_model,
+        )
 
     return ThreadingHTTPServer((host, port), Handler)
 
@@ -768,9 +970,19 @@ def main() -> None:
     parser.add_argument("--data-dir", type=Path, default=default_data_dir())
     parser.add_argument("--node-id", default="rhizome_01")
     parser.add_argument("--state-dir", type=Path, default=None)
+    parser.add_argument("--narrator-url", default=None, help="Optional Ollama-compatible adapter URL for Gemma visit summaries.")
+    parser.add_argument("--narrator-model", default="gemma4:e2b")
     args = parser.parse_args()
 
-    server = make_server(args.host, args.port, args.data_dir, args.node_id, args.state_dir)
+    server = make_server(
+        args.host,
+        args.port,
+        args.data_dir,
+        args.node_id,
+        args.state_dir,
+        narrator_url=args.narrator_url,
+        narrator_model=args.narrator_model,
+    )
     print(
         f"rhizome_sync_facade node_id={args.node_id} listening on http://{args.host}:{args.port}",
         flush=True,

--- a/code/rhizome/src/rhizome_sync_facade.py
+++ b/code/rhizome/src/rhizome_sync_facade.py
@@ -679,6 +679,11 @@ class RhizomeReadStore:
             if path.exists()
             for receipt in [_load_json(path)]
         ]
+        deduped: dict[str, dict[str, Any]] = {}
+        for receipt in receipts:
+            decision_id = str(receipt.get("decision_id") or "")
+            deduped[decision_id or f"anonymous_{len(deduped)}"] = receipt
+        receipts = list(deduped.values())
 
         since_dt = _parse_zulu(since)
         if since_dt is None:

--- a/code/rhizome/src/rhizome_sync_facade.py
+++ b/code/rhizome/src/rhizome_sync_facade.py
@@ -85,6 +85,8 @@ def _receipt_window(receipts: list[dict[str, Any]]) -> dict[str, int]:
     counts = {
         "total": len(receipts),
         "water": 0,
+        "water_proposed": 0,
+        "water_not_executed": 0,
         "block": 0,
         "alert": 0,
         "other": 0,
@@ -93,7 +95,11 @@ def _receipt_window(receipts: list[dict[str, Any]]) -> dict[str, int]:
     for receipt in receipts:
         action = str(receipt.get("action", "")).upper()
         if action.startswith("WATER"):
-            counts["water"] += 1
+            counts["water_proposed"] += 1
+            if receipt.get("executed") is True:
+                counts["water"] += 1
+            else:
+                counts["water_not_executed"] += 1
         elif action == "BLOCK":
             counts["block"] += 1
         elif action == "ALERT":
@@ -117,6 +123,11 @@ def _severity(snapshot: dict[str, Any], counts: dict[str, int]) -> str:
     if counts["block"] > 0 or (tank is not None and tank < 30):
         return "attention"
     return "ok"
+
+
+def _is_simulation_data(data_dir: Path) -> bool:
+    normalized = str(data_dir.resolve()).replace("\\", "/")
+    return "/demo_data/" in normalized or "/schemas/examples" in normalized
 
 
 def _plural_es(count: int, singular: str, plural: str) -> str:
@@ -308,15 +319,22 @@ def _explain_receipt(receipt: dict[str, Any], locale: str) -> str:
     params = receipt.get("action_params", {})
     rationale = str(receipt.get("rationale_full") or receipt.get("rationale_short") or "").strip()
     blocked_reason = str(receipt.get("blocked_reason") or "").strip()
+    executed = receipt.get("executed") is True
 
     if locale == "en":
         if action.startswith("WATER"):
             duration = params.get("duration_s")
             liters = params.get("expected_liters")
+            if not executed:
+                return (
+                    f"Rhizome proposed {action} for {duration}s, expecting about {liters} L, "
+                    f"but did not execute it. Reason code: {blocked_reason or 'not specified'}. "
+                    f"Receipt note: {rationale}"
+                )
             return (
                 f"Rhizome executed {action} for {duration}s, expecting about {liters} L. "
                 "The decision was allowed because the snapshot and active policy did not hit "
-                "a safety veto. The detailed DecisionReceipt remains available for audit."
+                f"a safety veto. Receipt note: {rationale}"
             )
         if action == "BLOCK":
             return (
@@ -331,6 +349,12 @@ def _explain_receipt(receipt: dict[str, Any], locale: str) -> str:
     if action.startswith("WATER"):
         duration = params.get("duration_s")
         liters = params.get("expected_liters")
+        if not executed:
+            return (
+                f"Rhizome propuso {action} durante {duration}s, con unos {liters} L esperados, "
+                f"pero no lo ejecutó. Código: {blocked_reason or 'sin especificar'}. "
+                f"Nota del recibo: {rationale}"
+            )
         return (
             f"Rhizome ejecutó {action} durante {duration}s, con unos {liters} L esperados. "
             "La decisión pasó porque el snapshot y la política activa no activaron ningún veto "
@@ -366,7 +390,8 @@ def _summary_text(
             headline = f"{node_id}: attention needed after your absence"
         highlights = [
             (
-                f"{_plural_en(counts['water'], 'watering event', 'watering events')}, "
+                f"{_plural_en(counts['water'], 'watering event executed', 'watering events executed')}, "
+                f"{_plural_en(counts['water_not_executed'], 'water proposal not executed', 'water proposals not executed')}, "
                 f"{_plural_en(counts['block'], 'safety block', 'safety blocks')}, "
                 f"{_plural_en(counts['alert'], 'alert', 'alerts')}."
             ),
@@ -381,8 +406,9 @@ def _summary_text(
             highlights.append(f"Latest recorded decision: {latest_action}.")
         summary = (
             f"While you were away, {node_id} recorded {counts['total']} decisions. "
-            f"It recorded {_plural_en(counts['water'], 'watering event', 'watering events')} "
-            f"and {_plural_en(counts['block'], 'blocked action', 'blocked actions')}. "
+            f"It executed {_plural_en(counts['water'], 'watering event', 'watering events')} "
+            f"and recorded {_plural_en(counts['water_not_executed'], 'water proposal not executed', 'water proposals not executed')}. "
+            f"It also recorded {_plural_en(counts['block'], 'blocked action', 'blocked actions')}. "
             f"Tank is now {tank:.0f}% and soil probes A/B are {soil_a:.0f}% / {soil_b:.0f}%."
             if (
                 tank is not None
@@ -403,7 +429,8 @@ def _summary_text(
         headline = f"{node_id}: conviene revisar lo ocurrido en tu ausencia"
     highlights = [
         (
-            f"{_plural_es(counts['water'], 'riego', 'riegos')}, "
+            f"{_plural_es(counts['water'], 'riego ejecutado', 'riegos ejecutados')}, "
+            f"{_plural_es(counts['water_not_executed'], 'propuesta de riego no ejecutada', 'propuestas de riego no ejecutadas')}, "
             f"{_plural_es(counts['block'], 'bloqueo de seguridad', 'bloqueos de seguridad')}, "
             f"{_plural_es(counts['alert'], 'alerta', 'alertas')}."
         ),
@@ -418,8 +445,9 @@ def _summary_text(
         highlights.append(f"Ultima decision registrada: {latest_action}.")
     summary = (
         f"Durante tu ausencia, {node_id} registro {counts['total']} decisiones. "
-        f"Registro {_plural_es(counts['water'], 'riego', 'riegos')} "
-        f"y {_plural_es(counts['block'], 'accion bloqueada', 'acciones bloqueadas')}. "
+        f"Ejecutó {_plural_es(counts['water'], 'riego', 'riegos')} "
+        f"y registró {_plural_es(counts['water_not_executed'], 'propuesta de riego no ejecutada', 'propuestas de riego no ejecutadas')}. "
+        f"También registró {_plural_es(counts['block'], 'accion bloqueada', 'acciones bloqueadas')}. "
         f"El deposito esta al {tank:.0f}% y las sondas A/B marcan {soil_a:.0f}% / {soil_b:.0f}%."
         if (
             tank is not None
@@ -448,6 +476,7 @@ class RhizomeReadStore:
         self.data_dir = data_dir or default_data_dir()
         self.node_id = node_id
         self.state_dir = state_dir or default_state_dir(node_id)
+        self.simulation = _is_simulation_data(self.data_dir)
 
     @property
     def active_policy_path(self) -> Path:
@@ -540,8 +569,8 @@ class RhizomeReadStore:
             "recommendation": recommendation,
             "counts": counts,
             "latest_snapshot_id": snapshot.get("snapshot_id"),
-            "source": "deterministic_demo_summary",
-            "simulation": True,
+            "source": "deterministic_visit_summary",
+            "simulation": self.simulation,
         }
 
     def active_policy_record(self) -> dict[str, Any] | None:

--- a/code/rhizome/tests/test_rhizome_steward.py
+++ b/code/rhizome/tests/test_rhizome_steward.py
@@ -214,6 +214,39 @@ class RhizomeStewardTest(unittest.TestCase):
         self.assertEqual(result["action"], "WATER_A")
         self.assertTrue(result["executed"])
 
+    def test_low_is_wet_raw_threshold_skips_current_wet_soil(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(
+                    tmp,
+                    execute_water=True,
+                    soil_raw_polarity="low_is_wet",
+                    soil_wet_below_raw=1300,
+                    soil_dry_above_raw=2600,
+                ),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=1265)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "SKIP")
+        self.assertFalse(result["executed"])
+
+    def test_low_is_wet_raw_without_dry_threshold_defers_outside_wet_band(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(
+                    tmp,
+                    execute_water=True,
+                    soil_raw_polarity="low_is_wet",
+                    soil_wet_below_raw=1300,
+                ),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=1700)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "DEFER")
+        self.assertFalse(result["executed"])
+
     def test_store_enforces_byte_budget(self):
         with tempfile.TemporaryDirectory() as tmp:
             store = BoundedJsonlStore(Path(tmp), retention_days=30, max_total_bytes=900)

--- a/code/rhizome/tests/test_rhizome_steward.py
+++ b/code/rhizome/tests/test_rhizome_steward.py
@@ -13,8 +13,10 @@ from schemas.rhizome_snapshot import RhizomeSnapshot
 
 from src.rhizome_steward import (
     BoundedJsonlStore,
+    ESP32CommandResult,
     FakeESP32Client,
     RhizomeSteward,
+    SerialESP32Client,
     StewardConfig,
     Telemetry,
     zulu,
@@ -246,6 +248,49 @@ class RhizomeStewardTest(unittest.TestCase):
 
         self.assertEqual(result["action"], "DEFER")
         self.assertFalse(result["executed"])
+
+    def test_low_is_wet_raw_threshold_waters_when_dry_above_xilema_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(
+                    tmp,
+                    execute_water=True,
+                    allow_missing_tank_sensor=True,
+                    soil_raw_polarity="low_is_wet",
+                    soil_wet_below_raw=1300,
+                    soil_dry_above_raw=2200,
+                ),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=2300, tank_level_pct=None)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "WATER_A")
+        self.assertTrue(result["executed"])
+
+    def test_pump_pulse_mode_maps_water_seconds_to_pump_pulse_ms(self):
+        class DummySerialClient(SerialESP32Client):
+            def __init__(self):
+                self.water_command_mode = "pump-pulse"
+                self.max_wait_s = 3.0
+                self.calls = []
+
+            def command(self, command, max_wait_s=None):
+                self.calls.append((command, max_wait_s))
+                return ESP32CommandResult(
+                    ok=True,
+                    command=command,
+                    sent_at=zulu(datetime.now(timezone.utc)),
+                    received_at=zulu(datetime.now(timezone.utc)),
+                    lines=[f"ACK command={command}"],
+                    ack_status="OK",
+                )
+
+        client = DummySerialClient()
+        result = client.water("A", 3)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(client.calls[0][0], "PUMP_PULSE 3000")
+        self.assertGreaterEqual(client.calls[0][1], 5.0)
 
     def test_store_enforces_byte_budget(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/code/rhizome/tests/test_rhizome_steward.py
+++ b/code/rhizome/tests/test_rhizome_steward.py
@@ -35,13 +35,13 @@ def _config(tmp: str, **overrides):
     return StewardConfig(**values)
 
 
-def _telemetry(*, soil_a_raw=30, tank_level_pct=70.0):
+def _telemetry(*, soil_a_raw=30, tank_level_pct=70.0, flow_pulses=0):
     return Telemetry(
         collected_at=zulu(datetime.now(timezone.utc)),
         soil_a_raw=soil_a_raw,
         soil_b_raw=soil_a_raw,
         tank_level_pct=tank_level_pct,
-        flow_pulses=0,
+        flow_pulses=flow_pulses,
         host_link="FRESH",
         host_age_ms=0,
     )
@@ -102,6 +102,52 @@ class RhizomeStewardTest(unittest.TestCase):
         self.assertEqual(result["action"], "ALERT")
         self.assertFalse(result["executed"])
         self.assertEqual(result["blocked_reason"], "TANK_LOW")
+
+    def test_missing_tank_sensor_defers_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=20, tank_level_pct=None)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "DEFER")
+        self.assertEqual(result["blocked_reason"], "TANK_SENSOR_UNAVAILABLE")
+
+    def test_minimal_hardware_mode_allows_missing_tank_with_trace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True, allow_missing_tank_sensor=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=20, tank_level_pct=None, flow_pulses=None)),
+            )
+            result = steward.run_once()
+            snapshot = steward.store.load_json("current_snapshot.json")
+            receipt = steward.store.load_json("last_decision_receipt.json")
+
+        self.assertEqual(result["action"], "WATER_A")
+        self.assertTrue(result["executed"])
+        self.assertIsNotNone(snapshot)
+        self.assertIsNotNone(receipt)
+        self.assertIn("tank_level_unavailable", snapshot["pending_contradictions"])
+        self.assertIn("flow_sensor_unavailable", receipt["contradictions"])
+        RhizomeSnapshot.model_validate(snapshot)
+        DecisionReceipt.model_validate(receipt)
+
+    def test_strict_flow_mode_defers_when_flow_sensor_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(
+                    tmp,
+                    execute_water=True,
+                    allow_missing_tank_sensor=True,
+                    allow_missing_flow_sensor=False,
+                ),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=20, tank_level_pct=None, flow_pulses=None)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "DEFER")
+        self.assertEqual(result["blocked_reason"], "FLOW_SENSOR_UNAVAILABLE")
 
     def test_cooldown_defers_second_water(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/code/rhizome/tests/test_rhizome_steward.py
+++ b/code/rhizome/tests/test_rhizome_steward.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "shared"))
+
+from schemas.decision_receipt import DecisionReceipt
+from schemas.rhizome_snapshot import RhizomeSnapshot
+
+from src.rhizome_steward import (
+    BoundedJsonlStore,
+    FakeESP32Client,
+    RhizomeSteward,
+    StewardConfig,
+    Telemetry,
+    zulu,
+)
+
+
+def _config(tmp: str, **overrides):
+    values = {
+        "state_dir": Path(tmp),
+        "sync_facade_state_dir": Path(tmp) / "sync_facade",
+        "decision_interval_s": 60,
+        "cooldown_s": 3600,
+        "requested_water_seconds": 8,
+        "max_total_bytes": 64 * 1024,
+        "retention_days": 30,
+    }
+    values.update(overrides)
+    return StewardConfig(**values)
+
+
+def _telemetry(*, soil_a_raw=30, tank_level_pct=70.0):
+    return Telemetry(
+        collected_at=zulu(datetime.now(timezone.utc)),
+        soil_a_raw=soil_a_raw,
+        soil_b_raw=soil_a_raw,
+        tank_level_pct=tank_level_pct,
+        flow_pulses=0,
+        host_link="FRESH",
+        host_age_ms=0,
+    )
+
+
+class RhizomeStewardTest(unittest.TestCase):
+    def test_dry_soil_executes_water_when_explicitly_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=30)),
+            )
+            result = steward.run_once()
+
+            receipts = steward.store.iter_jsonl("decision_receipts")
+            facade_snapshot_exists = (Path(tmp) / "facade_data" / "rhizome_snapshot.json").exists()
+            facade_receipt_exists = (Path(tmp) / "facade_data" / "decision_receipt.json").exists()
+
+        self.assertEqual(result["action"], "WATER_A")
+        self.assertTrue(result["executed"])
+        self.assertIsNone(result["blocked_reason"])
+        self.assertEqual(receipts[-1]["execution_details"]["esp32_ack_status"], "OK")
+        self.assertTrue(facade_snapshot_exists)
+        self.assertTrue(facade_receipt_exists)
+
+    def test_dry_soil_does_not_water_without_execute_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=False),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=30)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "WATER_A")
+        self.assertFalse(result["executed"])
+        self.assertEqual(result["blocked_reason"], "OBSERVE_MODE_EXECUTE_WATER_FALSE")
+
+    def test_wet_soil_skips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=70)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "SKIP")
+        self.assertFalse(result["executed"])
+        self.assertEqual(result["blocked_reason"], "NO_ACTION_NEEDED")
+
+    def test_tank_low_alerts_without_water(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=20, tank_level_pct=10.0)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "ALERT")
+        self.assertFalse(result["executed"])
+        self.assertEqual(result["blocked_reason"], "TANK_LOW")
+
+    def test_cooldown_defers_second_water(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=20)),
+            )
+            first = steward.run_once()
+            second = steward.run_once()
+
+        self.assertEqual(first["action"], "WATER_A")
+        self.assertTrue(first["executed"])
+        self.assertEqual(second["action"], "DEFER")
+        self.assertEqual(second["blocked_reason"], "COOLDOWN_NOT_MET")
+
+    def test_shadow_skeptic_records_observation_without_changing_action(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=False),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=30)),
+            )
+            result = steward.run_once()
+            shadow = steward.store.iter_jsonl("shadow_skeptic")
+
+        self.assertEqual(result["action"], "WATER_A")
+        self.assertFalse(shadow[-1]["affects_decision"])
+        self.assertIn("reviewed_action", shadow[-1])
+
+    def test_unknown_soil_defers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=1234)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "DEFER")
+        self.assertEqual(result["blocked_reason"], "SOIL_UNKNOWN")
+
+    def test_unknown_soil_snapshot_remains_shared_schema_compatible(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=1234)),
+            )
+            steward.run_once()
+            snapshot = steward.store.load_json("current_snapshot.json")
+            receipt = steward.store.load_json("last_decision_receipt.json")
+
+        self.assertIsNotNone(snapshot)
+        self.assertIsNotNone(receipt)
+        RhizomeSnapshot.model_validate(snapshot)
+        DecisionReceipt.model_validate(receipt)
+        self.assertIn("soil_a_unavailable_or_uncalibrated", snapshot["pending_contradictions"])
+
+    def test_raw_thresholds_allow_autonomy_with_uncalibrated_sensor_units(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            steward = RhizomeSteward(
+                _config(tmp, execute_water=True, soil_dry_below_raw=1500, soil_wet_above_raw=2600),
+                FakeESP32Client(telemetry=_telemetry(soil_a_raw=1200)),
+            )
+            result = steward.run_once()
+
+        self.assertEqual(result["action"], "WATER_A")
+        self.assertTrue(result["executed"])
+
+    def test_store_enforces_byte_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = BoundedJsonlStore(Path(tmp), retention_days=30, max_total_bytes=900)
+            now = datetime.now(timezone.utc) - timedelta(days=10)
+            for index in range(50):
+                store.append("telemetry_samples", {"index": index, "payload": "x" * 80}, now + timedelta(days=index))
+
+            total = sum(path.stat().st_size for path in Path(tmp).glob("*/*.jsonl"))
+
+        self.assertLessEqual(total, 900)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/rhizome/tests/test_sync_facade.py
+++ b/code/rhizome/tests/test_sync_facade.py
@@ -24,6 +24,10 @@ def _get_json(base_url: str, path: str):
         return json.loads(response.read().decode("utf-8"))
 
 
+def _get_json_from_file(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def _post_json(base_url: str, path: str, payload):
     body = json.dumps(payload).encode("utf-8")
     request = urllib.request.Request(
@@ -119,6 +123,26 @@ class SyncFacadeTest(unittest.TestCase):
         self.assertEqual(explanation["locale"], "en")
         self.assertIn("Rhizome executed", explanation["explanation"])
 
+    def test_explanation_respects_not_executed_water_candidate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_dir = Path(tmp)
+            shutil.copy(default_data_dir() / "rhizome_snapshot.json", data_dir / "rhizome_snapshot.json")
+            receipt = _get_json_from_file(default_data_dir() / "decision_receipt.json")
+            receipt["decision_id"] = "rec_observe_mode"
+            receipt["executed"] = False
+            receipt["execution_details"] = None
+            receipt["blocked_reason"] = "OBSERVE_MODE_EXECUTE_WATER_FALSE"
+            (data_dir / "decision_receipt.json").write_text(json.dumps(receipt), encoding="utf-8")
+            server, base_url = _run_server(data_dir)
+            try:
+                explanation = _get_json(base_url, "/explain/decision/rec_observe_mode?locale=en")
+            finally:
+                _stop_server(server)
+
+        self.assertIn("proposed WATER_A", explanation["explanation"])
+        self.assertIn("did not execute", explanation["explanation"])
+        self.assertNotIn("executed WATER_A", explanation["explanation"])
+
     def test_visit_summary_is_smart_button_payload(self):
         server, base_url = _run_server(default_data_dir())
         try:
@@ -131,9 +155,11 @@ class SyncFacadeTest(unittest.TestCase):
             _stop_server(server)
 
         self.assertEqual(summary["node_id"], "rhizome_01")
-        self.assertEqual(summary["source"], "deterministic_demo_summary")
+        self.assertEqual(summary["source"], "deterministic_visit_summary")
         self.assertEqual(summary["severity"], "attention")
         self.assertEqual(summary["counts"]["total"], 2)
+        self.assertEqual(summary["counts"]["water"], 1)
+        self.assertEqual(summary["counts"]["water_proposed"], 1)
         self.assertIn("Durante tu ausencia", summary["summary"])
         self.assertEqual(future_summary["counts"]["total"], 0)
         self.assertEqual(future_summary["locale"], "en")

--- a/code/rhizome/tests/test_sync_facade.py
+++ b/code/rhizome/tests/test_sync_facade.py
@@ -8,6 +8,7 @@ import unittest
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from src.rhizome_sync_facade import default_data_dir, make_server
@@ -41,8 +42,44 @@ def _post_json(base_url: str, path: str, payload):
         return json.loads(response.read().decode("utf-8"))
 
 
-def _run_server(data_dir: Path, node_id: str = "rhizome_01", state_dir: Path | None = None):
-    server = make_server("127.0.0.1", 0, data_dir, node_id=node_id, state_dir=state_dir)
+def _run_server(
+    data_dir: Path,
+    node_id: str = "rhizome_01",
+    state_dir: Path | None = None,
+    narrator_url: str | None = None,
+):
+    server = make_server(
+        "127.0.0.1",
+        0,
+        data_dir,
+        node_id=node_id,
+        state_dir=state_dir,
+        narrator_url=narrator_url,
+        narrator_model="fake-gemma",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    return server, f"http://{host}:{port}"
+
+
+def _run_fake_adapter(content: str):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            if content_length:
+                self.rfile.read(content_length)
+            body = json.dumps({"message": {"content": content}}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address
@@ -163,6 +200,45 @@ class SyncFacadeTest(unittest.TestCase):
         self.assertIn("Durante tu ausencia", summary["summary"])
         self.assertEqual(future_summary["counts"]["total"], 0)
         self.assertEqual(future_summary["locale"], "en")
+
+    def test_visit_summary_can_use_gemma_narrator_without_changing_counts(self):
+        content = json.dumps(
+            {
+                "headline": "Gemma visit headline",
+                "summary": "Gemma rewrote the operator summary from validated receipts.",
+                "highlights": ["Gemma highlight from receipts."],
+                "recommendation": "Review the receipt trail before changing policy.",
+            }
+        )
+        adapter, adapter_url = _run_fake_adapter(content)
+        server, base_url = _run_server(default_data_dir(), narrator_url=adapter_url)
+        try:
+            summary = _get_json(base_url, "/summary/since?locale=en")
+        finally:
+            _stop_server(server)
+            _stop_server(adapter)
+
+        self.assertEqual(summary["source"], "deterministic_visit_summary")
+        self.assertEqual(summary["narrative_source"], "gemma_visit_narrator")
+        self.assertTrue(summary["gemma_narrator"]["used"])
+        self.assertEqual(summary["counts"]["total"], 2)
+        self.assertEqual(summary["headline"], "Gemma visit headline")
+        self.assertIn("Gemma rewrote", summary["summary"])
+
+    def test_visit_summary_falls_back_when_gemma_narrator_is_invalid(self):
+        adapter, adapter_url = _run_fake_adapter("not-json")
+        server, base_url = _run_server(default_data_dir(), narrator_url=adapter_url)
+        try:
+            summary = _get_json(base_url, "/summary/since?locale=en")
+        finally:
+            _stop_server(server)
+            _stop_server(adapter)
+
+        self.assertEqual(summary["source"], "deterministic_visit_summary")
+        self.assertEqual(summary["narrative_source"], "deterministic_visit_summary")
+        self.assertFalse(summary["gemma_narrator"]["used"])
+        self.assertIn("error", summary["gemma_narrator"])
+        self.assertEqual(summary["counts"]["total"], 2)
 
     def test_second_rhizome_demo_data_can_run_on_another_port(self):
         data_dir = default_data_dir().parents[2] / "rhizome" / "demo_data" / "rhizome_02"


### PR DESCRIPTION
## Summary
- Adds Rhizome Steward v0: minimal autonomous loop for Jetson + ESP32 safety boundary.
- Adds bounded telemetry/receipt persistence, facade_data export for Pollen, fake/serial ESP32 clients, and Jetson wrappers.
- Adds explicit minimal ESP32 profile for pump + soil moisture while tank/flow sensors remain planned and traceable.
- Documents Gemma 4 rationale usage, ShadowSkeptic experimental second criterion, and Pollen/Rhizome jurisdiction notes.

## Validation
- python -m unittest tests.test_rhizome_steward tests.test_sync_facade
- python -m py_compile code/rhizome/src/rhizome_steward.py
- bash -n code/rhizome/jetson/run_steward_once.sh
- bash -n code/rhizome/jetson/start_steward_loop.sh
- Jetson fake smoke: ./run_steward_once.sh

## Safety Notes
- WATER remains blocked unless --execute-water / EXECUTE_WATER=1 is explicit.
- Missing tank sensor defers by default; minimal profile requires ALLOW_MISSING_TANK_SENSOR=1 and records tank_level_unavailable.
- Missing flow sensor is recorded as flow_sensor_unavailable; no sensor absence is silently converted into a normal zero reading.