### PR TITLE
[test-pollen] fix trivial type mismatch RoundTripTest:89 (500 → 500f)

### DIFF
--- a/code/pollen/app/src/test/kotlin/net/sprout/pollen/schemas/RoundTripTest.kt
+++ b/code/pollen/app/src/test/kotlin/net/sprout/pollen/schemas/RoundTripTest.kt
@@ -86,7 +86,7 @@ class RoundTripTest {
         """.trimIndent()
         val missionPatch = format.decodeFromString<MissionPatch>(missionPatchJson)
         assertEquals("apply", missionPatch.patchOp)
-        assertEquals(500, missionPatch.budgetCapMl)
+        assertEquals(500f, missionPatch.budgetCapMl)
 
         val validationStampJson = """
             {


### PR DESCRIPTION
Fix trivial: assertEquals(500, ...) → assertEquals(500f, ...) porque MissionPatch.budgetCapMl es Float? no Int.

Queda 1 test fallando (MiniEvaluatorTest:60 testConservativeNoKeywordMatch) que requiere revision de logica de Floema — NO se incluye en este PR.