### PR TITLE
[ci-pollen] usar testDemoDebugUnitTest (build flavors demo/device introducidos por PR #155)

### DIFF
--- a/.github/workflows/pollen-ci.yml
+++ b/.github/workflows/pollen-ci.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Assemble debug
         run: ./gradlew assembleDebug --stacktrace
 
-      - name: Unit tests
-        run: ./gradlew testDebugUnitTest --stacktrace
+      - name: Unit tests (demo flavor)
+        run: ./gradlew testDemoDebugUnitTest --stacktrace
 
       - name: Publish test results
         if: always()


### PR DESCRIPTION
Fix simple: con los flavors demo + device, Gradle genera tasks especificas. Cambiar testDebugUnitTest -> testDemoDebugUnitTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)