### PR TITLE
[audit2] fix MiniEvaluatorTest calibration + landing residuos (Local-first AI + mock sin modulación falsa)

### DIFF
--- a/code/pollen/app/src/test/kotlin/net/sprout/pollen/inference/MiniEvaluatorTest.kt
+++ b/code/pollen/app/src/test/kotlin/net/sprout/pollen/inference/MiniEvaluatorTest.kt
@@ -53,13 +53,30 @@ class MiniEvaluatorTest {
 
     @Test
     fun testConservativeNoKeywordMatch() {
-        val patch = MissionPatch("rhizome_01", "water_extra", null, 60, null, null, null, "Aplicar 60 segundos")
+        // El patch propone 20s (dentro de MAX_WATER_SECONDS_MVP=30). El transcript
+        // "agua un poco más" no contiene keywords fuertes ni números que matcheen
+        // con los campos del patch, asi que el evaluator aplica margen conservador
+        // del 75%: 20 * 0.75 = 15s.
+        val patch = MissionPatch("rhizome_01", "water_extra", null, 20, null, null, null, "Aplicar 20 segundos")
         val transcript = "agua un poco más"
         val result = MiniEvaluator.evaluate(transcript, patch, patch.rationaleEs, 0.9, baseSnapshot, basePolicy)
-        
+
         assertEquals(EvaluationAction.APPLY_CONSERVATIVE, result.action)
         assertEquals("MODERATE_CONFIDENCE", result.reasonCode)
-        assertEquals(45, result.policyPacket?.rules?.maxWateringDurationS) // 60 * 0.75
+        assertEquals(15, result.policyPacket?.rules?.maxWateringDurationS) // 20 * 0.75
+    }
+
+    @Test
+    fun testRefuseHardDurationAboveFirmwareLimit() {
+        // Cualquier patch con durationS > MAX_WATER_SECONDS_MVP (30) debe rechazarse
+        // como REFUSE_HARD antes de evaluar match semántico, para proteger el sobre
+        // físico del firmware.
+        val patch = MissionPatch("rhizome_01", "water_extra", null, 60, null, null, null, "Aplicar 60 segundos")
+        val transcript = "riega la parcela A 60 segundos"
+        val result = MiniEvaluator.evaluate(transcript, patch, patch.rationaleEs, 0.9, baseSnapshot, basePolicy)
+
+        assertEquals(EvaluationAction.REFUSE_HARD, result.action)
+        assertEquals("HARD_LIMIT_DOMAIN", result.reasonCode)
     }
 
     @Test

--- a/landing-demo/index.html
+++ b/landing-demo/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sprout — local-first water optimization for plots the network forgets</title>
-  <meta name="description" content="AI Local-first water optimization for plots the network and the human can't always reach. Three nodes (Rhizome, Pollen, Meristem) + an ESP32 safety coprocessor. Every intelligence has jurisdiction and expiry.">
+  <meta name="description" content="Local-first AI water optimization for plots the network and the human can't always reach. Three nodes (Rhizome, Pollen, Meristem) + an ESP32 safety coprocessor. Every intelligence has jurisdiction and expiry.">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
 
 <header class="hero">
   <div class="container">
-    <p class="kicker">AI Local-first · open-source</p>
+    <p class="kicker">Local-first AI · open-source</p>
     <h1>Sprout</h1>
     <p class="tagline-en">When network is absent — and the human is far — local criteria still irrigate.</p>
     <p class="tagline-es" lang="es"><em>Cuando la red no llega y nadie está cerca, el criterio sigue regando.</em></p>

--- a/landing-demo/js/api.js
+++ b/landing-demo/js/api.js
@@ -82,9 +82,19 @@ async function rhizomeDecideMock(state) {
     candidate_seconds = 18;
   }
 
-  // ESP32 SAFE_LIMIT: si la candidate excede max_seconds_per_event = 25, modula
-  const final_seconds = Math.min(candidate_seconds, 25);
-  const modulated = (final_seconds < candidate_seconds);
+  // ESP32 hard limit del firmware MVP: MAX_WATER_SECONDS_MVP = 30. Si la
+  // candidate excede 30, el firmware REAL responde REJECT con motivo
+  // EVENT_DURATION_OUT_OF_RANGE (no modula). Este mock determinista refleja
+  // esa semantica: si esta sobre el limite, queda fuera de envelope.
+  // La "modulacion" que aparecia antes (Math.min) no estaba en el firmware
+  // contractual y se rebajo tras la auditoria dia 28.
+  const FIRMWARE_MAX_SECONDS = 30;
+  const final_seconds = candidate_seconds <= FIRMWARE_MAX_SECONDS ? candidate_seconds : 0;
+  const modulated = false;
+  if (final_seconds === 0 && action === "irrigate") {
+    action = "block";
+    reason = "EVENT_DURATION_OUT_OF_RANGE";
+  }
 
   return {
     decision_id: "dec_" + Date.now().toString(36),


### PR DESCRIPTION
## Resumen

Cierra 3 puntos del feedback de la auditoría externa segunda pasada (2026-05-13):

1. **MiniEvaluatorTest:60** (P0 — último CI rojo Pollen). Diagnóstico auditora: `durationS=60` dispara `REFUSE_HARD` por `MAX_WATER_SECONDS_MVP=30`, no `APPLY_CONSERVATIVE`. Test mal calibrado. Aplicado parche mínimo: cambiar caso a `durationS=20` esperando 15 tras margen 75%, y nuevo test `testRefuseHardDurationAboveFirmwareLimit` para el caso 60→REFUSE_HARD.

2. **landing-demo/index.html**: `AI Local-first` → `Local-first AI` en `<meta description>` (L7) + `<p class=kicker>` (L14). Residuos de la pasada en READMEs.

3. **landing-demo/js/api.js mock Rhizome**: eliminar `Math.min(candidate, 25)` que simulaba modulación inexistente en firmware contractual. Mock ahora refleja semántica real: `FIRMWARE_MAX_SECONDS=30`, si excede → REJECT `EVENT_DURATION_OUT_OF_RANGE`. La narrativa 'AI propone, capa física dispone' sigue intacta; ya no contradice `app_main.c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)