### PR TITLE
chore(meristem-node): día 26 ajustes A+C Xilema — códigos canónicos inglés + equivalencia HARD_LIMIT_DOMAIN/SAFETY_DOWNGRADE

### DIFF
--- a/code/meristem_node/ARCHITECTURE.md
+++ b/code/meristem_node/ARCHITECTURE.md
@@ -173,7 +173,7 @@ Validan las 4 reglas del Evaluator + 1 control:
 |---|---|---|---|
 | M1 | Bundle limpio (camino feliz) | snapshot OK + 3 receipts WATER OK + weather fresh | CONFIRM_POLICY |
 | M2 | Bundle con disputa | ValidationStamp(disputed) + receipts mixtos | CONSERVATIVE_POLICY |
-| M3 | Bundle con emergencia | DEPOSITO_BAJO repetido + ALERT_LATCHED | ALERT_POLICY |
+| M3 | Bundle con emergencia | TANK_LOW repetido + ALERT_LATCHED | ALERT_POLICY |
 | M4 | Patch malicioso (hard limit) | bundle pide bajar tank_minimum_pct | REFUSE (HARD_LIMIT_DOMAIN) |
 | M5 | Pregunta puntual (jurisdicción Pollen) | bundle incluye request operador "regar 30s extra hoy" | REFUSE (JURISDICTION_POLLEN) |
 

--- a/code/meristem_node/draft_system_prompt_meristem_es.md
+++ b/code/meristem_node/draft_system_prompt_meristem_es.md
@@ -66,8 +66,8 @@ Reglas obligatorias:
   contradicciones (RhizomeSnapshot.pending_contradictions no vacío) o
   baja confianza (DecisionReceipt.confidence<0.7), emite policy más
   conservadora: mode_default="conservative", thresholds más estrictos.
-- Si el bundle muestra emergencia persistente (DEPOSITO_BAJO repetido,
-  HEARTBEAT_PERDIDO recurrente, ALERTA_LATCHED activo), considera
+- Si el bundle muestra emergencia persistente (TANK_LOW repetido,
+  JETSON_HEARTBEAT_LOST recurrente, ALERT_LATCHED activo), considera
   mode_default="alert" y rationale explicativo. NO bloquees el
   hardware, solo recomiendas ALERT al firmware.
 - Para preguntas sobre cambios físicos puntuales (override de horas,

--- a/code/meristem_node/examples/README.md
+++ b/code/meristem_node/examples/README.md
@@ -28,8 +28,8 @@ calling en directo en demo**. Estado del bundle:
 
 - `mode=alert`, `alert_latched=true`, `tank_pct=15` → Evaluator dispara
   ALERT_POLICY (PERSISTENT_EMERGENCY) sin ambigüedad.
-- 3 `decision_receipts` BLOCK seguidos (2 por DEPOSITO_BAJO + 1 por
-  ALERTA_LATCHED) → emergencia persistente clara.
+- 3 `decision_receipts` BLOCK seguidos (2 por TANK_LOW + 1 por
+  ALERT_LATCHED) → emergencia persistente clara.
 - **`weather_digest: null`** → el modelo no tiene contexto meteorológico
   y para escribir un rationale completo *necesita* llamar
   `get_weather_history(plot_id)`.

--- a/code/meristem_node/examples/bundle_M3_emergency.json
+++ b/code/meristem_node/examples/bundle_M3_emergency.json
@@ -12,8 +12,8 @@
     "tank_pct": 12
   },
   "decision_receipts": [
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"}
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"}
   ],
   "weather_digest": {"isStale": false, "summary": "Soleado intenso."},
   "validation_stamps": []

--- a/code/meristem_node/examples/bundle_M6_tool_calling_demo.json
+++ b/code/meristem_node/examples/bundle_M6_tool_calling_demo.json
@@ -12,9 +12,9 @@
     "tank_pct": 15
   },
   "decision_receipts": [
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "ALERTA_LATCHED"}
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "ALERT_LATCHED"}
   ],
   "weather_digest": null,
   "validation_stamps": []

--- a/code/meristem_node/examples/bundle_M7_compare_targets_demo.json
+++ b/code/meristem_node/examples/bundle_M7_compare_targets_demo.json
@@ -13,9 +13,9 @@
     "_demo_hint": "agricultor gestiona rhizome_01 y rhizome_02; este viene degradado, el otro estable"
   },
   "decision_receipts": [
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "ALERTA_LATCHED"}
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "ALERT_LATCHED"}
   ],
   "weather_digest": {"isStale": false, "summary": "Soleado moderado, sin lluvia esperada."},
   "validation_stamps": []

--- a/code/meristem_node/examples/bundle_R2_emergency.json
+++ b/code/meristem_node/examples/bundle_R2_emergency.json
@@ -12,8 +12,8 @@
     "tank_pct": 12
   },
   "decision_receipts": [
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
-    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"}
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
+    {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"}
   ],
   "weather_digest": {"isStale": false, "summary": "Soleado intenso."},
   "validation_stamps": []

--- a/code/meristem_node/src/evaluator.py
+++ b/code/meristem_node/src/evaluator.py
@@ -13,13 +13,23 @@ que se cumpla):
    - HARD_LIMIT_DOMAIN: intenta relajar un hard limit del firmware
      (bajar tank_minimum_pct, subir max_seconds_per_event, acortar
      alert_latched_persists_until).
+
+     **Equivalencia jurisdiccional con SAFETY_DOWNGRADE (Xilema día 26)**:
+     `HARD_LIMIT_DOMAIN` (cómo Meristem nombra el rechazo, perspectiva
+     del emisor) y `SAFETY_DOWNGRADE` (cómo Rhizome/Pollen nombran el
+     intento de bajar safety, perspectiva del validador) son la misma
+     realidad vista desde dos lados — no son duplicados, son
+     **equivalentes jurisdiccionales**. Si en futuras visitas un
+     `ValidationStamp` de Rhizome trae `reason: SAFETY_DOWNGRADE`,
+     Meristem lo interpreta como sinónimo de su propio
+     `HARD_LIMIT_DOMAIN` al consolidar evidencia.
    - JURISDICTION_POLLEN: cambio físico puntual reportado por
      operador (ej. "regar 30s extra hoy") → es jurisdicción de Pollen
      vía MissionPatch, no de Meristem vía PolicyPacket.
 
 2. **ALERT_POLICY — PERSISTENT_EMERGENCY**
    El nodo está en emergencia que persiste a través de varios receipts
-   o snapshot.mode == "alert" + ALERTA_LATCHED activa.
+   o snapshot.mode == "alert" + ALERT_LATCHED activa.
    Meristem afina con mode_default="alert", no bloquea hardware.
 
 3. **CONSERVATIVE_POLICY — EVIDENCE_LOW_CONFIDENCE**

--- a/code/meristem_node/src/schemas.py
+++ b/code/meristem_node/src/schemas.py
@@ -144,10 +144,11 @@ class Action(str, Enum):
     - CONFIRM_POLICY: bundle limpio, extiende valid_until +7d (camino feliz)
     - CONSERVATIVE_POLICY: disputas/baja confianza/contradicciones,
       mode=conservative, thresholds más estrictos
-    - ALERT_POLICY: emergencia persistente (DEPOSITO_BAJO repetido,
-      HEARTBEAT_PERDIDO recurrente, ALERTA_LATCHED activa), mode=alert
+    - ALERT_POLICY: emergencia persistente (TANK_LOW repetido,
+      JETSON_HEARTBEAT_LOST recurrente, ALERT_LATCHED activa), mode=alert
     - REFUSE: el bundle pide algo que viola la jurisdicción de Meristem
-      (HARD_LIMIT_DOMAIN, JURISDICTION_POLLEN)
+      (HARD_LIMIT_DOMAIN ≡ SAFETY_DOWNGRADE jurisdiccionalmente,
+      JURISDICTION_POLLEN)
     """
 
     CONFIRM_POLICY = "confirm_policy"

--- a/code/meristem_node/tests/test_evaluator.py
+++ b/code/meristem_node/tests/test_evaluator.py
@@ -157,7 +157,7 @@ def test_M3_alert_latched() -> None:
             "pending_contradictions": [],
         },
         decision_receipts=[
-            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
+            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
         ],
     )
 
@@ -179,9 +179,9 @@ def test_M3_bis_blocks_consecutivos() -> None:
             "pending_contradictions": [],
         },
         decision_receipts=[
-            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "HEARTBEAT_PERDIDO"},
-            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "HEARTBEAT_PERDIDO"},
-            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "DEPOSITO_BAJO"},
+            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "JETSON_HEARTBEAT_LOST"},
+            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "JETSON_HEARTBEAT_LOST"},
+            {"action": "BLOCK", "confidence": 1.0, "blocked_reason": "TANK_LOW"},
         ],
     )
 

--- a/code/meristem_node/tests/test_inference_tool_parser.py
+++ b/code/meristem_node/tests/test_inference_tool_parser.py
@@ -301,7 +301,7 @@ def test_compose_chat_response_recovers_inline_tool_call(monkeypatch):
         assert name == "get_recent_history"
         assert args["target_node_id"] == "rhizome_01"
         assert args["last_n"] == 5
-        return "Alerta DEPOSITO_BAJO persistente desde ayer 14:00."
+        return "Alerta TANK_LOW persistente desde ayer 14:00."
 
     monkeypatch.setattr(inference, "_post_chat", fake_post_chat)
     # call_tool se importa dentro de la función vía `from .prompts import call_tool`

--- a/docs/20_data_contracts.md
+++ b/docs/20_data_contracts.md
@@ -80,6 +80,16 @@ Meristem puede recomendar **más conservador** (umbrales más altos, ventanas m�
 
 Patrón general: *lo físico manda, Rhizome arbitra, Pollen media, Meristem afina.* La autoridad fluye de arriba a abajo cuando se trata de afinar criterio; se invierte cuando se trata de seguridad física.
 
+#### Nomenclatura: `HARD_LIMIT_DOMAIN` ≡ `SAFETY_DOWNGRADE` (equivalentes jurisdiccionales)
+
+Acordado entre Meristem y Xilema día 26. `HARD_LIMIT_DOMAIN` (cómo Meristem nombra el rechazo cuando un bundle intenta relajar un hard limit del firmware, perspectiva del emisor) y `SAFETY_DOWNGRADE` (cómo Rhizome/Pollen nombran el intento de bajar safety al validar, perspectiva del validador) son **la misma realidad vista desde dos lados**: no son códigos duplicados que haya que fusionar, son **equivalentes jurisdiccionales**.
+
+Implicaciones operativas:
+
+- Si un `ValidationStamp` de Rhizome trae `reason: "SAFETY_DOWNGRADE"`, Meristem lo interpreta como sinónimo de su propio `HARD_LIMIT_DOMAIN` al consolidar evidencia y al redactar rationale al operador.
+- Para el writeup/demo, citar cualquiera de los dos términos es válido; ambos apuntan al mismo invariante: lo físico manda.
+- Esta equivalencia no requiere rename en código — coexisten como sinónimos.
+
 ## 3.5 MissionPatch
 Intención humana compilada por Pollen.
 


### PR DESCRIPTION
Aplica los ajustes A y C que pidió Xilema día 26 antes de congelar la nomenclatura de reason codes. El ajuste B (PolicyPacket campos canónicos de `docs/20_data_contracts.md` §3.4) queda para día 27 — requiere refactor invasivo del schema y conviene discutirlo antes con Xilema.

---

## Ajuste A — migración a códigos canónicos en inglés

| Antes (castellano) | Después (canónico) |
|---|---|
| `DEPOSITO_BAJO` | `TANK_LOW` |
| `HEARTBEAT_PERDIDO` | `JETSON_HEARTBEAT_LOST` |
| `ALERTA_LATCHED` | `ALERT_LATCHED` |

**Archivos tocados (rename mecánico)**:

- `src/evaluator.py` — docstring
- `src/schemas.py` — docstring del enum `Action`
- `tests/test_evaluator.py` — 4 menciones en M3, M3_bis
- `tests/test_inference_tool_parser.py` — stub `call_tool` del test E2E de chat (heredado del PR #142 ya mergeado)
- `examples/bundle_M3_emergency.json` (2 ocurrencias)
- `examples/bundle_M6_tool_calling_demo.json` (3 ocurrencias)
- `examples/bundle_M7_compare_targets_demo.json` (3 ocurrencias)
- `examples/bundle_R2_emergency.json` (2 ocurrencias)
- `examples/README.md` — descripción M6
- `ARCHITECTURE.md` — tabla mini-batería línea 176
- `draft_system_prompt_meristem_es.md` — reglas líneas 69-70

## Ajuste C — clarificar `HARD_LIMIT_DOMAIN ≡ SAFETY_DOWNGRADE` jurisdiccionalmente

Acordado con Xilema: ambos códigos son **la misma realidad vista desde dos lados**.

- `HARD_LIMIT_DOMAIN`: cómo Meristem nombra el rechazo cuando un bundle intenta relajar un hard limit del firmware (perspectiva del emisor).
- `SAFETY_DOWNGRADE`: cómo Rhizome/Pollen nombran el intento de bajar safety al validar (perspectiva del validador).

**NO son duplicados que haya que fusionar** — son equivalentes que coexisten. Análogo conceptual: "ventana cerrada" vs "no se puede salir por ahí" — distinta gramática, misma puerta.

**Cambios**:

1. `docs/20_data_contracts.md` §3.4: sección nueva *"Nomenclatura: HARD_LIMIT_DOMAIN ≡ SAFETY_DOWNGRADE (equivalentes jurisdiccionales)"* documentando la equivalencia + 3 implicaciones operativas (la principal: Meristem interpreta `ValidationStamp.reason = "SAFETY_DOWNGRADE"` como sinónimo de su propio `HARD_LIMIT_DOMAIN` al consolidar evidencia).
2. `src/evaluator.py`: comentario en la docstring de la regla 1 REFUSE explicitando la equivalencia y la interpretación bidireccional.
3. `src/schemas.py`: nota breve en docstring del enum `Action`.

---

## Tests

Suite completa: **91/91 passed** (1 skipped preexistente, no relacionado).

```
==================== 91 passed, 1 skipped, 57 warnings in 5.61s ====================
```

---

## Pendiente día 27

Ajuste B (PolicyPacket campos canónicos de docs/20_data_contracts.md §3.4) en PR separado `feat/meristem-d27-policypacket-canonical` tras consensuar con Xilema el scope exacto del refactor. El `PolicyPacket` actual usa `rules: dict[str, Any]` genérico — el contrato canónico pide campos tipados (`horizon_h`, `watering_windows`, `soil_thresholds`, `max_seconds_per_event`, `daily_budget_ml`, `priority_order`, `failsafe_defaults`). Es invasivo y rompe forma del paquete que viaja a Rhizome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)