### PR TITLE
[housekeeping] dia 28 — Local-first AI orden modificadores READMEs + borrar static.zip

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -6,7 +6,7 @@
 
 # Sprout
 
-> **Optimización hídrica AI Local-first para parcelas que la red olvida.**
+> **Optimización hídrica Local-first AI para parcelas que la red olvida.**
 > *Seguro · explicable · open-source.*
 
 > *"Cuando la red no llega y nadie está cerca, el criterio sigue regando."*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Sprout
 
-> **AI Local-first water optimization for plots the network forgets.**
+> **Local-first AI water optimization for plots the network forgets.**
 > *Safe · explainable · open-source.*
 
 > *"When network is absent — and the human is far — local criteria still irrigate."*


### PR DESCRIPTION
## Resumen

Dos cambios pequeños de housekeeping para abrir el día 28 con repo limpio.

### 1. Coherencia 'Local-first AI' en READMEs (línea 9)

El writeup §0 ya usa el orden **'Local-first AI'** (correcto: AI modifica local-first). Los READMEs todavía decían 'AI Local-first', que el lector interpreta como dos cosas separadas. Cambio mínimo (4 caracteres), gran ganancia interpretativa:

- `README.md` L9: *AI Local-first water optimization* → **Local-first AI water optimization**
- `README.es.md` L9: *Optimización hídrica AI Local-first* → **Optimización hídrica Local-first AI**

Las líneas 21 ya estaban bien (*local-first AI architecture* / *arquitectura local-first de IA*).

### 2. Borrar `code/meristem_node/static.zip`

Residuo Venation que estaba untracked. No aporta nada al repo y ensucia `git status`.

## Test plan
- [x] `git diff` solo muestra los 2 reemplazos en READMEs (ninguna línea adicional tocada)
- [x] `static.zip` desaparece de `git status` tras `rm`
- [x] No toca writeup, landing, código ni nada bloqueante a PRs pendientes
- [ ] Bea aprueba

## Bloqueos
Ninguno. Cambio atómico, reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)