### PR TITLE
feat(meristem-node): mDNS - meristem.local:13000 funcionando

### DIFF
--- a/bitacora/2026-05-10_mdns-meristem-local-implementado_meristem-a-floema.md
+++ b/bitacora/2026-05-10_mdns-meristem-local-implementado_meristem-a-floema.md
@@ -1,0 +1,178 @@
+# mDNS implementado — `meristem.local:13000` funcionando
+
+**De**: Meristem
+**Para**: Floema (con CC Bea)
+**Fecha**: 2026-05-10 (día 24, tarde)
+**Antecede**:
+- `bitacora/2026-05-10_respuesta-floema-ip-mdns-meristem_meristem-a-floema.md`
+  (mi respuesta inicial proponiendo IP estática + mDNS opcional)
+- Respuesta de Bea: *"podríamos hacer lo de meristem.local"*
+
+---
+
+## TL;DR
+
+- **`meristem.local:13000` resuelve y responde**. Verificado en mi
+  portátil con `curl http://meristem.local:13000/health` → 200 OK.
+- **Funciona como con la Jetson** (`<jetson>.local`): paridad
+  conseguida.
+- Implementado vía `zeroconf` Python (lib pequeña, ya en
+  `requirements.txt`). Lifecycle gestionado por FastAPI lifespan:
+  registra al startup, desregistra al shutdown.
+- **45/46 tests PASS** (36 anteriores + 9 nuevos mDNS, 1 skipped
+  que requiere multicast real opt-in con env var).
+- **Listo para que Pollen Kotlin/OkHttp se conecte** a
+  `http://meristem.local:13000` sin saber IP estática.
+
+---
+
+## Verificación que hice
+
+### Smoke desde el mismo portátil
+
+```bash
+$ ping meristem.local
+Haciendo ping a meristem.local [192.168.1.36] con 32 bytes de datos:
+Respuesta desde 192.168.1.36: bytes=32 tiempo<1m TTL=128
+
+$ curl http://meristem.local:13000/health
+{"status":"ok","version":"0.1.0","port":13000,
+ "meristem_id":"meristem_demo_01",
+ "mdns":{"enabled":true,"node_name":"meristem",
+         "fqdn":"meristem.local","port":13000,
+         "registered":true},
+ ...}
+```
+
+`mdns.registered: true` confirma que el servicio está anunciado en
+multicast.
+
+### Bug encontrado y arreglado durante implementación
+
+**Primer intento**: el `Zeroconf()` síncrono dentro del `async def
+lifespan` colisionaba con el event loop de uvicorn (excepción sin
+mensaje). El servicio quedaba como `registered: false`.
+
+**Fix**: ejecutar `start()` y `stop()` vía
+`asyncio.get_event_loop().run_in_executor(None, ...)`. Eso aísla la
+lógica sync de zeroconf del event loop async de FastAPI.
+
+**Lección**: zeroconf 0.148 NO es event-loop-friendly por defecto.
+Tiene `zeroconf.asyncio.AsyncZeroconf` que se podría usar también,
+pero `run_in_executor` es más simple y suficiente para nuestro caso.
+
+---
+
+## Lo que ahora puedes hacer desde Pollen
+
+### Resolución DNS
+
+```kotlin
+// En Android (NSD nativo o JmDNS resuelven .local automáticamente):
+val url = "http://meristem.local:13000/visit"
+// El sistema operativo o la lib hacen mDNS lookup transparente.
+```
+
+### Endpoint REST (POST /visit)
+
+```kotlin
+val client = OkHttpClient()
+val body = bundleJson.toRequestBody("application/json".toMediaType())
+val req = Request.Builder()
+    .url("http://meristem.local:13000/visit")
+    .post(body)
+    .build()
+val resp = client.newCall(req).execute()
+```
+
+### Endpoint WebSocket (control plane)
+
+```kotlin
+val req = Request.Builder()
+    .url("ws://meristem.local:13000/ws/pollen-sync")
+    .build()
+val ws = client.newWebSocket(req, listener)
+```
+
+**Misma URL para REST y WS**, mismo nombre `meristem.local:13000`.
+
+### `/health` para sanity check
+
+Tu cliente puede hacer un GET a `http://meristem.local:13000/health`
+al arrancar para verificar que Meristem está vivo + averiguar el
+`meristem_id` antes de empezar el flujo.
+
+---
+
+## Configuración (env vars opcionales)
+
+| Env var | Default | Propósito |
+|---|---|---|
+| `MERISTEM_MDNS_ENABLED` | `true` | Set a `false` para desactivar (útil en CI o redes sin multicast) |
+| `MERISTEM_NODE_NAME` | `meristem` | Cambiar para tener varios Meristem en la misma red (`meristem-bea.local`, `meristem-coop.local`...) |
+| `MERISTEM_NODE_PORT` | `13000` | El puerto sigue siendo configurable como antes |
+
+---
+
+## Riesgos típicos de mDNS y mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| Wi-Fi guest con AP isolation bloquea multicast | Hotspot del móvil como red común |
+| Firewall de Windows del portátil filtra mDNS | Permitir Python.exe en Firewall (1 click cuando arranca primera vez) |
+| Cliente Android sin servicio NSD activo | Probar `ping meristem.local` desde Termux antes de lanzar la app |
+| Varios Meristem en la misma red | Usar `MERISTEM_NODE_NAME` distinto en cada uno |
+
+Si en la prueba E2E `meristem.local` no resuelve por algo de
+infraestructura (router raro, AP isolation), **puedo apagar el
+mDNS** con `MERISTEM_MDNS_ENABLED=false` y caer al plan B (IP
+estática). Cero riesgo de bloqueo total.
+
+---
+
+## Tests añadidos (9 nuevos, 45/46 PASS)
+
+`tests/test_mdns.py`:
+1. `test_is_mdns_enabled_default_true`
+2. `test_is_mdns_enabled_false_variants` — `false`, `0`, `no`
+3. `test_is_mdns_enabled_true_variants` — cualquier otro valor
+4. `test_get_node_name_default` — `meristem`
+5. `test_get_node_name_env_override` — lowercase + strip
+6. `test_get_local_ip_returns_string` — fallback `127.0.0.1` si no hay red
+7. `test_announcer_init_does_not_touch_network` — constructor lazy
+8. `test_announcer_state_snapshot_shape` — para `/health`
+9. `test_announcer_stop_before_start_is_noop` — idempotencia
+10. `test_announcer_start_stop_idempotent_with_real_zeroconf` —
+    SKIPPED por defecto, opt-in con `MERISTEM_MDNS_NETWORK_TESTS=1`
+
+---
+
+## Ahora me toca preguntar tu lado
+
+1. **¿Tu cliente WS Kotlin/OkHttp resuelve `.local` por sí mismo o
+   delega al OS Android?** Si lo segundo, asegúrate de que NSD
+   service está activo en tu app. Si lo primero, dime qué lib usas
+   y ajusto algo si hace falta.
+
+2. **¿Quieres hacer el smoke E2E inmediato ahora con `meristem.local`**
+   o prefieres esperar a que el equipo se sincronice? Yo puedo
+   levantar stack en cualquier momento.
+
+3. **¿Algún ajuste de `node_name` que quieras?** Default `meristem`
+   pero si en demo hay confusión con otros nodos, dilo.
+
+---
+
+## Estado al cerrar este punto
+
+- ✅ `meristem.local:13000` resuelve y responde
+- ✅ 45/46 tests PASS (1 skipped por opt-in)
+- ✅ `/health` extendido con `mdns` block
+- ✅ Configuración via env vars (default sensato)
+- ✅ Documentación completa (esta bitácora + dos mensajes anteriores)
+- ✅ Stack apagado limpio
+- ⏭️ Esperando tu respuesta para arrancar smoke E2E coordinado
+
+---
+
+— Meristem

--- a/code/meristem_node/requirements.txt
+++ b/code/meristem_node/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.110
 uvicorn[standard]>=0.27
 pydantic>=2.6
 httpx>=0.27
+zeroconf>=0.130  # mDNS para anunciar meristem.local en LAN local

--- a/code/meristem_node/src/main.py
+++ b/code/meristem_node/src/main.py
@@ -27,6 +27,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -34,6 +36,7 @@ from pydantic import BaseModel
 from . import ingest as ingest_service
 from . import persistence
 from .evaluator import evaluate
+from .mdns import MDNSAnnouncer, get_node_name, is_mdns_enabled
 from .inference import LLMUnavailableError, compose_rationale_via_llm
 from .policy_composer import compose_policy
 from .schemas import (
@@ -157,6 +160,45 @@ def _stub_rationale(rationale_seed: str) -> tuple[str, str]:
 def _build_app() -> FastAPI:
     persistence.init_db()
 
+    # mDNS announcer (lifecycle gestionado por lifespan).
+    # Si MERISTEM_MDNS_ENABLED=false, no se anuncia (útil en tests
+    # o entornos sin multicast).
+    mdns_announcer: MDNSAnnouncer | None = None
+    if is_mdns_enabled():
+        mdns_announcer = MDNSAnnouncer(
+            node_name=get_node_name(),
+            port=PORT,
+            meristem_id=MERISTEM_ID,
+            version="0.1.0",
+        )
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):  # type: ignore[no-redef]
+        # startup
+        if mdns_announcer is not None:
+            # Zeroconf() sync dentro de async lifespan colisiona con
+            # el event loop de uvicorn. Lo ejecutamos en thread executor
+            # para no bloquear ni colisionar.
+            import asyncio
+            try:
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, mdns_announcer.start)
+            except Exception as e:
+                # No bloquear arranque si mDNS falla (firewall, etc.)
+                logger.warning(
+                    "mDNS start fallo, continuamos sin: %s (%s)",
+                    type(e).__name__, e,
+                )
+        yield
+        # shutdown
+        if mdns_announcer is not None:
+            try:
+                import asyncio
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, mdns_announcer.stop)
+            except Exception as e:
+                logger.warning("mDNS stop fallo: %s", e)
+
     app = FastAPI(
         title="Meristem-nodo (Sprout)",
         version="0.1.0",
@@ -165,17 +207,24 @@ def _build_app() -> FastAPI:
             "agricultor o cooperativa. Ingiere bundles que Pollen trae de "
             "Rhizome y emite PolicyPacket actualizado. Día 15: lógica "
             "determinística + persistencia SQLite. Día 16: LLM Gemma 4 "
-            "E4B + tool calling integrado."
+            "E4B + tool calling integrado. Día 24: mDNS announce."
         ),
+        lifespan=lifespan,
     )
 
     @app.get("/health")
     async def health() -> dict[str, Any]:
+        mdns_state = (
+            mdns_announcer.state_snapshot()
+            if mdns_announcer is not None
+            else {"enabled": False}
+        )
         return {
             "status": "ok",
             "version": "0.1.0",
             "port": PORT,
             "meristem_id": MERISTEM_ID,
+            "mdns": mdns_state,
             "llm_mode": "real" if USE_LLM else "stub_disabled",
             "adapter_url": ADAPTER_URL if USE_LLM else None,
             "bundles_received_total": persistence.count_bundles(),

--- a/code/meristem_node/src/mdns.py
+++ b/code/meristem_node/src/mdns.py
@@ -1,0 +1,151 @@
+"""Anuncio mDNS del Meristem-node en la red local.
+
+Permite que Pollen Android (u otros clientes en la misma LAN)
+descubran al Meristem por nombre `meristem.local` en lugar de tener
+que conocer la IP estática del portátil del agricultor.
+
+Servicio anunciado:
+- Tipo: `_http._tcp.local.`
+- Nombre: `<MERISTEM_NODE_NAME>._http._tcp.local.` (default `meristem`)
+- Puerto: el del Meristem-node (`MERISTEM_NODE_PORT`, default 13000)
+- TXT properties: `version`, `service`, `meristem_id`
+
+Lifecycle vía FastAPI lifespan:
+- `startup`: registrar servicio + anunciar en multicast 224.0.0.251:5353
+- `shutdown`: desregistrar + cerrar Zeroconf instance
+
+Si `MERISTEM_MDNS_ENABLED=false`, todo este modulo es no-op (devuelve
+None de `start`). Util para tests + entornos sin multicast.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import socket
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def is_mdns_enabled() -> bool:
+    return os.environ.get("MERISTEM_MDNS_ENABLED", "true").lower() not in (
+        "false", "0", "no",
+    )
+
+
+def get_node_name() -> str:
+    """Nombre del servicio en mDNS, sin sufijo `.local`.
+
+    Por defecto `meristem`, configurable via `MERISTEM_NODE_NAME`.
+    """
+    return os.environ.get("MERISTEM_NODE_NAME", "meristem").strip().lower()
+
+
+def get_local_ip() -> str:
+    """Devuelve la IP local de la interfaz que sale a internet.
+
+    Truco: abre socket UDP no conectado a 8.8.8.8 (no envía datos)
+    para que el OS resuelva la interfaz de salida y nos diga su IP.
+    No requiere DNS ni conexión real.
+
+    Si no hay red, devuelve `127.0.0.1` como fallback.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+    except OSError:
+        ip = "127.0.0.1"
+    finally:
+        s.close()
+    return ip
+
+
+class MDNSAnnouncer:
+    """Wrapper en torno a `zeroconf.Zeroconf` con lifecycle simple.
+
+    Diseño explícito: no levanta el servicio en el constructor; solo
+    al llamar `start()`. Esto permite tests que crean el announcer
+    sin tocar la red.
+    """
+
+    def __init__(
+        self,
+        node_name: str,
+        port: int,
+        meristem_id: str = "meristem_demo_01",
+        version: str = "0.1.0",
+    ) -> None:
+        self.node_name = node_name
+        self.port = port
+        self.meristem_id = meristem_id
+        self.version = version
+        self._zeroconf: Any = None
+        self._service_info: Any = None
+        self._registered: bool = False
+
+    @property
+    def fqdn(self) -> str:
+        """Nombre completo `meristem.local` (con punto final omitido)."""
+        return f"{self.node_name}.local"
+
+    def state_snapshot(self) -> dict[str, Any]:
+        """Snapshot serializable para `/health` endpoint."""
+        return {
+            "enabled": True,
+            "node_name": self.node_name,
+            "fqdn": self.fqdn,
+            "port": self.port,
+            "registered": self._registered,
+        }
+
+    def start(self) -> bool:
+        """Registra el servicio mDNS en multicast. Idempotente.
+
+        Returns True si registró nuevo servicio, False si ya estaba.
+        """
+        if self._registered:
+            return False
+        # Import local: si zeroconf no está instalado, fallar al
+        # llamar start() es mejor que en import time.
+        from zeroconf import ServiceInfo, Zeroconf
+
+        ip = get_local_ip()
+        info = ServiceInfo(
+            type_="_http._tcp.local.",
+            name=f"{self.node_name}._http._tcp.local.",
+            addresses=[socket.inet_aton(ip)],
+            port=self.port,
+            properties={
+                "version": self.version,
+                "service": "meristem-node",
+                "meristem_id": self.meristem_id,
+            },
+            server=f"{self.node_name}.local.",
+        )
+        zc = Zeroconf()
+        zc.register_service(info)
+        self._zeroconf = zc
+        self._service_info = info
+        self._registered = True
+        logger.info(
+            "mDNS announced as %s.local (port=%d, ip=%s)",
+            self.node_name, self.port, ip,
+        )
+        return True
+
+    def stop(self) -> None:
+        """Desregistra y cierra Zeroconf. Idempotente."""
+        if not self._registered:
+            return
+        try:
+            if self._zeroconf is not None and self._service_info is not None:
+                self._zeroconf.unregister_service(self._service_info)
+                self._zeroconf.close()
+        except Exception as e:
+            logger.warning("Error parando mDNS: %s", e)
+        finally:
+            self._zeroconf = None
+            self._service_info = None
+            self._registered = False
+            logger.info("mDNS deregistered")

--- a/code/meristem_node/tests/test_mdns.py
+++ b/code/meristem_node/tests/test_mdns.py
@@ -1,0 +1,113 @@
+"""Tests del modulo mdns (anuncio de meristem.local en LAN).
+
+Linea respuesta a Floema dia 24: usar mDNS en lugar de IP estatica
+para que Pollen pueda conectarse a `meristem.local:13000`.
+
+Cubre:
+- is_mdns_enabled() respeta env var
+- get_node_name() respeta env var
+- get_local_ip() devuelve IP no vacia
+- MDNSAnnouncer inicializa sin tocar red (lazy)
+- state_snapshot devuelve shape esperado
+- start() y stop() son idempotentes
+- start() registra de verdad y stop() limpia (smoke con red)
+
+Tests con red real (start/stop) se saltan si MERISTEM_MDNS_NETWORK_TESTS
+no esta seteado, para no requerir multicast en CI.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.mdns import (
+    MDNSAnnouncer,
+    get_local_ip,
+    get_node_name,
+    is_mdns_enabled,
+)
+
+
+def test_is_mdns_enabled_default_true(monkeypatch):
+    """Default sin env var = enabled."""
+    monkeypatch.delenv("MERISTEM_MDNS_ENABLED", raising=False)
+    assert is_mdns_enabled() is True
+
+
+def test_is_mdns_enabled_false_variants(monkeypatch):
+    """false / 0 / no desactivan."""
+    for v in ("false", "False", "0", "no", "NO"):
+        monkeypatch.setenv("MERISTEM_MDNS_ENABLED", v)
+        assert is_mdns_enabled() is False, f"failed for {v!r}"
+
+
+def test_is_mdns_enabled_true_variants(monkeypatch):
+    """Cualquier valor que no sea false/0/no es enabled."""
+    for v in ("true", "1", "yes", "anything"):
+        monkeypatch.setenv("MERISTEM_MDNS_ENABLED", v)
+        assert is_mdns_enabled() is True, f"failed for {v!r}"
+
+
+def test_get_node_name_default(monkeypatch):
+    monkeypatch.delenv("MERISTEM_NODE_NAME", raising=False)
+    assert get_node_name() == "meristem"
+
+
+def test_get_node_name_env_override(monkeypatch):
+    monkeypatch.setenv("MERISTEM_NODE_NAME", "Meristem-cooperativa")
+    # Lowercase + strip
+    assert get_node_name() == "meristem-cooperativa"
+
+
+def test_get_local_ip_returns_string():
+    """No falla, devuelve algo. Puede ser 127.0.0.1 si no hay red."""
+    ip = get_local_ip()
+    assert isinstance(ip, str)
+    assert len(ip) >= 7  # min '0.0.0.0'
+
+
+def test_announcer_init_does_not_touch_network():
+    """Constructor NO debe tocar red — solo state."""
+    a = MDNSAnnouncer(node_name="test-node", port=13000)
+    assert a.node_name == "test-node"
+    assert a.port == 13000
+    assert a.fqdn == "test-node.local"
+    assert a._registered is False
+
+
+def test_announcer_state_snapshot_shape():
+    a = MDNSAnnouncer(node_name="meristem", port=13000)
+    snap = a.state_snapshot()
+    assert snap == {
+        "enabled": True,
+        "node_name": "meristem",
+        "fqdn": "meristem.local",
+        "port": 13000,
+        "registered": False,
+    }
+
+
+def test_announcer_stop_before_start_is_noop():
+    """stop() sin start() previo no debe fallar."""
+    a = MDNSAnnouncer(node_name="test", port=13000)
+    a.stop()  # no levanta excepcion
+    assert a._registered is False
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MERISTEM_MDNS_NETWORK_TESTS"),
+    reason="Tests con multicast real desactivados; setea "
+           "MERISTEM_MDNS_NETWORK_TESTS=1 para activar",
+)
+def test_announcer_start_stop_idempotent_with_real_zeroconf():
+    """Smoke con multicast real. Saltado por defecto en CI/dev."""
+    a = MDNSAnnouncer(node_name="meristem-test", port=13000)
+    assert a.start() is True
+    assert a._registered is True
+    # Llamar start() de nuevo no debe re-anunciar
+    assert a.start() is False
+    a.stop()
+    assert a._registered is False
+    # Llamar stop() de nuevo no falla
+    a.stop()


### PR DESCRIPTION
Bea aprobó implementar mDNS por paridad con la Jetson. ~30 min como estimé + verificación E2E.

## Verificación que hice

```bash
$ ping meristem.local
Respuesta desde 192.168.1.36 (mi IP portátil) — resuelve OK

$ curl http://meristem.local:13000/health
{...,"mdns":{"enabled":true,"node_name":"meristem","fqdn":"meristem.local","port":13000,"registered":true},...}
```

## Bug encontrado y arreglado

`Zeroconf()` síncrono dentro de `async def lifespan` colisiona con event loop uvicorn → excepción sin mensaje, `registered=false`. **Fix**: ejecutar `start()` y `stop()` vía `asyncio.get_event_loop().run_in_executor(None, ...)`. Aísla la lógica sync de zeroconf del event loop async.

## Cambios

- `requirements.txt`: `zeroconf>=0.130`
- `src/mdns.py` NUEVO: `MDNSAnnouncer` encapsulado, lazy, idempotente
- `src/main.py`: lifespan async con run_in_executor + `/health` extendido con bloque `mdns`
- `tests/test_mdns.py`: 9 PASS + 1 skipped (opt-in con red real)

## Para Pollen

Mismo nombre para REST + WS:
- `http://meristem.local:13000/visit`
- `ws://meristem.local:13000/ws/pollen-sync`
- `http://meristem.local:13000/health`

## Config env vars

| Var | Default | Propósito |
|---|---|---|
| `MERISTEM_MDNS_ENABLED` | `true` | `false` para desactivar |
| `MERISTEM_NODE_NAME` | `meristem` | Permite varios Meristem en misma red |
| `MERISTEM_NODE_PORT` | `13000` | Igual que antes |

## Plan B si mDNS falla en LAN del local

Apagar con `MERISTEM_MDNS_ENABLED=false` y caer a IP estática. Cero riesgo de bloqueo total.

## Tests

**45 PASS + 1 skipped opt-in** (eran 36 antes → +9 nuevos en `test_mdns.py`).

## Pendiente Floema

¿Cliente WS Kotlin/OkHttp resuelve `.local` por sí mismo o delega al OS Android?

🤖 Generated with [Claude Code](https://claude.com/claude-code)