### PR TITLE
feat(meristem-node): día 26 — endpoints HTTP fallback para Pollen (Variante D-bis)

### DIFF
--- a/code/meristem_node/scripts/seed_demo_policy.py
+++ b/code/meristem_node/scripts/seed_demo_policy.py
@@ -1,0 +1,80 @@
+"""Seed de 1 policy demo en la BBDD para que el primer 'cargar política'
+desde Pollen devuelva algo visible.
+
+Uso:
+    cd code/meristem_node
+    python scripts/seed_demo_policy.py [--db-path PATH] [--target rhizome_01]
+
+Por defecto seedea para target=rhizome_01 contra la BBDD que use Meristem
+(env MERISTEM_DB_PATH o `meristem_node.db` en cwd).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Ruta SQLite. Por defecto la que usa Meristem (env MERISTEM_DB_PATH o ./meristem_node.db).",
+    )
+    parser.add_argument(
+        "--target",
+        default="rhizome_01",
+        help="target_node_id de la policy demo (default: rhizome_01).",
+    )
+    args = parser.parse_args()
+
+    # Importar tras parsear args (init_db lee env)
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+    from src import persistence
+    from src.schemas import PolicyPacket
+
+    db_path = args.db_path or str(persistence.DEFAULT_DB_PATH)
+    persistence.init_db(db_path)
+
+    policy = PolicyPacket(
+        schema_version="1.0",
+        policy_id=f"pkt_meristem_demo_{uuid.uuid4().hex[:8]}",
+        target_node_id=args.target,
+        valid_until=datetime.now() + timedelta(days=7),
+        mode_default="normal",
+        rules={
+            "soil_dry_threshold_pct": 30,
+            "tank_minimum_pct": 20,
+            "max_seconds_per_event": 60,
+            "watering_windows": ["06:00-08:00", "20:00-21:30"],
+            "daily_budget_ml": 2000,
+        },
+        rationale=(
+            "Policy seedeada para demo: baseline normal coherente con "
+            "campaña primavera, sin alertas activas. El operador la "
+            "verá como 'política actualizada' al cargarla desde Pollen."
+        ),
+        signature="<demo-seed-v0>",
+        policy_origin="meristem-durable",
+        policy_scope="durable",
+    )
+
+    record = persistence.insert_policy(
+        policy=policy,
+        evidence_refs=[],  # seed manual, no viene de un bundle
+        db_path=db_path,
+    )
+    print(f"OK seed policy {record.policy_id} para target={args.target}")
+    print(f"   emitted_at: {record.emitted_at.isoformat()}")
+    print(f"   db_path:    {db_path}")
+    print(f"   valid_until {policy.valid_until.isoformat()}")
+    print(f"   mode:       {policy.mode_default}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/meristem_node/src/main.py
+++ b/code/meristem_node/src/main.py
@@ -59,8 +59,11 @@ from .schemas import (
 )
 from .ws_manager import manager as pollen_manager
 from .ws_schemas import (
+    BundlesPushedPayload,
     CommandPayload,
     MeristemReadyPayload,
+    PoliciesPulledPayload,
+    PollenHelloPayload,
     WSEvent,
 )
 
@@ -533,6 +536,161 @@ def _build_app() -> FastAPI:
             "command": req.command,
             "expected_count": req.expected_count,
         }
+
+    # -----------------------------------------------------------------------
+    # Endpoints HTTP fallback para Pollen (Variante D-bis, día 26)
+    #
+    # Pensados para Floema Android sin WebSocket persistente. Cada endpoint
+    # es el equivalente HTTP del evento WS homónimo. Coexisten con el WS
+    # (Floema usa el que tenga implementado).
+    #
+    # Sesión HTTP: se mantiene viva con POST /pollen/hello + heartbeats
+    # periódicos (POST /pollen/heartbeat). Auto-expira tras
+    # HEARTBEAT_TIMEOUT_S=30s sin heartbeat. Todos los endpoints /pollen/*
+    # refrescan el last_heartbeat automáticamente.
+    # -----------------------------------------------------------------------
+
+    @app.post("/pollen/hello")
+    async def pollen_hello_http(payload: PollenHelloPayload) -> dict[str, Any]:
+        """Equivalente HTTP del evento WS `pollen_hello`.
+
+        Devuelve el payload `meristem_ready` con la lista de policies listas
+        para retirar para los targets que Pollen indica.
+
+        Idempotente: si Floema reenvía hello (ej. reinicio app), refresca
+        la sesión sin error.
+        """
+        # Si hay WS activo, rechazamos para no mezclar modalidades.
+        if pollen_manager.is_http_session is False and pollen_manager.is_connected:
+            raise HTTPException(
+                status_code=409,
+                detail="Ya hay un Pollen conectado vía WebSocket en este Meristem.",
+            )
+        pollen_manager.register_http_hello(payload.pollen_id, payload.app_version)
+        persistence.log_ws_event(
+            direction="in",
+            event=WSEvent.POLLEN_HELLO.value,
+            payload=payload.model_dump(mode="json"),
+        )
+        logger.info(
+            "Pollen %s v%s conectado (HTTP). bundles_pending=%d, policies_pickup=%s",
+            payload.pollen_id, payload.app_version,
+            payload.bundles_pending_count,
+            payload.policies_to_pickup_target_ids,
+        )
+        pickup = []
+        for tid in payload.policies_to_pickup_target_ids:
+            pol = persistence.get_latest_policy_for(tid)
+            if pol:
+                pickup.append({"target_node_id": tid, "policy_id": pol.policy_id})
+        ready_payload = MeristemReadyPayload(
+            meristem_id=MERISTEM_ID,
+            version="0.1.0",
+            policies_ready_for_pickup=pickup,
+        ).model_dump(mode="json")
+        persistence.log_ws_event(
+            direction="out",
+            event=WSEvent.MERISTEM_READY.value,
+            payload=ready_payload,
+        )
+        return ready_payload
+
+    @app.post("/pollen/heartbeat")
+    async def pollen_heartbeat_http() -> dict[str, Any]:
+        """Equivalente HTTP del evento WS `pollen_heartbeat`.
+
+        Refresca el last_heartbeat. Floema debe llamar a este endpoint cada
+        10-20s mientras quiera mantener la sesión "conectada" en la UI
+        Meristem. Si pasa más de 30s sin heartbeat, la sesión auto-expira.
+        """
+        if not pollen_manager.is_connected:
+            raise HTTPException(
+                status_code=409,
+                detail="Pollen no ha hecho hello (o sesión expirada).",
+            )
+        pollen_manager.heartbeat()
+        persistence.log_ws_event(
+            direction="in",
+            event=WSEvent.POLLEN_HEARTBEAT.value,
+            payload={},
+        )
+        ack_payload = {"online": True}
+        persistence.log_ws_event(
+            direction="out",
+            event=WSEvent.MERISTEM_HEARTBEAT_ACK.value,
+            payload=ack_payload,
+        )
+        return ack_payload
+
+    @app.post("/pollen/bundles-pushed")
+    async def pollen_bundles_pushed_http(
+        payload: BundlesPushedPayload,
+    ) -> dict[str, str]:
+        """Equivalente HTTP del evento WS `bundles_pushed`.
+
+        Pollen llama a este endpoint cuando termina de empujar bundles
+        vía POST /visit, para señalizar a la UI Meristem que la tanda
+        está completa. Refresca heartbeat automáticamente.
+        """
+        if not pollen_manager.is_connected:
+            raise HTTPException(
+                status_code=409,
+                detail="Pollen no conectado (envía /pollen/hello primero).",
+            )
+        pollen_manager.heartbeat()
+        persistence.log_ws_event(
+            direction="in",
+            event=WSEvent.BUNDLES_PUSHED.value,
+            payload=payload.model_dump(mode="json"),
+        )
+        logger.info(
+            "Pollen termino de empujar bundles (HTTP): count=%d ids=%s",
+            payload.count, payload.bundle_ids,
+        )
+        return {"status": "ack"}
+
+    @app.post("/pollen/policies-pulled")
+    async def pollen_policies_pulled_http(
+        payload: PoliciesPulledPayload,
+    ) -> dict[str, str]:
+        """Equivalente HTTP del evento WS `policies_pulled`.
+
+        Pollen llama a este endpoint cuando termina de retirar policies
+        vía GET /policies/recent (o GET /policy/by-target). Refresca
+        heartbeat automáticamente.
+        """
+        if not pollen_manager.is_connected:
+            raise HTTPException(
+                status_code=409,
+                detail="Pollen no conectado (envía /pollen/hello primero).",
+            )
+        pollen_manager.heartbeat()
+        persistence.log_ws_event(
+            direction="in",
+            event=WSEvent.POLICIES_PULLED.value,
+            payload=payload.model_dump(mode="json"),
+        )
+        logger.info(
+            "Pollen termino de retirar policies (HTTP): count=%d ids=%s",
+            payload.count, payload.policy_ids,
+        )
+        return {"status": "ack"}
+
+    @app.post("/pollen/goodbye")
+    async def pollen_goodbye_http() -> dict[str, str]:
+        """Desconexión limpia HTTP (opcional).
+
+        Si Pollen sale de la app, puede llamar a este endpoint para que la
+        UI Meristem refleje desconexión inmediata (en vez de esperar al
+        timeout de 30s del heartbeat).
+        """
+        await pollen_manager.disconnect()
+        persistence.log_ws_event(
+            direction="in",
+            event="pollen_goodbye",  # no es evento WS estándar, solo audit
+            payload={},
+        )
+        return {"status": "disconnected"}
 
     # -----------------------------------------------------------------------
     # UI estática para el agricultor (HTML/CSS/JS vanilla servido por FastAPI)

--- a/code/meristem_node/src/ws_manager.py
+++ b/code/meristem_node/src/ws_manager.py
@@ -50,7 +50,25 @@ class PollenConnectionManager:
 
     @property
     def is_connected(self) -> bool:
-        return self._websocket is not None
+        """True si hay sesión activa.
+
+        Considera dos modalidades:
+        - **WebSocket persistente** (Variante D original): `_websocket is not None`.
+        - **HTTP-only** (Variante D-bis añadida día 26 para Floema Android sin WS):
+          `last_heartbeat` reciente (< HEARTBEAT_TIMEOUT_S). Floema mantiene la
+          sesión con POST /pollen/hello + POST /pollen/heartbeat periódicos.
+        """
+        if self._websocket is not None:
+            return True
+        if self._last_heartbeat is not None:
+            elapsed = datetime.utcnow() - self._last_heartbeat
+            return elapsed < timedelta(seconds=HEARTBEAT_TIMEOUT_S)
+        return False
+
+    @property
+    def is_http_session(self) -> bool:
+        """True si la sesión es HTTP-only (no hay WebSocket activo)."""
+        return self._websocket is None and self._last_heartbeat is not None
 
     @property
     def pollen_id(self) -> str | None:
@@ -66,9 +84,16 @@ class PollenConnectionManager:
 
     def state_snapshot(self) -> dict[str, Any]:
         """Snapshot serializable para `/health` y `/sync-state` endpoints."""
+        if self._websocket is not None:
+            mode = "websocket"
+        elif self.is_http_session and self.is_alive:
+            mode = "http"
+        else:
+            mode = "disconnected"
         return {
             "connected": self.is_connected,
             "alive": self.is_alive,
+            "mode": mode,
             "pollen_id": self._pollen_id,
             "app_version": self._app_version,
             "connected_at": (
@@ -112,6 +137,24 @@ class PollenConnectionManager:
         self._pollen_id = pollen_id
         self._app_version = app_version
         self._last_heartbeat = datetime.utcnow()
+
+    def register_http_hello(self, pollen_id: str, app_version: str) -> None:
+        """Registra una sesión HTTP-only (Variante D-bis, día 26).
+
+        Equivalente a `accept_or_reject` + `register_hello` pero sin WS.
+        Floema Android usa esto cuando no levanta WS persistente. La sesión
+        se mantiene viva via heartbeats HTTP periódicos (POST /pollen/heartbeat).
+        Auto-expira tras HEARTBEAT_TIMEOUT_S sin heartbeat.
+
+        Idempotente: si Floema reenvía hello (ej. reconexión), simplemente
+        refresca el last_heartbeat sin error.
+        """
+        self._pollen_id = pollen_id
+        self._app_version = app_version
+        now = datetime.utcnow()
+        if self._connected_at is None:
+            self._connected_at = now
+        self._last_heartbeat = now
 
     def heartbeat(self) -> None:
         """Refresca el last_heartbeat. Llamado en cada mensaje recibido."""

--- a/code/meristem_node/tests/test_pollen_http_endpoints.py
+++ b/code/meristem_node/tests/test_pollen_http_endpoints.py
@@ -1,0 +1,238 @@
+"""Tests de los endpoints HTTP fallback para Pollen (Variante D-bis, día 26).
+
+Para Floema Android sin WebSocket persistente. Cada endpoint HTTP es
+equivalente al evento WebSocket homónimo. Estos tests no usan
+TestClient.websocket_connect — son POSTs HTTP normales.
+
+Cubre:
+- hello → meristem_ready con policies_ready_for_pickup
+- /health refleja connected + mode=http tras hello
+- heartbeat refresca last_heartbeat
+- 409 si heartbeat/bundles-pushed/policies-pulled sin hello previo
+- bundles-pushed y policies-pulled ack
+- goodbye limpia el estado
+- hello duplicado es idempotente (refresca, no error)
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Cliente con DB temporal aislada y manager reset."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "test_meristem.db")
+    monkeypatch.setenv("MERISTEM_DB_PATH", db_path)
+    from src.ws_manager import manager
+    manager._websocket = None
+    manager._pollen_id = None
+    manager._app_version = None
+    manager._connected_at = None
+    manager._last_heartbeat = None
+    from importlib import reload
+    from src import persistence
+    reload(persistence)
+    persistence.init_db(db_path)
+    from src import main as main_module
+    reload(main_module)
+    return TestClient(main_module.app)
+
+
+# ---------------------------------------------------------------------------
+# hello + ready
+# ---------------------------------------------------------------------------
+
+
+def test_hello_returns_meristem_ready_payload(client):
+    """POST /pollen/hello devuelve meristem_ready con pickup list."""
+    r = client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "meristem_id" in body
+    assert body["version"] == "0.1.0"
+    assert body["policies_ready_for_pickup"] == []  # no hay policies seedeadas
+
+
+def test_hello_returns_pickup_when_policies_exist(client):
+    """Si hay policies para los target_ids pedidos, vienen en pickup."""
+    # Seedear 1 policy primero usando /visit con bundle real
+    bundle = {
+        "source_pollen_id": "pollen_seed",
+        "target_rhizome_id": "rhizome_01",
+        "active_policy_id": "pkt_baseline",
+        "rhizome_snapshot": {
+            "snapshot_id": "snap_x",
+            "mode": "normal",
+            "alert_latched": False,
+            "pending_contradictions": [],
+        },
+        "decision_receipts": [],
+        "validation_stamps": [],
+    }
+    r_visit = client.post("/visit", json=bundle)
+    assert r_visit.status_code == 200
+
+    r = client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": ["rhizome_01"],
+    })
+    body = r.json()
+    pickup = body["policies_ready_for_pickup"]
+    assert len(pickup) == 1
+    assert pickup[0]["target_node_id"] == "rhizome_01"
+    assert pickup[0]["policy_id"].startswith("pkt_meristem_")
+
+
+def test_health_reflects_http_mode_after_hello(client):
+    """/health.pollen_connection muestra mode=http tras hello HTTP."""
+    client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    })
+    h = client.get("/health").json()
+    p = h["pollen_connection"]
+    assert p["connected"] is True
+    assert p["mode"] == "http"
+    assert p["pollen_id"] == "pollen_test_http_01"
+    assert p["app_version"] == "0.1.0"
+
+
+def test_hello_is_idempotent(client):
+    """Segundo hello con mismo pollen_id no rompe (refresca sesión)."""
+    payload = {
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    }
+    r1 = client.post("/pollen/hello", json=payload)
+    assert r1.status_code == 200
+    r2 = client.post("/pollen/hello", json=payload)
+    assert r2.status_code == 200  # no 409
+
+
+# ---------------------------------------------------------------------------
+# heartbeat
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_409_without_hello(client):
+    """POST /pollen/heartbeat sin hello previo → 409."""
+    r = client.post("/pollen/heartbeat")
+    assert r.status_code == 409
+
+
+def test_heartbeat_after_hello_ok(client):
+    """POST /pollen/heartbeat tras hello → 200 online:true."""
+    client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    })
+    r = client.post("/pollen/heartbeat")
+    assert r.status_code == 200
+    assert r.json() == {"online": True}
+
+
+# ---------------------------------------------------------------------------
+# bundles-pushed / policies-pulled (ack)
+# ---------------------------------------------------------------------------
+
+
+def test_bundles_pushed_409_without_hello(client):
+    r = client.post("/pollen/bundles-pushed", json={
+        "count": 0, "bundle_ids": [],
+    })
+    assert r.status_code == 409
+
+
+def test_bundles_pushed_ack_after_hello(client):
+    client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    })
+    r = client.post("/pollen/bundles-pushed", json={
+        "count": 2, "bundle_ids": ["b_aaa", "b_bbb"],
+    })
+    assert r.status_code == 200
+    assert r.json() == {"status": "ack"}
+
+
+def test_policies_pulled_409_without_hello(client):
+    r = client.post("/pollen/policies-pulled", json={
+        "count": 0, "policy_ids": [],
+    })
+    assert r.status_code == 409
+
+
+def test_policies_pulled_ack_after_hello(client):
+    client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    })
+    r = client.post("/pollen/policies-pulled", json={
+        "count": 1, "policy_ids": ["pkt_demo_xyz"],
+    })
+    assert r.status_code == 200
+    assert r.json() == {"status": "ack"}
+
+
+# ---------------------------------------------------------------------------
+# goodbye
+# ---------------------------------------------------------------------------
+
+
+def test_goodbye_cleans_state(client):
+    """POST /pollen/goodbye desconecta y /health refleja mode=disconnected."""
+    client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    })
+    r = client.post("/pollen/goodbye")
+    assert r.status_code == 200
+    assert r.json() == {"status": "disconnected"}
+
+    h = client.get("/health").json()
+    p = h["pollen_connection"]
+    assert p["connected"] is False
+    assert p["mode"] == "disconnected"
+
+
+# ---------------------------------------------------------------------------
+# Persistencia de eventos (audit trail)
+# ---------------------------------------------------------------------------
+
+
+def test_hello_persists_event_in_audit_log(client):
+    """log_ws_event registra pollen_hello incluso en modo HTTP (mismo audit)."""
+    client.post("/pollen/hello", json={
+        "pollen_id": "pollen_test_http_01",
+        "app_version": "0.1.0",
+        "bundles_pending_count": 0,
+        "policies_to_pickup_target_ids": [],
+    })
+    h = client.get("/health").json()
+    counts = h["ws_events_by_type"]
+    assert counts.get("pollen_hello", 0) >= 1
+    assert counts.get("meristem_ready", 0) >= 1


### PR DESCRIPTION
Floema descubrió día 26 tarde que su cliente Android sólo hace POST HTTP, no WebSocket persistente, para `pollen_hello`. En vez de obligar a Floema a rebuild Android antes del demo de mañana, añadimos endpoints HTTP equivalentes a los 5 eventos WS principales. **Coexisten con el WebSocket (PR #81) sin romperlo** — Floema usa el que tenga implementado.

## Endpoints añadidos

| HTTP | Equivalente WS | Función |
|---|---|---|
| `POST /pollen/hello` | event `pollen_hello` | Devuelve `meristem_ready` payload con `policies_ready_for_pickup` |
| `POST /pollen/heartbeat` | event `pollen_heartbeat` | Refresca sesión, devuelve `{online: true}` |
| `POST /pollen/bundles-pushed` | event `bundles_pushed` | Ack tras terminar tanda POST /visit |
| `POST /pollen/policies-pulled` | event `policies_pulled` | Ack tras retirar policies vía GET /policy/* |
| `POST /pollen/goodbye` | event `disconnect` | Desconexión limpia (opcional, evita esperar timeout 30s) |

## Sesión HTTP-only

Se mantiene viva via heartbeats periódicos. Si pasa `HEARTBEAT_TIMEOUT_S=30s` sin heartbeat, **auto-expira**. Cada POST a `/pollen/*` refresca el `last_heartbeat` automáticamente (Floema sólo necesita `/pollen/heartbeat` explícito cuando está idle).

## Trade-off documentado

En HTTP-only **no hay push de comandos Meristem → Pollen** (el endpoint `/pollen/command` queda inutilizado). Para el flow del demo (agricultor dispara todo desde el móvil, UI Meristem sólo refleja) esa bidireccionalidad **no se usa**, así que cero pérdida real. Si en futuro la UI Meristem quiere botones que disparen comandos al móvil, Floema necesitará WS para esa función.

## Cambios en `ws_manager.py`

- `is_connected` extendido: True si WS activo **O** `last_heartbeat` reciente
- Nueva propiedad `is_http_session` (distingue modalidad)
- Nuevo método `register_http_hello()` (equivalente HTTP de `accept_or_reject + register_hello` sin WS)
- `state_snapshot()` incluye campo nuevo `mode` con `"websocket"` / `"http"` / `"disconnected"` para que la UI Meristem muestre la modalidad

## Helper de seed

`scripts/seed_demo_policy.py` inserta 1 policy demo en BBDD para que el primer *"cargar política"* desde Pollen devuelva algo visible. Usado en el ensayo de esta tarde, útil para el demo de mañana. Ejecutar antes de arrancar Meristem:

```bash
cd code/meristem_node
python scripts/seed_demo_policy.py
```

## Tests

`tests/test_pollen_http_endpoints.py`: **12 tests** cubriendo:
- hello → ready payload
- pickup populated con policies reales
- /health refleja `mode=http` tras hello HTTP
- hello idempotente (segundo hello no rompe)
- 409 sin hello previo (heartbeat, bundles-pushed, policies-pulled)
- heartbeat/bundles-pushed/policies-pulled acks
- goodbye limpia estado correctamente
- log_ws_event registra el evento HTTP en audit trail

**Suite completa**: 103 passed, 1 skipped (preexistente, no relacionado).

## Verificado E2E via curl

```
$ curl -X POST http://localhost:13000/pollen/hello \
    -d '{"pollen_id":"pollen_test","app_version":"0.1.0",...,
         "policies_to_pickup_target_ids":["rhizome_01"]}'
{"meristem_id":"meristem_demo_01","version":"0.1.0",
 "policies_ready_for_pickup":[
   {"target_node_id":"rhizome_01","policy_id":"pkt_meristem_demo_..."}
 ]}

$ curl http://localhost:13000/health | jq .pollen_connection
{"connected": true, "mode": "http", "pollen_id":"pollen_test", ...}

$ curl -X POST http://localhost:13000/pollen/goodbye
{"status":"disconnected"}

$ curl http://localhost:13000/health | jq .pollen_connection.mode
"disconnected"
```

## Para el demo de mañana

Floema sólo necesita implementar los 5 POSTs. URL base: `http://meristem.local:13000` (mDNS) o `http://192.168.1.36:13000` (IP fallback). Spec exacta de payloads en `code/meristem_node/src/ws_schemas.py` (modelos `PollenHelloPayload`, `BundlesPushedPayload`, `PoliciesPulledPayload`, `MeristemReadyPayload`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)