### PR TITLE
[readme] Project status / Estado del proyecto actualizado con material dia 25 (EN+ES)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -132,8 +132,19 @@ La app usa el `DownloadManager` de Android para bajar `gemma-4-E4B-it.litertlm` 
 
 ## Estado del proyecto
 
-- **MVP**: los cuatro nodos operativos. Cadena Pollen ↔ Rhizome real validada. Veto físico ESP32 confirmado en placa real. Integración LLM Meristem con tool calling cerrada.
-- **Arquitectura**: invariantes estables. Routing entre tres nodos con lógica determinista + LLMs Gemma 4 como autores del rationale.
+- **Ciclo de riego físico cerrado en hardware (día 25)**. La cadena completa `decisión software → relé → bomba 12V → agua → suelo → sensor capacitivo` funciona y deja huella medible: el valor crudo de humedad bajó de **2278 → 1289** tras un pulso, confirmando el ciclo en campo. El `WATER` autónomo sigue en `DRY_RUN`; el pulso físico real solo bajo `TEST_ONLY` supervisado hasta cerrar dos preguntas abiertas sobre el umbral de suelo seco y la ruta de pulso.
+
+- **Rhizome Steward v0 (día 25)**. Bucle host-side autónomo con gates deterministas, recibos persistentes, política de rotación diseñada para meses (`retention_days=120`, `max_total_bytes=64 MiB`), y **`ShadowSkeptic` agente auditor secundario** corriendo con `affects_decision=false` — primera jurisdicción local de doble agente en producción. Registra cada disensión contra la decisión principal sin poder vetar, recogiendo datos para promoción futura a una versión LLM.
+
+- **Pollen ↔ Meristem end-to-end real (día 25)**. Conectividad REST en producción, sin mocks: `GET /health` con indicador visual, `POST /visit` subiendo `RhizomeSnapshot` + `DecisionReceipts` reales, `GET /policy/by-target/{id}`. Consola de logs estilo terminal en la UI para trazabilidad visual.
+
+- **Endpoints bilingües en producción (día 25)**. `?locale=es|en` operativo en `/summary/since` y `/explain/decision/<id>` de Rhizome. El narrador Gemma 4 mejora `rationale_short` sin alterar los facts. **Approach C** (`research/07_llm_localization_strategy.md`) declarado estándar oficial de i18n del proyecto: los nodos edge piensan en Inglés Técnico estable, Pollen + Gemma 4 E4B local traduce al idioma de la UI — preparando el sistema para fine-tuning de lenguas minoritarias (pular, wolof, swahili, quechua, catalán, euskera) sin re-flashear el hardware de campo.
+
+- **Plano de control de Meristem**. 53 tests PASS. mDNS verificado end-to-end (`meristem.local:13000`). UI accesible desde toda la LAN — validada con un click real desde `192.168.1.36` con `trace_id` correlado end-to-end. **`POST /chat` read-only por construcción** — cero superficie de prompt injection sobre hardware, formalmente verificado por test. Hallazgo de latencia: `num_predict` (longitud de salida) genera la reducción del 53%, no `num_ctx` (longitud de entrada); demo en directo viable a ~1.5 min/bundle.
+
+- **Pollen voz → política**. Micrófono + Gemma 4 E4B multimodal audio en Android validado end-to-end contra voz humana real. Frases agrícolas compilan a `MissionPatch`; sin sentido obtiene `REFUSE_RETRY` en lugar de acción fabricada. *Refusal as feature*, validado empíricamente.
+
+- **Invariantes arquitecturales estables**. Routing entre tres nodos con lógica determinista + LLMs Gemma 4 como autores del rationale. Veto de capa física (ESP32) confirmado en placa real (5 reglas + `SAFETY_DOWNGRADE`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,19 @@ The app uses Android's `DownloadManager` to fetch `gemma-4-E4B-it.litertlm` (3.6
 
 ## Project status
 
-- **MVP**: all four nodes operational. Real Pollen ↔ Rhizome chain validated. ESP32 physical veto confirmed on real board. Meristem LLM integration with tool calling closed.
-- **Architecture**: invariants stable. Three-node routing with deterministic logic + Gemma 4 LLMs as rationale authors.
+- **Physical irrigation cycle closed on hardware (day 25)**. The full chain `software decision → relay → 12V pump → water → soil → capacitive sensor` works and leaves measurable trace: raw moisture reading dropped from **2278 → 1289** after a pulse, confirming the cycle in the field. Autonomous `WATER` remains in `DRY_RUN`; real physical pulse only under supervised `TEST_ONLY` until two open questions on the soil-dry threshold and pulse routing are closed.
+
+- **Rhizome Steward v0 (day 25)**. Autonomous host-side loop with deterministic gates, persistent receipts, rotation policy designed for months (`retention_days=120`, `max_total_bytes=64 MiB`), and **`ShadowSkeptic` second-agent auditor** running with `affects_decision=false` — first dual-agent local jurisdiction in production. Logs each disagreement against the primary decision without veto, gathering data for future promotion to an LLM version.
+
+- **Pollen ↔ Meristem end-to-end real (day 25)**. REST connectivity in production, no mocks: `GET /health` sanity check with visual indicator, `POST /visit` uploading real `RhizomeSnapshot` + `DecisionReceipts`, `GET /policy/by-target/{id}`. Terminal-style log console in the UI for visual traceability.
+
+- **Bilingual endpoints in production (day 25)**. `?locale=es|en` operational on Rhizome's `/summary/since` and `/explain/decision/<id>`. Gemma 4 narrator improves `rationale_short` without altering facts. **Approach C** (`research/07_llm_localization_strategy.md`) declared the project's official i18n standard: edge nodes think in stable English Tech, Pollen + Gemma 4 E4B local translates to the UI language — preparing the system for minority-language fine-tuning (Pular, Wolof, Swahili, Quechua, Catalan, Basque) without re-flashing field hardware.
+
+- **Meristem control plane**. 53 tests PASS. mDNS verified end-to-end (`meristem.local:13000`). UI accessible across the LAN — validated with a real click from `192.168.1.36` with `trace_id` correlated end-to-end. **Read-only `POST /chat` by construction** — zero prompt-injection surface on hardware, formally verified by test. Latency finding: `num_predict` (output length) drives the 53% reduction, not `num_ctx` (input length); live-demo viable at ~1.5 min/bundle.
+
+- **Pollen voice → policy**. Microphone + Gemma 4 E4B multimodal audio on Android validated end-to-end against real human voice. Agricultural sentences compile to `MissionPatch`; nonsense gets `REFUSE_RETRY` instead of fabricated action. *Refusal as feature*, validated empirically.
+
+- **Architecture invariants stable**. Three-node routing with deterministic logic + Gemma 4 LLMs as rationale authors. Physical layer veto (ESP32) confirmed on real board (5 rules + `SAFETY_DOWNGRADE`).
 
 ---
 


### PR DESCRIPTION
## Resumen

Sección **"Project status"** / **"Estado del proyecto"** del README EN+ES reescrita para reflejar fielmente el estado real del sistema tras las 6 piezas grandes del día 25.

## Antes (2 bullets genéricos)

```
- MVP: all four nodes operational ...
- Architecture: invariants stable ...
```

## Después (7 bullets concretos con evidencia)

1. **Ciclo de riego físico cerrado en hardware (día 25)** — humedad raw 2278 → 1289 tras pulso.
2. **Rhizome Steward v0 (día 25)** — bucle autónomo con `ShadowSkeptic` doble agente determinista.
3. **Pollen ↔ Meristem E2E real (día 25)** — REST en producción sin mocks.
4. **Endpoints bilingües en producción (día 25)** — `?locale=es|en` operativo, Approach C estándar oficial.
5. **Meristem control plane** — 53 tests, mDNS, UI LAN, chat read-only, hallazgo `num_predict` 53%.
6. **Pollen voz → política** — micrófono + Gemma 4 multimodal validado E2E.
7. **Invariantes arquitecturales estables**.

## Origen

Bitácoras del equipo del día 25, leídas tras la corrección de Bea:

- `bitacora/2026-05-10_endodermis-rhizome-steward-v0_endodermis.md`
- `bitacora/2026-05-10_cierre-dia-25-floema-a-cambium.md`
- `research/07_llm_localization_strategy.md`
- `bitacora/2026-05-10_cierre-dia-24-meristem-a-cambium_meristem.md`

Disciplina nueva documentada en `bitacora/2026-05-11_disciplina-lectura-bitacoras-cambium.md` (PR #144) y citada en writeup §5 (PR #143).

## Coherencia con PRs hermanos

- **PR #143** (writeup integración día 25): mismo material aplicado al writeup §3, §4, §5, §6, §9.
- **PR #144** (bitácora aprendizaje): explica la disciplina nueva de lectura de bitácoras.

Los tres PRs son independientes y mergeables en cualquier orden.

## Test plan

- [x] Sección EN y ES son espejo.
- [x] Sin tocar otras secciones del README.
- [x] Coherente con writeup §6 ("Hacemos vs Proyectamos").
- [x] Identidad inline `Cambium <cambium@sprout.local>`.
- [ ] Revisar visualmente cuando se merguee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)