### PR TITLE
[readme] seccion Future work / Roadmap amplia EN+ES (apuntes Bea dia 25)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -125,6 +125,48 @@ make test   # ejecuta 13 tests deterministas + smoke LLM
 
 ---
 
+## Trabajo futuro / Roadmap
+
+Sprout resuelve el caso mínimo. La arquitectura está diseñada para escalar. Esto es lo que ya estamos diseñando para las próximas iteraciones:
+
+### Autonomía hardware
+
+- **Alimentación solar de Rhizome.** Combinar el perfil MAXN_SUPER de la Jetson Orin Nano Super con un panel fotovoltaico pequeño + batería LiFePO4 para eliminar dependencia de red eléctrica. Edge AI sin red eléctrica es el complemento natural a local-first: el campo tampoco necesita enchufe.
+- **Mesh entre parcelas sin WiFi.** LoRa o Meshtastic entre Rhizomes para federación cuando la señal celular es débil y el móvil del agricultor es la única red al alcance. Pollen como portador principal; LoRa como fallback de bajo ancho de banda para propagar `AlertEvent`.
+
+### Gemma 4 multimodal en campo
+
+- **Visión multimodal.** Cámara + Gemma 4 detectando estrés hídrico visible, presión de plagas, fase de crecimiento. La arquitectura ya está preparada — el mismo schema `MissionPatch` puede transportar referencias a imágenes sin cambio de contrato.
+- **Audio bidireccional.** Pollen también le habla al agricultor: pre-aviso conversacional — *"mañana toca riego, pero el depósito está al 30%"*. Full-duplex con salida de audio Gemma 4, mismo modelo de privacidad on-device.
+
+### Localización lingüística
+
+- **Gemma 4 traduce al idioma del usuario.** El sistema razona en contratos (inglés, estructurado, determinista); Pollen adapta el idioma de superficie a lo que hable el agricultor. El usuario nunca ve JSON; ve su idioma. Desacoplar **razonamiento interno** de **superficie externa** mantiene la trazabilidad limpia y la experiencia de usuario nativa.
+- **Fine-tuning de Gemma 4 en lenguas minoritarias.** Los pequeños agricultores del mundo no hablan inglés. Fine-tuning de E4B sobre vocabularios agrícolas locales (swahili, hausa, wolof, quechua, aimara, catalán, euskera…) abre el sistema al **84% de las explotaciones por debajo de 2 hectáreas** que la FAO cuenta como la fuerza agrícola primaria del mundo.
+
+### Sensores y complejidad de parcela
+
+- **Más sensores por parcela.** Conductividad, pH, temperatura de suelo más allá de la humedad. Riego multi-zona con electroválvulas y planificación por zona.
+- **Estaciones meteorológicas locales.** Un sensor meteorológico físico junto a PLOT_01 sustituye al `WeatherDigest` portátil que lleva Pollen para parcelas con visitas frecuentes.
+- **Integración con plataformas climáticas oficiales.** AEMET (España), MeteoCat (Cataluña) o equivalentes regionales — sustituir el `WeatherDigest` portado por datos institucionales verificados cuando hay red disponible.
+
+### Escalado del sistema
+
+- **Meristem de 4 reglas a 8-12.** Hoy el Evaluator determinista corre 4 reglas; post-hackathon ampliación a lógica estacional, cultivos heterogéneos, presupuestos hídricos multi-mes. Plan documentado en 7 fases progresivas.
+- **Fine-tuning de E4B con Unsloth.** Entrenar sobre dataset agrícola sintético + real para especializar la autoría de políticas de Meristem sin degradar razonamiento general.
+- **Federación multi-Rhizome.** Scheduler local coordinando N Rhizomes lógicos en una sola Jetson (explotaciones medianas con múltiples zonas) + federación real entre múltiples Jetsons (explotaciones grandes con parcelas geográficamente separadas).
+- **GPU quality pass.** Cerrar la deriva semántica del offload GPU (casos de test RD04, RH02) para promocionar el perfil `gpu-experimental` a contractual.
+
+### Deuda y pulido
+
+- Tests automatizados de UI (hoy smoke manual).
+- API docs auto-generadas (OpenAPI desde contratos JSON).
+- Identidad visual signal-seed (`#C5F26B`) consistente en todos los frontends.
+
+**Sprout resuelve el caso mínimo. La arquitectura escala.**
+
+---
+
 ## Equipo
 
 **zigiella** — solo developer trabajando con un equipo coordinado de agentes IA especializados (Cambium, Floema, Meristem, Xilema, Corola, Endodermis, Bract, Venation), cada uno con un rol e identidad definidos. La metodología — repo-first, bitácoras escritas como contrato, identidad inline en git, mensajes de coordinación de inicio del día con plantilla `Interrelaciones` explícita — está documentada en [`CONTRIBUTING.md`](CONTRIBUTING.md) y comentada en [writeup §5](writeup/draft.md).

--- a/README.md
+++ b/README.md
@@ -125,6 +125,48 @@ make test   # runs 13 deterministic tests + LLM smoke
 
 ---
 
+## Future work / Roadmap
+
+Sprout solves the minimum case. The architecture is designed to scale. Here is what we are already designing for the next iterations:
+
+### Hardware autonomy
+
+- **Solar power for Rhizome.** Combine the Jetson Orin Nano Super's MAXN_SUPER profile with a small PV array + LiFePO4 battery to remove grid dependency. Edge AI without grid is the natural complement to local-first: the field doesn't need power either.
+- **Mesh between plots without WiFi.** LoRa or Meshtastic between Rhizomes for federation when the cell signal is weak and the farmer's phone is the only network in range. Pollen as primary ferry; LoRa as low-bandwidth fallback for `AlertEvent` propagation.
+
+### Multimodal Gemma 4 in the field
+
+- **Vision multimodal.** Camera + Gemma 4 detecting visible water stress, pest pressure, growth phase. The architecture is already set up — the same `MissionPatch` schema can carry image references with no contract change.
+- **Bidirectional audio.** Pollen also speaks to the farmer: conversational pre-warning — *"tomorrow's irrigation is scheduled, but the tank is at 30%"*. Full-duplex with Gemma 4 audio output, same on-device privacy model.
+
+### Language localization
+
+- **Gemma 4 translates to the user's language.** The system reasons in contracts (English, structured, deterministic); Pollen adapts the surface language to whatever the farmer speaks. The user never sees JSON; they see their language. Decoupling **internal reasoning** from **external surface** keeps the audit trail clean and the user experience native.
+- **Fine-tuning Gemma 4 on minority languages.** Small farmers globally don't speak English. Fine-tuning E4B on local agricultural vocabularies (Swahili, Hausa, Wolof, Quechua, Aymara, Catalan, Basque…) opens the system to the **84% of farms under 2 hectares** that FAO counts as the world's primary agricultural force.
+
+### Sensors and field complexity
+
+- **More sensors per plot.** Conductivity, pH, soil temperature beyond moisture. Multi-zone irrigation with electrovalves and per-zone scheduling.
+- **Local weather stations.** A physical weather sensor next to PLOT_01 replaces the portable `WeatherDigest` carried by Pollen for plots with frequent visits.
+- **Integration with official climate platforms.** AEMET (Spain), MeteoCat (Catalonia), or regional equivalents — replace the carried `WeatherDigest` with verified institutional data when network is available.
+
+### System scaling
+
+- **Meristem from 4 rules to 8-12.** Today the deterministic Evaluator runs 4 rules; post-hackathon expansion to seasonal logic, heterogeneous crops, multi-month water budgets. Plan documented in 7 progressive phases.
+- **Fine-tuning E4B with Unsloth.** Train on a synthetic + real agricultural dataset to specialize Meristem's policy authoring without degrading general reasoning.
+- **Multi-Rhizome federation.** Local scheduler coordinating N logical Rhizomes on a single Jetson (medium farms with multiple zones) + real federation across multiple Jetsons (large farms with geographically separate plots).
+- **GPU quality pass.** Close GPU offload semantic drift (test cases RD04, RH02) to promote the `gpu-experimental` profile to contractual.
+
+### Debt and polish
+
+- Automated UI tests (currently manual smoke).
+- Auto-generated API docs (OpenAPI from JSON contracts).
+- Signal-seed visual identity (`#C5F26B`) consistent across all frontends.
+
+**Sprout solves the minimum case. The architecture scales.**
+
+---
+
 ## Team
 
 **zigiella** — solo developer working with a coordinated team of specialized AI agents (Cambium, Floema, Meristem, Xilema, Corola, Endodermis, Bract, Venation), each with a defined role and identity. The methodology — repo-first, written bitácoras as contract, identity inline for git, day-start coordination messages with explicit `Interrelaciones` template — is documented in [`CONTRIBUTING.md`](CONTRIBUTING.md) and discussed in [writeup §5](writeup/draft.md).


### PR DESCRIPTION
## Resumen

Nueva seccion **"Future work / Roadmap"** despues de **"Project status"** en `README.md` y `README.es.md`. Mas amplia que el writeup §9 (que tiene limite 120 palabras Kaggle). Sin tocar nada mas.

## Origen

Apuntes Bea dia 25 (5 puntos explicitos):
- Alimentacion solar de Rhizome.
- Fine tuning de Gemma 4 para lenguas minoritarias en Pollen.
- Gemma 4 traduce al idioma del usuario (Endodermis lo apunto dia 25 como contrato de localizacion: Rhizome razona en contratos, Pollen adapta idioma).
- Vision.
- Meteo local.

Mas material acumulado de conversaciones previas (audio bidireccional, multi-Rhizome federado, GPU quality pass, Meristem 8-12 reglas con Unsloth, deuda apuntada).

## Estructura (6 bloques)

1. **Hardware autonomy** — solar + mesh LoRa.
2. **Multimodal Gemma 4 in the field** — vision + audio bidireccional.
3. **Language localization** — traduccion + fine-tuning lenguas minoritarias.
4. **Sensors and field complexity** — mas sensores + meteo local + AEMET/MeteoCat.
5. **System scaling** — Meristem ampliacion + fine-tuning E4B + multi-Jetson + GPU quality.
6. **Debt and polish** — UI tests, OpenAPI, signal-seed.

Cierre coherente con writeup §9: *"Sprout solves the minimum case. The architecture scales."* / *"Sprout resuelve el caso minimo. La arquitectura escala."*

## Test plan

- [x] Seccion EN y ES son espejo (estructura identica, contenido equivalente, terminologia tecnica preservada).
- [x] Cierre alineado con writeup §9 ("la arquitectura escala").
- [x] Sin tocar otras secciones del README.
- [x] Sin tocar el writeup (§9 mantiene su limite 120 palabras).
- [ ] Revisar visualmente cuando se merguee.

## Independiente del PR #130

PR #130 (reframe optimizacion hidrica + flujo onboarding modelo) sigue OPEN. **Este PR es scope independiente** — se puede mergear en cualquier orden respecto al #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)