### PR TITLE
[bitacora] disciplina lectura bitacoras antes de despachar (aprendizaje propio dia 25)

### DIFF
--- a/bitacora/2026-05-11_disciplina-lectura-bitacoras-cambium.md
+++ b/bitacora/2026-05-11_disciplina-lectura-bitacoras-cambium.md
@@ -1,0 +1,87 @@
+# Disciplina lectura bitácoras antes de despachar — Cambium
+
+**Fecha:** 2026-05-11 (día 26)
+**Autora:** Cambium
+**Tema:** aprendizaje propio del día 25 → día 26. Disciplina §9.2 aplicada al consumo de información del equipo, no solo a git.
+
+---
+
+## Contexto
+
+Al cierre del día 25, redacté:
+
+- Mensajes de inicio del día 26 para los siete agentes del equipo (`CAJON\mensajes_inicio_dia26.md`).
+- Digest 2026-05-11 para el padre de Bea (`CAJON\digest_sprout\daily_digest_2026-05-11.md`).
+- Valoración global del día 25 en chat con Bea.
+
+Los tres artefactos los redacté **leyendo solo los chats de cierre** que Bea me había pegado, **sin abrir las bitácoras que el equipo había escrito en el repo**. El resultado: tres piezas estructuralmente correctas pero **superficialmente equivocadas**.
+
+## Qué pasó
+
+Bea me corrigió: *"Creo que no te has leído todo lo que han escrito las miembras. Endo escribió varios documentos: ..."* — y me listó cinco archivos que yo había ignorado.
+
+Cuando los leí, encontré que **cinco de las seis piezas grandes del día 25 no estaban en mi valoración previa**:
+
+1. **`ShadowSkeptic deterministic_shadow_skeptic_v0`** activo por defecto en Steward (Endo). Primer doble agente local de Sprout. Material de tesis, no de hackathon.
+2. **Narrador Gemma 4 bilingüe en endpoints Rhizome** (`?locale=en|es`) ya operativo en producción. Endo dia 25.
+3. **Persistencia operacional para meses** (`retention_days=120`, `max_total_bytes=64 MiB`) diseñada para pilotos reales, no para demo. Endo dia 25.
+4. **Conectividad E2E REST Pollen↔Meristem** ya implementada con `GET /health` automático + `POST /visit` + `GET /policy/by-target/{id}` + consola de logs en vivo en UI. Floema dia 25.
+5. **Approach C declarado estándar oficial del proyecto** (`research/07_llm_localization_strategy.md`). Floema dia 25.
+6. **Reflexión Pollen-Rhizome jurisdicción** de Endo con frases tesis directamente citables para writeup §3.
+
+El chat de cierre que recibí era resumen, no contrato. Las bitácoras eran el contrato.
+
+## Qué se hizo
+
+Tras la corrección de Bea (noche del día 25 → día 26):
+
+1. **Lectura completa** de:
+   - `bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md`
+   - `bitacora/2026-05-10_articulo-rhizome-steward-v0_endodermis.md`
+   - `bitacora/2026-05-10_reflexion-pollen-rhizome-jurisdiccion_endodermis.md`
+   - `bitacora/2026-05-10_cierre-dia-25-floema-a-cambium.md`
+   - `research/07_llm_localization_strategy.md`
+   - `bitacora/2026-05-10_cierre-dia-24-meristem-a-cambium_meristem.md`
+   - `code/rhizome/README.md` (actualizado por Endo)
+   - `hardware/wiring_diagrams/day20_mvp_single_pump_relay_wiring.md` (Xilema)
+
+2. **Reescritura de los tres artefactos**:
+   - `mensajes_inicio_dia26.md`: tres mensajes (Floema, Meristem, Endo) ajustados con kudos sincero por trabajo que yo había despachado sin leer + sección nueva "Material nuevo para integrar al writeup" en el resumen a Bea.
+   - `daily_digest_2026-05-11.md`: reescritura completa de 4 → 6 secciones temáticas, con dos secciones nuevas — *"Una segunda inteligencia que vigila a la primera"* (ShadowSkeptic) y *"El sistema aprende dos idiomas"* (narrador bilingüe + Approach C).
+   - **Valoración global a Bea**: corregida con reconocimiento explícito del error.
+
+3. **Integración al writeup** (día 26, PR #143): §3, §4, §5, §6, §9 todos con material del día 25 que el equipo había documentado pero yo no había leído.
+
+## Qué se aprende
+
+**Regla operativa nueva**:
+
+> Antes de despachar mensajes de inicio, digest del padre o valoración global a Bea, **leer todas las bitácoras pusheadas desde el cierre anterior**. El chat de cierre que Bea me pasa es resumen amigable; la bitácora es el contrato técnico. Las dos cosas no son intercambiables.
+
+**Disciplina §9.2 extendida**: la verificación tres puntos antes de commit (`git status`, `git branch`, `git stash list`) tiene su análogo en consumo de información:
+
+1. **`git log --since='1 day ago' --name-only`** o `git diff --name-only origin/main main~5..main` — qué archivos cambiaron desde mi última intervención.
+2. **Filtrar `bitacora/2026-MM-DD*`** del cambio reciente — bitácoras nuevas que el equipo escribió.
+3. **Leer cada una** antes de despachar artefactos sintéticos (digest, mensajes de inicio, valoración).
+
+Si el chat de cierre y la bitácora cuentan historias distintas, **la bitácora gana**. Siempre.
+
+## Cómo aplica al writeup §5
+
+Esta bitácora se cita en `writeup/draft.md §5` (PR #143) como caso de oficio paralelo a:
+
+- Disciplina §9.2 push temprano (Meristem, branch jumping detectado 4ª vez).
+- Validar-antes-de-portar con sketch Arduino (Xilema + Bea, módulo relé 3V3 vs 5V).
+- Testeo antes de decidir configuraciones (`num_predict` hallazgo de Meristem).
+
+Patrón común: **medir antes de actuar**. En este caso, *medir* significa *leer la bitácora del equipo antes de sintetizar*.
+
+## Coordinación posterior
+
+- **Bea** validó la corrección en chat. Mensajes de inicio + digest reescritos.
+- **PR #143** (writeup integración día 25) abierto y mergeable.
+- **Próximos cierres del día 26**: aplicaré la disciplina nueva — leer todas las bitácoras pusheadas antes de redactar mensajes inicio día 27 y digest 2026-05-12.
+
+---
+
+*"Lo que no se mide, no se sostiene. Lo que se mide pero no se lee, tampoco."* — apunte propio dia 26.


### PR DESCRIPTION
## Resumen

Bitácora propia en `bitacora/2026-05-11_disciplina-lectura-bitacoras-cambium.md` documentando aprendizaje del día 25 → día 26.

**Contexto**: cierre día 25 hecho leyendo solo los chats de Bea, sin abrir las bitácoras del equipo. Bea me corrigió. Tras leerlas, encontré 5 de 6 piezas grandes del día que no estaban en mi valoración previa (ShadowSkeptic, narrador bilingüe, persistencia para meses, E2E REST, Approach C, reflexión Pollen-Rhizome).

**Regla nueva**: leer todas las bitácoras pusheadas desde el cierre anterior antes de redactar mensajes de inicio, digest del padre o valoración global. El chat es resumen amigable; la bitácora es el contrato técnico.

**Disciplina §9.2 extendida** al consumo de información, no solo a git.

## Conexión con writeup

Esta bitácora se cita en `writeup/draft.md §5` (PR #143) como caso de oficio paralelo a:

- Push temprano salva ante branch jumping (Meristem, 4ª vez).
- Validar-antes-de-portar con sketch Arduino (Xilema + Bea, módulo relé 3V3 vs 5V).
- Testeo antes de decidir configuraciones (Meristem `num_predict` 53% latencia).

Patrón común: **medir antes de actuar**.

## Test plan

- [x] La bitácora sigue el formato del proyecto (header con fecha + autoría + tema, secciones contexto / qué pasó / qué se hizo / qué se aprende / cómo aplica / coordinación posterior).
- [x] Sin tocar otros archivos.
- [x] Mensaje commit con identidad inline `Cambium <cambium@sprout.local>`.
- [ ] Cuando merguee con PR #143, queda referencia cruzada limpia entre writeup §5 y esta bitácora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)