### PR TITLE
[docs] dia 29 cascada final — README + SUBMISSION + READMEs nodos + CITATION + ROADMAP

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,41 @@
+name: Deploy landing to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'landing-demo/**'
+      - '.github/workflows/deploy-landing.yml'
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping intermediate.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload landing artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./landing-demo
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use or reference Sprout, please cite as below."
+title: "Sprout — local-first AI water optimization for plots the network forgets"
+abstract: "Sprout is a safety-bounded decision network for water under absence. It combines three Gemma 4 nodes (Rhizome on Jetson, Pollen on Android via LiteRT-LM, Meristem on a home laptop) with an ESP32-S3 physical veto coprocessor. Every intelligence has jurisdiction. And expiry."
+authors:
+  - name: "zigiella"
+    affiliation: "Sprout project · Castellar de n'Hug, Catalonia, Spain"
+keywords:
+  - "local-first AI"
+  - "Gemma 4"
+  - "edge AI"
+  - "irrigation"
+  - "agriculture"
+  - "safety-bounded AI"
+  - "physical veto"
+  - "Android LiteRT-LM"
+  - "Jetson llama.cpp"
+  - "ESP32 firmware"
+  - "dual-agent pattern"
+version: "1.0.0"
+date-released: 2026-05-15
+license: Apache-2.0
+repository-code: "https://github.com/zigiella/sprout"
+url: "https://zigiella.com/sprout"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- Project README · English first · Spanish version: README.es.md -->
+<!-- Main public README · English first · Spanish version: README.es.md -->
 
 🇬🇧 **English** · 🇪🇸 **[Español](README.es.md)**
 
@@ -7,220 +7,241 @@
 # Sprout
 
 > **Local-first AI water optimization for plots the network forgets.**
-> *Safe · explainable · open-source.*
+> *Open · local · safe · explainable.*
 
-> *"When network is absent — and the human is far — local criteria still irrigate."*
+> **Sprout is a safety-bounded decision network for water under absence.**
 
-📜 **Read the [technical writeup](writeup/draft.md)** — engineering proof behind the system
-🏗️ **Reproduce locally** — see [setup section](#reproduce-locally) below
+[Watch the 3-minute video](#) · [Try the live contract demo](https://zigiella.com/sprout) · [Read the Kaggle writeup](writeup/draft.md) · [Submission guide](SUBMISSION.md)
 
 ---
 
 ## In 30 seconds
 
-Sprout is a **local-first AI architecture for water optimization in remote plots** — places where the field, the person and the network rarely coincide in time.
+Sprout is a local-first AI architecture for irrigation in remote or weakly connected plots — places where the field, the person and the network rarely coincide in time.
 
-Each plot runs **Rhizome**, an autonomous node that decides offline using **Gemma 4 E2B** on a Jetson Orin Nano Super. Rhizome never moves water directly: an **ESP32-S3** with custom firmware enforces hard safety limits and can veto or modulate any action.
+The demo uses pots, a Jetson, an ESP32, an Android phone, a laptop, a 12V pump and real soil readings. The pattern represents something larger: small farms, community gardens, rural plots and peripheral land where water decisions cannot wait for the cloud or for the next human visit.
 
-When a person visits the plots, **Pollen** runs on Android with **Gemma 4 E4B** (multimodal, audio native via LiteRT-LM). Pollen turns each visit into something more valuable than a sync: it talks with the person, asks Rhizome what happened, validates the local state, compiles human intent, and federates context between plots that have no direct network between them.
+Sprout distributes intelligence across three Gemma 4 nodes and one physical veto layer:
 
-**Meristem** runs on the farmer's home laptop with **Gemma 4 E4B** via `llama.cpp`. When things are calm — at the end of the day, in the kitchen, not in the field — Meristem receives the bundles Pollen has carried back, evaluates with **deterministic logic**, and emits a new durable policy. **The LLM only writes the rationale; the decision is auditable down to a concrete rule.**
+- **Rhizome** lives in the plot. It runs **Gemma 4 E2B** on Jetson via `llama.cpp`, reads local state and decides whether to irrigate, defer, skip or block.
+- **Pollen** lives on the farmer’s Android phone. It runs **Gemma 4 E4B** through **LiteRT-LM**, turns visits and voice into expiring `MissionPatch` objects, and carries context between disconnected plots.
+- **Meristem** lives on the farmer’s home laptop. It runs **Gemma 4 E4B** via `llama.cpp`, evaluates bundles and refines durable `PolicyPacket` objects for the next window.
+- **ESP32-S3** owns physical safety. It runs custom ESP-IDF firmware and can veto commands before anything touches water.
 
-The result: **better irrigation criteria when the field, the person and the network don't coincide in time.**
+**The LLM can propose. The physical layer can say no.**
 
 ---
 
 ## Why Sprout
 
-In 2023, **48% of the world's land area suffered at least one month of extreme drought** — the second largest extent since 1951.<sup>[1]</sup> **1.8 billion people are affected by drought worldwide; the cost is $300 billion per year.**<sup>[1]</sup>
+Irrigation is a timing problem as much as a water problem. A plot can become dry while the farmer is away. A local forecast can change while the network is absent. A human observation can matter more than a sensor, but only when a person actually visits.
 
-In Spain alone, drought cost the agricultural sector **€5.55 billion in 2023**.<sup>[2]</sup> 370,000 hectares of rain-fed cereal in the Mediterranean basin lost between 60% and 90% of their harvest. Two years in a row.<sup>[3]</sup>
+Sprout reduces the latency between local evidence and local action.
 
-But the field for which we design doesn't live in continuous connectivity. Globally, **only 58% of the rural population uses internet — in low-income countries, just 14%.**<sup>[4]</sup>
+Instead of assuming permanent connectivity, Sprout uses three time scales:
 
-Sprout exists to bring **operational criteria to plots where you can't be every day, and where you can't always rely on the network.**
+| Layer | Time scale | Question |
+|---|---:|---|
+| **Rhizome** | minutes | What should this plot do now? |
+| **Pollen** | visit TTL | What human intent and context should enter the plot? |
+| **Meristem** | days | What policy should govern the next window? |
+| **ESP32** | physical instant | Is this command safe enough to execute? |
 
 ---
 
 ## Architecture
 
+```text
+             Pollen · Android · Gemma 4 E4B · LiteRT-LM
+          visit voice → MissionPatch · WeatherDigest · FieldVisit
+                                │
+                                ▼
+        Rhizome · Jetson · Gemma 4 E2B · llama.cpp
+           local telemetry → candidate action → DecisionReceipt
+                                │
+                                ▼
+              ESP32-S3 · ESP-IDF firmware · physical veto
+                    pump · relay · soil sensor · tank/flow
+                                ▲
+                                │
+        Meristem · home laptop · Gemma 4 E4B · llama.cpp
+               bundles → evaluator/tools → PolicyPacket
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  Physical layer (ESP32 firmware) — VETO                         │
-│       ↑                                                          │
-│  Rhizome (Jetson + Gemma 4 E2B) — minutes                       │
-│       ↑                                                          │
-│  Pollen (Android + Gemma 4 E4B + audio multimodal) — visit TTL  │
-│       ↑                                                          │
-│  Meristem (home laptop + Gemma 4 E4B) — days                    │
-└─────────────────────────────────────────────────────────────────┘
-```
 
-| Node | Question it answers | Hardware | Gemma 4 model | Runtime | Jurisdiction |
-|------|---------------------|----------|---------------|---------|--------------|
-| **Rhizome** | Should I irrigate now? | Jetson Orin Nano Super (or Raspberry Pi 5) + ESP32-S3 | E2B (it, Q4_K_S) | `llama.cpp` | Minutes |
-| **Pollen** | What human criteria + context? | Android device | E4B | LiteRT-LM | Visit with short TTL |
-| **Meristem** | What policy for the next window? | Farmer's home laptop (Linux/macOS/Windows) | E4B | `llama.cpp` | Days |
-| **ESP32** | Is this command physically safe? | ESP32-S3 N16R8 (or any ESP32-S3 variant) | None — ESP-IDF firmware | — | Physical veto |
+### Invariants
 
-**Invariants:**
+1. **Physical layer prevails.** No LLM can bypass the ESP32.
+2. **Every intelligence has jurisdiction.** Rhizome arbitrates, Pollen mediates, Meristem refines.
+3. **Every criterion expires.** `MissionPatch`, `WeatherDigest` and `PolicyPacket` objects carry TTL or validity windows.
+4. **Deterministic logic decides; Gemma 4 writes rationale and helps formulate criteria.**
+5. **Refusal is a feature.** When the system is uncertain, stale or unsafe, it refuses with a legible reason.
 
-1. *"Physical layer prevails. Rhizome arbitrates. Pollen mediates. Meristem refines."*
-2. *"Every intelligence has jurisdiction. And expiry."* Every `MissionPatch` carries a short TTL. Every `PolicyPacket` carries a validity window. Every `WeatherDigest` expires before going stale. Expired objects get `EXPIRED → REJECTED` with legible reason in `DecisionReceipt`. **No criterion stays silently valid past its window.**
-3. No `PolicyPacket` from Meristem can reduce the firmware's hard limits. It can only recommend more conservative behavior.
+---
 
-**Key pattern (validated empirically)**: deterministic logic decides; the LLM only writes the rationale. When GPU offload caused semantic drift in a test case (output: `need_clarification` instead of `ok`), the system held its contract — the deterministic Evaluator kept the action stable while the LLM continued to author safe-but-off-contract prose. **Empirical proof of the architectural thesis: semantic drift in the model + deterministic guardrail = contractual behavior even under LLM failure.**
+## What is real vs simulated
+
+Sprout is a hackathon MVP with explicit boundaries.
+
+### Validated paths
+
+- Rhizome local decision loop on Jetson with Gemma 4 E2B via `llama.cpp`.
+- Pollen Android app with `demo` and `device` flavors; device path uses LiteRT-LM and Gemma 4 E4B.
+- Pollen voice path records `.wav` audio and feeds audio content to the LiteRT-LM device backend.
+- Meristem local evaluator and Gemma 4 E4B tool-calling path.
+- ESP32-S3 firmware with serial protocol, heartbeat, safety checks, `WATER` `DRY_RUN`, and supervised `PUMP_PULSE` `TEST_ONLY` hardware proof.
+- Physical bench path with relay, 12V pump, soil moisture readings and supervised pulses.
+
+### Deliberately conservative boundaries
+
+- Autonomous `WATER` remains conservative in `DRY_RUN` while production semantics are closed.
+- Physical actuation is demonstrated through supervised `PUMP_PULSE <ms>` as `TEST_ONLY`.
+- The browser demo is a deterministic contract simulator. Real Gemma 4 execution happens in the Android, Jetson and laptop paths documented in this repo.
+
+This distinction is intentional. Sprout values honest safety boundaries over demo theatre.
 
 ---
 
 ## How Gemma 4 is used
 
-Sprout uses Gemma 4 in five concrete ways, each exploiting a different capability of the model:
+Sprout uses Gemma 4 in concrete, node-specific ways:
 
-- **Multimodal audio native** — Pollen feeds raw 16kHz `.wav` directly to Gemma 4 E4B via LiteRT-LM, **without a separate STT pipeline**. Validated end-to-end against real microphone input, with `REFUSE_RETRY` operating over agricultural-nonsense sentences. Code: `code/pollen/.../PollenVoiceInfra.kt`.
-- **Tool calling** — Meristem uses Gemma 4 E4B with native tool calling for `compose_policy(...)`, `validate_bundle(...)` and `compare_targets(...)`. Mini-battery 5/5 PASS. End-to-end runtime validated day 26 with `tool_calls_recovered_from_text=1` from real LLM output. Code: `code/meristem_node/...`.
-- **Three-node routing — two runtimes, one architecture**: three Gemma 4 instances (E2B + E4B + E4B), three jurisdictions, no cloud roundtrip. Runtime choice is conscious per node: **`llama.cpp`** on Jetson (Rhizome) and home laptop (Meristem) — the open-source engine with the richest quantization ecosystem for heterogeneous CPU/GPU; **LiteRT-LM** on Android (Pollen) — Google AI Edge's official runtime, the path that makes native multimodal audio viable on-device. Each node holds the context type its layer is responsible for.
-- **Bilingual narrator in Rhizome** — endpoints `GET /summary/since?locale=es|en` and `GET /explain/decision/<id>?locale=es|en` operational in production. Gemma 4 E2B (via `llama.cpp`) improves the `rationale_short` over a decision **already closed** by deterministic logic — never changes action, never authorizes water, never invents facts. **The system speaks two languages in production.**
-- **Universal Presentation Layer (surface language)** — official project standard for i18n (`research/07_llm_localization_strategy.md`). Edge nodes (Rhizome, ESP32) reason in stable English Tech; Pollen + Gemma 4 E4B via LiteRT-LM translates to the UI language milliseconds before rendering. **The user's language lives in their pocket; the system's criterion lives in the node.** Benefits: hardware agnosticism (no re-flashing nodes per language), preparation for minority-language fine-tuning (Pular, Wolof, Swahili, Quechua, Catalan, Basque) without replicating explanations in N languages in central storage.
+### Rhizome — Gemma 4 E2B on Jetson
 
-**Key pattern**: the final decision is **never** signed by the LLM. The deterministic Evaluator decides; Gemma 4 writes the rationale and adapts the surface language.
+- Runtime: `llama.cpp`.
+- Role: local rationale and arbitration support for a decision already bounded by deterministic gates.
+- Constraint: Gemma 4 does not authorize water.
+
+### Pollen — Gemma 4 E4B on Android
+
+- Runtime: Google AI Edge LiteRT-LM.
+- Role: multimodal audio input, natural-language mission compilation, refusal/retry for unclear instructions.
+- Output: expiring `MissionPatch` objects validated before application.
+
+### Meristem — Gemma 4 E4B on home laptop
+
+- Runtime: `llama.cpp`.
+- Role: tool-calling-assisted policy review and explanation.
+- Output: durable `PolicyPacket` objects for the next window.
+
+### Configuration work
+
+We tested prompt and runtime configurations before freezing the demo path: context window, output budget, thinking behavior and structured-output stability. One useful finding was that latency often followed what the model wrote, not only what it read. Shorter output budgets improved usability when the contract stayed stable.
+
+---
+
+## Live demo
+
+The public web demo is a **deterministic contract simulator**:
+
+- inspect Rhizome decisions;
+- compile Pollen-style mission patches;
+- evaluate Meristem-style policy changes;
+- see TTLs, receipts and refusal paths.
+
+It does not pretend to run Gemma 4 in the browser. It exists so anyone can experience the architecture without hardware, model downloads, cloud APIs or login.
+
+The real local Gemma 4 paths are documented in:
+
+- `code/pollen/` — Android + LiteRT-LM;
+- `code/rhizome/` — Jetson + `llama.cpp`;
+- `code/meristem_node/` — laptop + `llama.cpp`;
+- `hardware/firmware_esp32/` — physical safety coprocessor.
 
 ---
 
 ## Reproduce locally
 
-### Requirements
-
-- **Laptop** for Meristem. 8GB RAM minimum, 16GB ideal. Linux, macOS or Windows.
-- **Jetson Orin Nano Super 8GB** for Rhizome. **Alternative**: Raspberry Pi 5 (with adapted llama.cpp build).
-- **ESP32-S3 N16R8 board** (or any ESP32-S3 variant) for the safety firmware. Required — the physical veto layer is part of the architecture, not optional.
-- **Android device** for Pollen. Android 12 / API 31+ and 64-bit hardware. For Gemma 4 E4B to run smoothly: **12GB RAM recommended, 16GB ideal, at least 6GB free**. CPU is the stable runtime path; GPU/NPU performance depends heavily on the device.
-
-### Quick start
+### Meristem, no hardware needed
 
 ```bash
-git clone https://github.com/zigiella/sprout.git
-cd sprout
-
-# 1. Run Meristem locally (no hardware needed)
 cd code/meristem_node
-make run    # serves on :8000
-make test   # runs 13 deterministic tests + LLM smoke
-
-# 2. Run Pollen demo flavor (mock, runs in any emulator or Appetize)
-# See code/pollen/README.md for Android Studio setup
-
-# 3. (Optional) Run Rhizome on Jetson
-# See code/rhizome/jetson/README.md and run_runtime.sh
+make run
+make test
 ```
 
-### Detailed setup
+### Pollen Android demo flavor
 
-- Meristem-node: [`code/meristem_node/README.md`](code/meristem_node/README.md)
-- Pollen Android: [`code/pollen/README.md`](code/pollen/README.md)
-- Rhizome Jetson: [`code/rhizome/jetson/`](code/rhizome/jetson/) (see scripts `run_runtime.sh`, `start_adapter.sh`, `smoke_adapter.sh`)
-- ESP32 firmware: [`hardware/firmware_esp32/README.md`](hardware/firmware_esp32/README.md)
-- Wiring schematics: [`hardware/wiring_diagrams/day19_mounting_schematics.md`](hardware/wiring_diagrams/day19_mounting_schematics.md)
+```bash
+cd code/pollen
+./gradlew assembleDemoDebug
+./gradlew testDemoDebugUnitTest
+```
 
-### Installing the model on the phone
+Install the demo APK from `demo/` or build locally. The demo flavor uses deterministic inference so it runs without a 3GB model file.
 
-The user installs Pollen from the store — the app itself is light (**~15 MB**). On first launch with WiFi, an onboarding screen appears:
+### Pollen device flavor with Gemma 4 E4B
 
-> *"Downloading agronomic brain (Gemma 4)..."*
+```bash
+cd code/pollen
+./gradlew assembleDeviceRelease
+adb push gemma-4-E4B-it.litertlm /data/local/tmp/gemma-4-E4B-it.litertlm
+```
 
-The app uses Android's `DownloadManager` to fetch `gemma-4-E4B-it.litertlm` (3.6 GB) from a secure CDN directly into the app's private internal storage (`/data/data/net.sprout.pollen/files/`). Once the download completes, **the model lives on the device forever and Pollen runs 100% offline** — no further network round-trip.
+Then open Pollen on Android and select the local model path.
 
-> Requires: Android 12 / API 31+, 12 GB RAM recommended (16 GB ideal), at least 6 GB free for the model file plus runtime headroom. CPU is the stable runtime path; GPU/NPU varies by device.
+### Rhizome on Jetson
 
-> For developers and nightly testers, the `adb push` sideload flow is documented in [`code/pollen/README.md`](code/pollen/README.md).
+```bash
+cd code/rhizome/jetson
+./run_runtime.sh safe-cpu
+./start_adapter.sh
+./smoke_adapter.sh
+```
 
----
+### ESP32 firmware
 
-## Project status
+```bash
+cd hardware/firmware_esp32
+idf.py set-target esp32s3
+idf.py build
+idf.py -p /dev/ttyACM0 flash monitor
+```
 
-- **Physical irrigation cycle closed on hardware (day 25)**. The full chain `software decision → relay → 12V pump → water → soil → capacitive sensor` works and leaves measurable trace: raw moisture reading dropped from **2278 → 1289** after a pulse, confirming the cycle in the field. Autonomous `WATER` remains in `DRY_RUN`; real physical pulse only under supervised `TEST_ONLY` until two open questions on the soil-dry threshold and pulse routing are closed.
-
-- **Rhizome Steward v0 (day 25)**. Autonomous host-side loop with deterministic gates, persistent receipts, rotation policy designed for months (`retention_days=120`, `max_total_bytes=64 MiB`), and **`ShadowSkeptic` second-agent auditor** running with `affects_decision=false` — first dual-agent local jurisdiction in production. Logs each disagreement against the primary decision without veto, gathering data for future promotion to an LLM version.
-
-- **Pollen ↔ Meristem end-to-end real (day 25)**. REST connectivity in production, no mocks: `GET /health` sanity check with visual indicator, `POST /visit` uploading real `RhizomeSnapshot` + `DecisionReceipts`, `GET /policy/by-target/{id}`. Terminal-style log console in the UI for visual traceability.
-
-- **Bilingual endpoints in production (day 25)**. `?locale=es|en` operational on Rhizome's `/summary/since` and `/explain/decision/<id>`. Gemma 4 narrator improves `rationale_short` without altering facts. **Approach C** (`research/07_llm_localization_strategy.md`) declared the project's official i18n standard: edge nodes think in stable English Tech, Pollen + Gemma 4 E4B local translates to the UI language — preparing the system for minority-language fine-tuning (Pular, Wolof, Swahili, Quechua, Catalan, Basque) without re-flashing field hardware.
-
-- **Meristem control plane**. 53 tests PASS. mDNS verified end-to-end (`meristem.local:13000`). UI accessible across the LAN — validated with a real click from `192.168.1.36` with `trace_id` correlated end-to-end. **Read-only `POST /chat` by construction** — zero prompt-injection surface on hardware, formally verified by test. Latency finding: `num_predict` (output length) drives the 53% reduction, not `num_ctx` (input length); live-demo viable at ~1.5 min/bundle.
-
-- **Pollen voice → policy**. Microphone + Gemma 4 E4B multimodal audio on Android validated end-to-end against real human voice. Agricultural sentences compile to `MissionPatch`; nonsense gets `REFUSE_RETRY` instead of fabricated action. *Refusal as feature*, validated empirically.
-
-- **Architecture invariants stable**. Three-node routing with deterministic logic + Gemma 4 LLMs as rationale authors. Physical layer veto (ESP32) confirmed on real board (5 rules + `SAFETY_DOWNGRADE`).
-
----
-
-## Future work / Roadmap
-
-Sprout solves the minimum case. The architecture is designed to scale. Here is what we are already designing for the next iterations:
-
-### Hardware autonomy
-
-- **Solar power for Rhizome.** Combine the Jetson Orin Nano Super's MAXN_SUPER profile with a small PV array + LiFePO4 battery to remove grid dependency. Edge AI without grid is the natural complement to local-first: the field doesn't need power either.
-- **Mesh between plots without WiFi.** LoRa or Meshtastic between Rhizomes for federation when the cell signal is weak and the farmer's phone is the only network in range. Pollen as primary ferry; LoRa as low-bandwidth fallback for `AlertEvent` propagation.
-
-### Multimodal Gemma 4 in the field
-
-- **Vision multimodal.** Camera + Gemma 4 detecting visible water stress, pest pressure, growth phase. The architecture is already set up — the same `MissionPatch` schema can carry image references with no contract change.
-- **Bidirectional audio.** Pollen also speaks to the farmer: conversational pre-warning — *"tomorrow's irrigation is scheduled, but the tank is at 30%"*. Full-duplex with Gemma 4 audio output, same on-device privacy model.
-
-### Language localization
-
-- **Gemma 4 translates to the user's language.** The system reasons in contracts (English, structured, deterministic); Pollen adapts the surface language to whatever the farmer speaks. The user never sees JSON; they see their language. Decoupling **internal reasoning** from **external surface** keeps the audit trail clean and the user experience native.
-- **Fine-tuning Gemma 4 on minority languages.** Small farmers globally don't speak English. Fine-tuning E4B on local agricultural vocabularies (Swahili, Hausa, Wolof, Quechua, Aymara, Catalan, Basque…) opens the system to the **84% of farms under 2 hectares** that FAO counts as the world's primary agricultural force.
-
-### Sensors and field complexity
-
-- **More sensors per plot.** Conductivity, pH, soil temperature beyond moisture. Multi-zone irrigation with electrovalves and per-zone scheduling.
-- **Local weather stations.** A physical weather sensor next to PLOT_01 replaces the portable `WeatherDigest` carried by Pollen for plots with frequent visits.
-- **Integration with official climate platforms.** AEMET (Spain), MeteoCat (Catalonia), or regional equivalents — replace the carried `WeatherDigest` with verified institutional data when network is available.
-
-### System scaling
-
-- **Meristem from 4 rules to 8-12.** Today the deterministic Evaluator runs 4 rules; post-hackathon expansion to seasonal logic, heterogeneous crops, multi-month water budgets. Plan documented in 7 progressive phases.
-- **Fine-tuning E4B with Unsloth.** Train on a synthetic + real agricultural dataset to specialize Meristem's policy authoring without degrading general reasoning.
-- **Multi-Rhizome federation.** Local scheduler coordinating N logical Rhizomes on a single Jetson (medium farms with multiple zones) + real federation across multiple Jetsons (large farms with geographically separate plots).
-- **GPU quality pass.** Close GPU offload semantic drift (test cases RD04, RH02) to promote the `gpu-experimental` profile to contractual.
-
-### Debt and polish
-
-- Automated UI tests (currently manual smoke).
-- Auto-generated API docs (OpenAPI from JSON contracts).
-- Signal-seed visual identity (`#C5F26B`) consistent across all frontends.
-
-**Sprout solves the minimum case. The architecture scales.**
+See each component README for full setup.
 
 ---
 
-## Team
+## Repository map
 
-**zigiella** — solo developer working with a coordinated team of specialized AI agents (Cambium, Floema, Meristem, Xilema, Corola, Endodermis, Bract, Venation), each with a defined role and identity. The methodology — repo-first, written bitácoras as contract, identity inline for git, day-start coordination messages with explicit `Interrelaciones` template — is documented in [`CONTRIBUTING.md`](CONTRIBUTING.md) and discussed in [writeup §5](writeup/draft.md).
-
----
-
-## License
-
-[Apache 2.0](LICENSE). Same as Gemma 4.
-
-## Attribution
-
-Sprout uses Gemma 4 models by Google. **Gemma is a trademark of Google LLC.** This project is not affiliated with or endorsed by Google.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+| Path | Purpose |
+|---|---|
+| `SUBMISSION.md` | Fast path for evaluation: links, proof, what is real vs contract |
+| `writeup/` | Kaggle writeup and supporting notes |
+| `landing-demo/` | Public deterministic contract demo |
+| `code/rhizome/` | Jetson plot node, local decision loop, sync facade |
+| `code/pollen/` | Android mobile node, LiteRT-LM path, voice → MissionPatch |
+| `code/meristem_node/` | Home laptop slow brain, evaluator, policy composer |
+| `hardware/firmware_esp32/` | ESP32 safety coprocessor firmware |
+| `docs/` | Architecture, specs, data contracts and safety rules |
+| `bitacora/` | Spanish development journal and decision trail |
+| `research/` | Evaluation notes, model configuration work and sources |
+| `video/` | Video scripts and production notes |
 
 ---
 
-## Sources
+## Language note
 
-[1] UNCCD — *Global Drought Hotspots Report 2023-2025* + OECD — *Global Drought Outlook 2025*.
-[2] COAG / MAPA — Spain agricultural sector losses due to drought 2023.
-[3] COAG Castilla y León — Mediterranean basin rain-fed cereal losses 2023-2024.
-[4] ITU — *Facts and Figures 2025*: Internet use in urban and rural areas.
+Sprout was built by a Spanish-speaking team. Public entry points are English-first or bilingual; internal bitácoras and fast-moving specs remain in Spanish by design. This mirrors the product thesis: local intelligence should meet people in the language and context where work actually happens.
 
-(Full references with URLs in [`research/metrics/impact_stats.md`](research/metrics/impact_stats.md).)
+---
+
+## Status
+
+Sprout is an MVP, not a production irrigation controller. It demonstrates the core architecture:
+
+- local Gemma 4 reasoning by jurisdiction;
+- Android mobile node with LiteRT-LM path;
+- edge node with `llama.cpp`;
+- laptop slow brain with policy refinement;
+- physical ESP32 safety veto;
+- signed receipts, TTLs and refusal paths.
+
+Future work includes production `WATER` semantics with flow metering, multi-zone irrigation, solar power, local weather stations, vision evidence and language tuning for local agricultural vocabularies.
+
+---
+
+## License and attribution
+
+Apache 2.0. See [`LICENSE`](LICENSE).
+
+Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC. This project is not affiliated with or endorsed by Google.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,112 @@
+# Sprout — Roadmap
+
+> Sprout is a safety-bounded decision network for water under absence.
+> This roadmap extends the same authority model: every new feature respects the rule that **physical safety prevails, Rhizome arbitrates, Pollen mediates, Meristem refines** — and that every intelligence has jurisdiction and expiry.
+
+The MVP delivered in the Gemma 4 Good Hackathon (May 2026) is intentionally minimum but real. The roadmap below is a list of direct extensions, not a wishlist.
+
+---
+
+## 1. Production water semantics
+
+**Goal**: close the autonomous `WATER` command into a contractual production path.
+
+**Why pending**: the MVP keeps autonomous `WATER` in `DRY_RUN` while supervised `PUMP_PULSE` runs as `TEST_ONLY`. The distinction protects users while the production loop is closed.
+
+**What it requires**:
+- Flow meter integration on `FLOW_PULSES` (currently stubbed).
+- `NO_FLOW_DETECTED` rule promoted to active firmware enforcement.
+- Field calibration of `SOIL_WET_BELOW_RAW` / `SOIL_DRY_ABOVE_RAW` per soil type.
+- Bench validation of 24h continuous autonomous loops without operator presence.
+
+---
+
+## 2. Dual-agent maturation
+
+**Goal**: promote `ShadowSkeptic` from observer to bounded second authority.
+
+**Why pending**: the current `ShadowSkeptic` runs deterministic with `affects_decision=false`. Before giving authority to a second voice, Sprout measures whether that voice actually improves safety.
+
+**What it requires**:
+- Comparative analysis of `ShadowSkeptic` objections vs later outcomes (false positives / false negatives).
+- Promotion of recurring proven objections into deterministic gates of the primary steward.
+- Optional Gemma 4 promotion of the auditor itself, with jurisdiction strictly limited to "question the first agent, not decide".
+
+---
+
+## 3. Language fine-tuning
+
+**Goal**: bring Sprout into local agricultural vocabularies and minority languages.
+
+**Why pending**: the current Pollen path uses Gemma 4 E4B base for audio compilation. It works in English and Spanish. Local farms speak local languages.
+
+**What it requires**:
+- Fine-tuning of Gemma 4 E4B over agricultural corpora in Pular, Wolof, Swahili, Quechua, Catalan, Basque and others.
+- Universal Presentation Layer pattern preserved: contracts stay in stable English; only surface language adapts in Pollen.
+- Validation against local field operators per language.
+
+---
+
+## 4. Sensor and actuator expansion
+
+**Goal**: more evidence, more zones, more autonomy.
+
+**What it requires**:
+- **Vision input** through Gemma 4 multimodal: cameras detect visible water stress, pests, growth — non-authoritative evidence to inform Rhizome rationale.
+- **Multi-zone irrigation**: independent valves per soil profile within a single plot, sharing the same physical safety envelope.
+- **Conductivity, pH, soil temperature** sensors as optional Rhizome inputs.
+- **Local weather station** to replace or enrich `WeatherDigest` objects carried by Pollen when stable connectivity is intermittent.
+- **Integration with public meteorological APIs** (AEMET, MeteoCat, etc.) when network is available — still as one input among others.
+
+---
+
+## 5. Full-duplex voice
+
+**Goal**: Pollen also speaks back to the operator.
+
+**Why pending**: the current Pollen path is voice-in (operator speaks → MissionPatch). The natural next step is voice-out (Pollen also reads receipts, asks clarification, gives proactive warnings).
+
+**What it requires**:
+- Two-way audio pipeline through LiteRT-LM.
+- Pre-alert conversational pattern for low tank, expired policy, flagged anomaly.
+- Refusal as conversation: when Pollen does not understand, it asks back instead of returning a code.
+
+---
+
+## 6. Energy and federation
+
+**Goal**: longer field autonomy and multi-plot scale.
+
+**What it requires**:
+- **Solar power for Rhizome**: Jetson MAXN_SUPER + PV panel + LiFePO4 battery for complete energy autonomy.
+- **Federation between multiple Jetsons** in larger farms (>10 plots): scheduler local coordinator + cross-Jetson context sharing without requiring central network.
+- **Scheduler local agent** coordinating N logical nodes within a single Jetson for clustered plots.
+
+---
+
+## 7. Meristem capability scaling
+
+**Goal**: richer slow-brain policy reasoning.
+
+**What it requires**:
+- Evaluator extended from 4 rules to 8–12 (seasonality, heterogeneous crops, multi-month budgets).
+- Fine-tuning E4B over synthetic + real agricultural datasets.
+- Parallel-LLM mode comparing rationales across multiple model variants for policy quality auditing.
+
+---
+
+## Out of scope (deliberately)
+
+- **Cloud control plane**: Sprout's thesis is local-first. Adding a mandatory cloud roundtrip would invalidate the architecture.
+- **Replacing the farmer**: Sprout preserves the farmer's criteria during absence. It is not an autonomous farm AI.
+- **LLM as physical authority**: the ESP32 firmware veto is non-negotiable. No model output, fine-tuned or otherwise, ever signs the final physical action.
+
+---
+
+## How this roadmap evolves
+
+The Sprout project keeps a public `bitacora/` (development journal). Every architectural decision is recorded there with a date, a reason and a context. The roadmap above is the synthesis of intentions documented in the bitácora; the bitácora is where the live thinking lives.
+
+**Sprout is open, local AI for water decisions under absence: expiring authority, signed receipts, a second local voice that audits without authority, and a physical layer that can say no.**
+
+*Apache 2.0 · Built on Gemma 4 by Google. Gemma is a trademark of Google LLC.*

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -10,9 +10,9 @@
 | Asset | Where |
 |-------|-------|
 | **Video (≤ 3 min)** | TBD — public YouTube URL once final cut is uploaded |
-| **Landing demo** | TBD — public hosted URL |
+| **Landing demo** | https://zigiella.com/sprout |
 | **Repository** | https://github.com/zigiella/sprout |
-| **Writeup** | [`writeup/draft.md`](writeup/draft.md) |
+| **Writeup** | [`writeup/draft.md`](writeup/draft.md) (1467 words, also submitted as Kaggle draft) |
 | **Pollen demo APK** | [`demo/pollen-demo.apk`](demo/pollen-demo.apk) (~39 MB, mock LiteRT inference, no model needed) |
 | **Pollen Venation UI APK** | [`demo/pollen-venation-ui.apk`](demo/pollen-venation-ui.apk) (~58 MB, polished UI, no device LiteRT model) |
 | **License** | Apache 2.0 |

--- a/code/pollen/README.md
+++ b/code/pollen/README.md
@@ -1,5 +1,14 @@
 # pollen/
 
+**Abstract:**
+Pollen is the mobile edge-node of the Sprout agricultural ecosystem, built as an Android application for Pixel 10 Pro. It operates as the "roaming brain" of the farm, acting as an offline bridge between the central Meristem server and the remote Rhizome micro-controllers. Pollen handles synchronous data transport via local HTTP APIs and relies entirely on on-device LLM inference using the cutting-edge Gemma 4 E4B model. By integrating native `16kHz .wav` audio capturing with Google's `LiteRT-LM` framework, Pollen enables multi-modal, natural language interactions with farm operators directly in the field, with zero reliance on cloud connectivity. It validates agricultural policies, records field observations, and evaluates complex voice commands deterministically before syncing back to the base station.
+
+**Build Flavors:**
+- **`demo` flavor:** Uses a deterministic mock evaluator to simulate model decisions instantly. Ideal for UI testing, fast iteration, and simulator deployments without requiring heavy model downloads or specific hardware.
+- **`device` flavor:** The production-ready hardware path. Integrates the real `LiteRT-LM` pipeline bound to an on-device Gemma 4 E4B model. Requires Android 12+ (API 31+) and a device with NPU/GPU capabilities for interactive generation speeds.
+
+---
+
 Aplicación Android para el Pixel 10 Pro. Es el **nodo itinerante** del sistema Sprout.
 
 ## Rol

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -1,26 +1,26 @@
 # rhizome/
 
-Nodo edge de parcela. Corre en Jetson Orin Nano Super con Gemma 4 E2B (fine-tuned cuando tengamos v1).
+**Abstract.** Rhizome is the plot node. In the current MVP it runs on Jetson Orin Nano Super and operates offline-first: it reads local telemetry from the ESP32-S3 over serial, builds `RhizomeSnapshot` objects, applies deterministic safety and irrigation-need gates, and writes every outcome as a `DecisionReceipt`. When configured, Gemma 4 E2B via `llama.cpp` is used only to produce short human-readable rationales and visit summaries for Pollen; **it does not authorize water**. The deterministic gate decides whether an action is eligible, and the ESP32 owns the physical veto and pump execution boundary. Pollen consumes Rhizome through the local HTTP sync facade. Camera/vision, multi-zone control, and learning are outside the critical MVP path.
 
 ## Rol
 
-- Lee sensores (humedad suelo x2, caudalimetro, nivel deposito)
-- Captura imagen de camara periodicamente
-- Toma decisiones locales con Gemma 4 E2B
-- Ejecuta o bloquea accion con validacion dura del ESP32
-- Persiste snapshots, eventos, recibos
-- Sirve endpoint local para Pollen (sync via WiFi Direct)
+- Lee telemetría local del ESP32-S3 vía serial (humedad de suelo, nivel de depósito, heartbeat, estado de bomba).
+- Construye `RhizomeSnapshot` y aplica gates deterministas de seguridad y necesidad.
+- Persiste `DecisionReceipt` con evidencia, política activa, candidato, salida del ESP32, acción final y rationale.
+- Cuando hay configuración, pide a Gemma 4 E2B vía `llama.cpp` un rationale corto en lenguaje natural (no autoriza agua).
+- Sirve la fachada HTTP local para Pollen (`GET /summary/since?locale=es|en`, `GET /explain/decision/<id>`, `POST /visit`).
+- `ShadowSkeptic` registra objeciones de un segundo agente con `affects_decision=false`.
 
-## Stack
+## Stack actual (MVP)
 
-- Python 3.11
-- Ollama (`gemma4:e2b` o `sprout-rhizome-e2b-v1` cuantizado)
-- `pydantic` para schemas
-- `smbus2` / `adafruit-circuitpython-ads1x15` para ADC I2C
-- `opencv-python` + `picamera2` para camara
-- Comunicacion con ESP32 via UART o I2C
+- Python 3.11.
+- **`llama.cpp`** con Gemma 4 E2B-it Q4_K_S (perfil `safe-cpu` contractual; perfil `gpu-experimental` con 36/36 capas a GPU para iteración).
+- `pydantic` para schemas.
+- Comunicación con ESP32-S3 via USB-CDC serial.
+- Persistencia rotada (`retention_days=120`, `max_total_bytes=64 MiB`).
+- `decisions_by_rule` en `/health` para trazabilidad ejercitada.
 
-## Estructura (a construir)
+## Estructura real (post-day-28)
 
 ```
 rhizome/

--- a/hardware/firmware_esp32/README.md
+++ b/hardware/firmware_esp32/README.md
@@ -1,5 +1,11 @@
 # firmware_esp32
 
+**Abstract.** This firmware is Sprout's physical safety coprocessor, written in C with ESP-IDF for ESP32-S3. It owns the relay, the pump, the soil moisture reading on `GPIO4` and the relay control on `GPIO16`. It validates every irrigation command against five hard rules (`JETSON_HEARTBEAT_LOST`, `TANK_LOW`, `EVENT_DURATION_OUT_OF_RANGE`, `NO_FLOW_DETECTED`, `ALERT_LATCHED`) and rejects with a legible reason if any fails. The state machine is `SAFE_IDLE → READY → EXECUTING → DEGRADED → ALERT_LATCHED`. The LLM proposes; this firmware disposes.
+
+> **Submission status:** `WATER` remains the conservative contract path and returns `DRY_RUN`; supervised physical actuation is demonstrated through `PUMP_PULSE <ms>` as `TEST_ONLY`. This distinction is intentional: it keeps the autonomous control path conservative while proving the physical pump/soil loop on real hardware. Day 27 validated 12 supervised pulses with measurable soil moisture drop (raw 2278 → 1289 after pulse).
+
+---
+
 Bootstrap del firmware real de la capa dura de seguridad para `Sprout`.
 
 ## Objetivo del milestone actual

--- a/landing-demo/css/style.css
+++ b/landing-demo/css/style.css
@@ -1,309 +1,265 @@
 /*
-  Sprout landing-demo · primera versión funcional · día 21
-  CSS funcional, no diseño final. Venation reescribirá CSS sobre
-  esta estructura HTML estable cuando llegue su turno (días 22-25).
-  Paleta: neutra, accesible, sobria. Cero verde-lima signal.seed
-  (que se reserva para "AI active" en el sistema visual oficial).
+  Sprout landing-demo · v2 dia 29 (segunda auditoria externa)
+  Paleta: soil graphite (#1a1a18) + soil oat (#f3ede4) + signal seed (#c5f26b).
+  Sin librerias externas. Mobile-first responsive.
 */
 
 :root {
-  --bg: #fafaf7;
-  --bg-soft: #f0eee8;
-  --ink: #1a1a1a;
-  --ink-soft: #555;
-  --muted: #8a8a8a;
-  --accent: #2d5a4a;       /* verde oliva sobrio */
-  --accent-ink: #1a3a30;
-  --beta: #d97706;         /* ámbar/orange para BETA badge */
-  --rule: #d8d6cf;
-  --code-bg: #efece4;
-  --max-width: 880px;
-  --r: 8px;
+  --bg: #f3ede4;
+  --ink: #1a1a18;
+  --muted: #6e665f;
+  --seed: #c5f26b;
+  --line: #d8cec2;
+  --soft: #fffaf2;
+  --danger: #b94a3d;
 }
 
 * { box-sizing: border-box; }
 
-html, body {
+body {
   margin: 0;
-  padding: 0;
   background: var(--bg);
   color: var(--ink);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-  line-height: 1.55;
-  font-size: 17px;
+  font: 16px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
-a {
-  color: var(--accent);
-  text-decoration: underline;
-  text-underline-offset: 2px;
+a { color: inherit; }
+
+code {
+  font-family: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.95em;
 }
-a:hover { color: var(--accent-ink); }
 
 .container {
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 0 24px;
+  max-width: 1120px;
+  margin: auto;
+  padding: 72px 24px;
 }
 
-.section { padding: 56px 0; border-top: 1px solid var(--rule); }
-.bg-soft { background: var(--bg-soft); border-top: none; border-bottom: 1px solid var(--rule); }
-
-/* Hero */
+/* --- Hero --- */
 .hero {
-  padding: 96px 0 64px;
-  background: var(--bg-soft);
-  border-bottom: 1px solid var(--rule);
-}
-.kicker {
-  font-size: 14px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin: 0 0 12px;
-}
-h1 {
-  font-size: 64px;
-  line-height: 1.1;
-  margin: 0 0 16px;
-  letter-spacing: -0.02em;
-}
-.tagline-en {
-  font-size: 22px;
-  font-weight: 600;
-  margin: 0 0 4px;
-  color: var(--accent-ink);
-}
-.tagline-es {
-  font-size: 17px;
-  margin: 0 0 28px;
-  color: var(--ink-soft);
-}
-.lede {
-  font-size: 18px;
-  max-width: 60ch;
-  margin: 0 0 32px;
+  background: #1a1a18;
+  color: #f3ede4;
+  min-height: 86vh;
 }
 
-/* Buttons */
-.cta-row { display: flex; gap: 12px; flex-wrap: wrap; }
-.btn {
-  display: inline-block;
-  padding: 12px 22px;
-  border-radius: var(--r);
+.nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  padding: 24px 32px;
+  flex-wrap: wrap;
+}
+
+.brand {
+  font-weight: 800;
+  margin-right: auto;
+}
+
+.nav a {
   text-decoration: none;
-  font-weight: 600;
-  font-size: 15px;
-  border: 1px solid transparent;
+  color: #f3ede4;
+  opacity: 0.85;
 }
-.btn-primary {
-  background: var(--accent);
-  color: white;
-}
-.btn-primary:hover { background: var(--accent-ink); color: white; }
 
-.btn-secondary {
-  background: white;
-  color: var(--accent);
-  border-color: var(--accent);
-}
-.btn-secondary:hover { background: var(--accent); color: white; }
+.nav a:hover { opacity: 1; }
 
-.btn-ghost {
+.hero-inner {
+  max-width: 980px;
+  padding: 11vh 32px 80px;
+}
+
+.kicker, .node {
+  color: var(--seed);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 13px;
+}
+
+.hero h1 {
+  font-size: clamp(44px, 8vw, 92px);
+  line-height: 0.95;
+  margin: 20px 0;
+}
+
+.tagline {
+  font-size: clamp(21px, 3vw, 34px);
+  max-width: 880px;
+}
+
+.lede {
+  font-size: 20px;
+  max-width: 900px;
+  color: #dcd3c7;
+}
+
+.cta-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 32px;
+}
+
+.btn, button {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 12px 18px;
+  text-decoration: none;
   background: transparent;
-  color: var(--ink-soft);
-  border-color: var(--rule);
-}
-.btn-ghost:hover { color: var(--ink); border-color: var(--ink-soft); }
-
-/* Headings */
-h2 { font-size: 32px; margin: 0 0 24px; letter-spacing: -0.01em; }
-h3 { font-size: 22px; margin: 0 0 12px; }
-
-/* Cards grid */
-.grid { display: grid; gap: 24px; }
-.cards-3 { grid-template-columns: repeat(3, 1fr); }
-@media (max-width: 720px) {
-  .cards-3 { grid-template-columns: 1fr; }
-  h1 { font-size: 44px; }
+  color: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 15px;
+  font-family: inherit;
 }
 
-.card {
+button { color: var(--ink); }
+
+.primary {
+  background: var(--seed);
+  color: #1a1a18;
+  border-color: var(--seed);
+}
+
+.ghost { opacity: 0.8; }
+
+/* --- Truth section --- */
+.truth {
+  margin-top: -72px;
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 28px;
+}
+
+.truth-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin: 24px 0;
+}
+
+.truth-grid div {
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
   background: white;
-  border: 1px solid var(--rule);
-  border-radius: var(--r);
+}
+
+.truth-grid strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.truth-grid span {
+  display: block;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.note, .muted {
+  color: var(--muted);
+}
+
+/* --- Demo cards --- */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-top: 24px;
+}
+
+.cards article {
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 24px;
   padding: 24px;
 }
-.card h3 { margin-top: 0; }
-.card-meta {
-  font-size: 13px;
-  color: var(--muted);
-  margin: -4px 0 12px;
-}
-.card p { margin: 0 0 16px; font-size: 15px; }
 
-/* Lists */
-.howlist {
-  margin: 0 0 24px;
-  padding: 0;
-  list-style: none;
-}
-.howlist li {
-  padding: 16px 0;
-  border-top: 1px solid var(--rule);
-}
-.howlist li:first-child { border-top: none; padding-top: 0; }
-
-/* Inline code */
-code {
-  background: var(--code-bg);
-  padding: 1px 6px;
-  border-radius: 4px;
-  font-family: "SF Mono", Menlo, Consolas, monospace;
-  font-size: 90%;
-}
-
-/* Muted helpers */
-.muted { color: var(--ink-soft); }
-.small { font-size: 13px; }
-
-/* Footer */
-.footer {
-  border-top: 1px solid var(--rule);
-  padding: 32px 0;
-  font-size: 14px;
-}
-.footer p { margin: 0 0 8px; }
-
-/* ===========================
-   Demo pages (try/*)
-   =========================== */
-
-.demo-header {
-  padding: 56px 0 24px;
-  background: var(--bg-soft);
-  border-bottom: 1px solid var(--rule);
-}
-.demo-header .breadcrumb {
-  font-size: 13px;
-  color: var(--muted);
-  margin: 0 0 8px;
-}
-.demo-header h1 { font-size: 40px; margin: 0 0 8px; }
-
-.beta-badge {
-  display: inline-block;
-  background: var(--beta);
-  color: white;
-  font-size: 11px;
-  font-weight: 700;
-  padding: 4px 10px;
-  border-radius: 999px;
-  letter-spacing: 0.05em;
-  vertical-align: middle;
-  margin-left: 12px;
-}
-
-.demo-disclaimer {
-  background: #fef9e8;
-  border: 1px solid #f5d97a;
-  border-radius: var(--r);
-  padding: 14px 18px;
-  font-size: 14px;
-  margin: 24px 0;
-}
-.demo-disclaimer strong { color: #8a6a00; }
-
-/* Demo layout */
-.demo-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 24px;
-  margin: 24px 0;
-}
-@media (max-width: 720px) {
-  .demo-grid { grid-template-columns: 1fr; }
-}
-
-.demo-panel {
-  background: white;
-  border: 1px solid var(--rule);
-  border-radius: var(--r);
-  padding: 20px;
-}
-.demo-panel h3 {
-  font-size: 16px;
-  margin: 0 0 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-}
-
-/* Form / inputs */
-.demo-form { margin: 16px 0; }
-.demo-form label {
-  display: block;
-  font-weight: 600;
-  font-size: 14px;
-  margin: 0 0 6px;
-}
-.demo-form textarea,
-.demo-form input[type="text"],
-.demo-form select {
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid var(--rule);
-  border-radius: var(--r);
-  font-family: inherit;
-  font-size: 15px;
-  background: white;
-}
-.demo-form textarea { min-height: 80px; resize: vertical; }
-.demo-form .hint {
-  font-size: 13px;
-  color: var(--muted);
-  margin: 6px 0 0;
-}
-
-/* Output blocks */
-.output-block {
-  background: var(--code-bg);
-  border-radius: var(--r);
-  padding: 16px;
-  font-family: "SF Mono", Menlo, Consolas, monospace;
-  font-size: 13px;
-  white-space: pre-wrap;
-  overflow-x: auto;
+.cards h3 {
+  font-size: 26px;
+  line-height: 1.1;
   margin: 12px 0;
-  min-height: 60px;
 }
 
-.status-pill {
-  display: inline-block;
-  padding: 3px 10px;
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+.cards .deep {
+  margin-top: 16px;
+  font-size: 14px;
 }
-.status-pill.ok { background: #e1f3eb; color: var(--accent-ink); }
-.status-pill.alert { background: #fce5e0; color: #a02016; }
-.status-pill.warn { background: #fef0d6; color: #8a6a00; }
-.status-pill.idle { background: #ececec; color: var(--ink-soft); }
 
-/* Log area */
-.log-area {
-  font-family: "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
-  background: #1a1f1c;
-  color: #d4ddd6;
-  padding: 16px;
-  border-radius: var(--r);
-  height: 320px;
-  overflow-y: auto;
+.cards .deep a {
+  color: var(--muted);
+  text-decoration: none;
+  border-bottom: 1px solid var(--muted);
 }
-.log-area .ts { color: #6b8478; }
-.log-area .ev-decision { color: #b0d4c1; }
-.log-area .ev-veto { color: #f0a090; }
-.log-area .ev-policy { color: #a8c8e0; }
+
+pre {
+  padding: 22px;
+  border-radius: 18px;
+  background: #1a1a18;
+  color: var(--seed);
+  white-space: pre-wrap;
+  min-height: 170px;
+  margin-top: 24px;
+  font-family: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/* --- Gemma split --- */
+.split {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 40px;
+  align-items: start;
+}
+
+.split ul {
+  padding-left: 22px;
+}
+
+.split li {
+  margin-bottom: 12px;
+}
+
+.split blockquote {
+  font-size: 28px;
+  line-height: 1.2;
+  border-left: 8px solid var(--seed);
+  padding-left: 24px;
+  margin: 0;
+  font-style: italic;
+}
+
+/* --- Safety --- */
+.safety {
+  background: var(--soft);
+}
+
+.safety ol {
+  padding-left: 22px;
+}
+
+.safety li {
+  margin-bottom: 14px;
+}
+
+/* --- Footer --- */
+footer {
+  padding: 32px;
+  color: var(--muted);
+  text-align: center;
+  border-top: 1px solid var(--line);
+  font-size: 14px;
+}
+
+/* --- Responsive --- */
+@media (max-width: 760px) {
+  .truth-grid, .cards, .split {
+    grid-template-columns: 1fr;
+  }
+  .hero-inner { padding-top: 6vh; }
+  .nav { flex-wrap: wrap; }
+  .hero h1 { font-size: 48px; }
+  .container { padding: 48px 20px; }
+  .truth { margin-top: -40px; border-radius: 20px; }
+}

--- a/landing-demo/css/style_old.css
+++ b/landing-demo/css/style_old.css
@@ -1,0 +1,309 @@
+/*
+  Sprout landing-demo · primera versión funcional · día 21
+  CSS funcional, no diseño final. Venation reescribirá CSS sobre
+  esta estructura HTML estable cuando llegue su turno (días 22-25).
+  Paleta: neutra, accesible, sobria. Cero verde-lima signal.seed
+  (que se reserva para "AI active" en el sistema visual oficial).
+*/
+
+:root {
+  --bg: #fafaf7;
+  --bg-soft: #f0eee8;
+  --ink: #1a1a1a;
+  --ink-soft: #555;
+  --muted: #8a8a8a;
+  --accent: #2d5a4a;       /* verde oliva sobrio */
+  --accent-ink: #1a3a30;
+  --beta: #d97706;         /* ámbar/orange para BETA badge */
+  --rule: #d8d6cf;
+  --code-bg: #efece4;
+  --max-width: 880px;
+  --r: 8px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  line-height: 1.55;
+  font-size: 17px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+a:hover { color: var(--accent-ink); }
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.section { padding: 56px 0; border-top: 1px solid var(--rule); }
+.bg-soft { background: var(--bg-soft); border-top: none; border-bottom: 1px solid var(--rule); }
+
+/* Hero */
+.hero {
+  padding: 96px 0 64px;
+  background: var(--bg-soft);
+  border-bottom: 1px solid var(--rule);
+}
+.kicker {
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 12px;
+}
+h1 {
+  font-size: 64px;
+  line-height: 1.1;
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+}
+.tagline-en {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: var(--accent-ink);
+}
+.tagline-es {
+  font-size: 17px;
+  margin: 0 0 28px;
+  color: var(--ink-soft);
+}
+.lede {
+  font-size: 18px;
+  max-width: 60ch;
+  margin: 0 0 32px;
+}
+
+/* Buttons */
+.cta-row { display: flex; gap: 12px; flex-wrap: wrap; }
+.btn {
+  display: inline-block;
+  padding: 12px 22px;
+  border-radius: var(--r);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 15px;
+  border: 1px solid transparent;
+}
+.btn-primary {
+  background: var(--accent);
+  color: white;
+}
+.btn-primary:hover { background: var(--accent-ink); color: white; }
+
+.btn-secondary {
+  background: white;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.btn-secondary:hover { background: var(--accent); color: white; }
+
+.btn-ghost {
+  background: transparent;
+  color: var(--ink-soft);
+  border-color: var(--rule);
+}
+.btn-ghost:hover { color: var(--ink); border-color: var(--ink-soft); }
+
+/* Headings */
+h2 { font-size: 32px; margin: 0 0 24px; letter-spacing: -0.01em; }
+h3 { font-size: 22px; margin: 0 0 12px; }
+
+/* Cards grid */
+.grid { display: grid; gap: 24px; }
+.cards-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 720px) {
+  .cards-3 { grid-template-columns: 1fr; }
+  h1 { font-size: 44px; }
+}
+
+.card {
+  background: white;
+  border: 1px solid var(--rule);
+  border-radius: var(--r);
+  padding: 24px;
+}
+.card h3 { margin-top: 0; }
+.card-meta {
+  font-size: 13px;
+  color: var(--muted);
+  margin: -4px 0 12px;
+}
+.card p { margin: 0 0 16px; font-size: 15px; }
+
+/* Lists */
+.howlist {
+  margin: 0 0 24px;
+  padding: 0;
+  list-style: none;
+}
+.howlist li {
+  padding: 16px 0;
+  border-top: 1px solid var(--rule);
+}
+.howlist li:first-child { border-top: none; padding-top: 0; }
+
+/* Inline code */
+code {
+  background: var(--code-bg);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 90%;
+}
+
+/* Muted helpers */
+.muted { color: var(--ink-soft); }
+.small { font-size: 13px; }
+
+/* Footer */
+.footer {
+  border-top: 1px solid var(--rule);
+  padding: 32px 0;
+  font-size: 14px;
+}
+.footer p { margin: 0 0 8px; }
+
+/* ===========================
+   Demo pages (try/*)
+   =========================== */
+
+.demo-header {
+  padding: 56px 0 24px;
+  background: var(--bg-soft);
+  border-bottom: 1px solid var(--rule);
+}
+.demo-header .breadcrumb {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0 0 8px;
+}
+.demo-header h1 { font-size: 40px; margin: 0 0 8px; }
+
+.beta-badge {
+  display: inline-block;
+  background: var(--beta);
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  vertical-align: middle;
+  margin-left: 12px;
+}
+
+.demo-disclaimer {
+  background: #fef9e8;
+  border: 1px solid #f5d97a;
+  border-radius: var(--r);
+  padding: 14px 18px;
+  font-size: 14px;
+  margin: 24px 0;
+}
+.demo-disclaimer strong { color: #8a6a00; }
+
+/* Demo layout */
+.demo-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin: 24px 0;
+}
+@media (max-width: 720px) {
+  .demo-grid { grid-template-columns: 1fr; }
+}
+
+.demo-panel {
+  background: white;
+  border: 1px solid var(--rule);
+  border-radius: var(--r);
+  padding: 20px;
+}
+.demo-panel h3 {
+  font-size: 16px;
+  margin: 0 0 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+/* Form / inputs */
+.demo-form { margin: 16px 0; }
+.demo-form label {
+  display: block;
+  font-weight: 600;
+  font-size: 14px;
+  margin: 0 0 6px;
+}
+.demo-form textarea,
+.demo-form input[type="text"],
+.demo-form select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--rule);
+  border-radius: var(--r);
+  font-family: inherit;
+  font-size: 15px;
+  background: white;
+}
+.demo-form textarea { min-height: 80px; resize: vertical; }
+.demo-form .hint {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 6px 0 0;
+}
+
+/* Output blocks */
+.output-block {
+  background: var(--code-bg);
+  border-radius: var(--r);
+  padding: 16px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  margin: 12px 0;
+  min-height: 60px;
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.status-pill.ok { background: #e1f3eb; color: var(--accent-ink); }
+.status-pill.alert { background: #fce5e0; color: #a02016; }
+.status-pill.warn { background: #fef0d6; color: #8a6a00; }
+.status-pill.idle { background: #ececec; color: var(--ink-soft); }
+
+/* Log area */
+.log-area {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  background: #1a1f1c;
+  color: #d4ddd6;
+  padding: 16px;
+  border-radius: var(--r);
+  height: 320px;
+  overflow-y: auto;
+}
+.log-area .ts { color: #6b8478; }
+.log-area .ev-decision { color: #b0d4c1; }
+.log-area .ev-veto { color: #f0a090; }
+.log-area .ev-policy { color: #a8c8e0; }

--- a/landing-demo/index.html
+++ b/landing-demo/index.html
@@ -3,171 +3,122 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Sprout — local-first water optimization for plots the network forgets</title>
-  <meta name="description" content="Local-first AI water optimization for plots the network and the human can't always reach. Three nodes (Rhizome, Pollen, Meristem) + an ESP32 safety coprocessor. Every intelligence has jurisdiction and expiry.">
+  <title>Sprout — Local-first AI water optimization</title>
+  <meta name="description" content="Sprout is a safety-bounded Gemma 4 decision network for irrigation under absence. Rhizome decides beside the water, Pollen turns visits into expiring criteria, Meristem refines policy at home, and an ESP32 owns the physical veto.">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
 
 <header class="hero">
-  <div class="container">
-    <p class="kicker">Local-first AI · open-source</p>
-    <h1>Sprout</h1>
-    <p class="tagline-en">When network is absent — and the human is far — local criteria still irrigate.</p>
-    <p class="tagline-es" lang="es"><em>Cuando la red no llega y nadie está cerca, el criterio sigue regando.</em></p>
-    <p class="lede">
-      Sprout is a local-first AI architecture for <strong>water optimization</strong> in remote plots —
-      places where the field, the person and the network rarely coincide in time.
-      Three nodes with distinct jurisdictions, an ESP32 safety coprocessor that vetoes physically,
-      and Gemma 4 doing what it does best on each layer. <em>Every intelligence has jurisdiction. And expiry.</em>
-    </p>
+  <nav class="nav">
+    <span class="brand">Sprout</span>
+    <a href="#truth">What is real</a>
+    <a href="#demo">Demo</a>
+    <a href="#gemma">Gemma 4</a>
+    <a href="#safety">Safety</a>
+    <a href="https://github.com/zigiella/sprout">GitHub</a>
+  </nav>
+  <section class="hero-inner">
+    <p class="kicker">Local-first AI · Gemma 4 · open source</p>
+    <h1>Water decisions for plots the network forgets.</h1>
+    <p class="tagline">When the network is absent — and the human is far — local criteria still irrigate.</p>
+    <p class="lede">Sprout is a safety-bounded Gemma 4 decision network for irrigation under absence: Rhizome decides beside the water, Pollen turns each visit into expiring criteria, Meristem refines policy at home, and an ESP32 safety coprocessor owns the physical veto.</p>
     <div class="cta-row">
-      <a class="btn btn-primary" href="#try-it">Try the system</a>
-      <a class="btn btn-ghost" href="https://github.com/zigiella/sprout">View source on GitHub</a>
+      <a class="btn primary" href="#" id="video-link">Watch the 3-minute demo</a>
+      <a class="btn" href="#demo">Try the architecture demo</a>
+      <a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/SUBMISSION.md">Reviewer quickstart</a>
     </div>
-  </div>
+  </section>
 </header>
 
-<section id="try-it" class="container section">
-  <h2>Try the three nodes hands-on</h2>
-  <p class="muted">
-    Each demo runs against <strong>deterministic mocks</strong> in your browser — no cloud, no API key,
-    no model download. <strong>This is intentional and coherent with the thesis:</strong> the real
-    system runs Gemma 4 fully local on Jetson, Pixel and laptop with no network dependency, and we
-    want you to be able to probe the architecture exactly the same way — from any browser, without
-    network. To see Gemma 4 actually running, watch the video, install the APK
-    (Pollen <code>demo</code> flavor), or run <code>make test</code> on the repo. The mock code is
-    public and easy to read: <a href="https://github.com/zigiella/sprout/blob/main/landing-demo/js/api.js">js/api.js</a>.
-  </p>
+<main>
 
-  <div class="grid cards-3">
-    <article class="card">
-      <h3>Rhizome</h3>
-      <p class="card-meta">Plot node · Gemma 4 E2B · jurisdiction: minutes</p>
-      <p>The autonomous brain that lives next to the sensors. Decides offline whether to irrigate, defer, skip or block. Never moves water directly: an ESP32 with custom firmware enforces hard safety limits.</p>
-      <a class="btn btn-secondary" href="try/rhizome.html">Try Rhizome →</a>
+<section id="truth" class="truth container">
+  <h2>What is real in this submission</h2>
+  <div class="truth-grid">
+    <div><strong>Rhizome</strong><span>Jetson + Gemma 4 E2B via <code>llama.cpp</code></span></div>
+    <div><strong>Pollen</strong><span>Android device path + Gemma 4 E4B via LiteRT-LM, native audio</span></div>
+    <div><strong>ESP32</strong><span>Physical board, pump/soil supervised <code>TEST_ONLY</code> path</span></div>
+    <div><strong>Meristem</strong><span>Home laptop evaluator + Gemma 4 E4B tool-calling</span></div>
+  </div>
+  <p class="note">The browser demo below is <strong>deterministic by design</strong>. It lets reviewers inspect contracts, TTLs, receipts and refusal paths instantly; it does not pretend to run Gemma 4 in the browser. Real Gemma 4 execution lives in the Android, Jetson and laptop paths documented in the repo.</p>
+</section>
+
+<section id="demo" class="container">
+  <h2>Try the three jurisdictions</h2>
+  <p class="muted">Click any node to inspect its contract live. <strong>Mock code is public</strong> in <a href="https://github.com/zigiella/sprout/blob/main/landing-demo/js/api.js">js/api.js</a>.</p>
+  <div class="cards">
+    <article>
+      <p class="node">Rhizome · minutes</p>
+      <h3>Should I irrigate now?</h3>
+      <p>The plot node reads local state, proposes a bounded action and signs a <code>DecisionReceipt</code>. The ESP32 can still veto.</p>
+      <button data-demo="rhizome">Run Rhizome decision</button>
+      <p class="deep"><a href="try/rhizome.html">Deep dive →</a></p>
     </article>
-    <article class="card">
-      <h3>Pollen</h3>
-      <p class="card-meta">Mobile node · Gemma 4 E4B · jurisdiction: visit TTL</p>
-      <p>The roaming brain on the farmer's Android. Multimodal: feeds raw audio to Gemma 4 directly. Compiles human intent into a <code>MissionPatch</code> that the field can use immediately, federates context between plots without direct network.</p>
-      <a class="btn btn-secondary" href="try/pollen.html">Try Pollen →</a>
+    <article>
+      <p class="node">Pollen · visit TTL</p>
+      <h3>The farmer speaks. Pollen compiles.</h3>
+      <p>Human intent becomes an expiring <code>MissionPatch</code>. If it cannot be grounded, Pollen <strong>refuses</strong>.</p>
+      <button data-demo="pollen">Compile MissionPatch</button>
+      <p class="deep"><a href="try/pollen.html">Deep dive →</a></p>
     </article>
-    <article class="card">
-      <h3>Meristem</h3>
-      <p class="card-meta">Slow brain · Gemma 4 E4B · jurisdiction: days</p>
-      <p>The kitchen-table brain. Receives bundles from Pollen, evaluates with deterministic logic, emits durable policies. The LLM only writes the rationale — the decision is always auditable down to a concrete rule.</p>
-      <a class="btn btn-secondary" href="try/meristem.html">Try Meristem →</a>
+    <article>
+      <p class="node">Meristem · days</p>
+      <h3>What policy for the next window?</h3>
+      <p>The home laptop ingests bundles and refines durable <code>PolicyPacket</code> after the urgency is gone.</p>
+      <button data-demo="meristem">Evaluate bundle</button>
+      <p class="deep"><a href="try/meristem.html">Deep dive →</a></p>
     </article>
   </div>
+  <pre id="output">Click a node to inspect a contract.</pre>
 </section>
 
-<section class="container section bg-soft">
-  <h2>Why local-first AI matters here</h2>
-  <p>
-    In 2023, <strong>48% of the world's land area suffered at least one month of extreme drought</strong> —
-    the second largest extent since 1951.<sup>[1]</sup>
-    Drought affects 1.8 billion people and costs $300 billion per year.<sup>[1]</sup>
-    But the field for which we design doesn't live in continuous connectivity:
-    only 58% of the rural population worldwide uses internet — in low-income countries, 14%.<sup>[2]</sup>
-  </p>
-  <p>
-    The bottleneck isn't data. It's the <strong>lag</strong> between what happens in the plot and the
-    decision that should correct it. When the network fails or the farmer isn't there, that lag is days.
-    Closing it requires <strong>moving the decision where the water is</strong> — not the other way around.
-  </p>
-
-  <p class="muted small">
-    Sources: [1] UNCCD Global Drought Hotspots 2023-2025 + OECD Global Drought Outlook 2025.
-    [2] ITU Facts and Figures 2025. Full references in
-    <a href="https://github.com/zigiella/sprout/blob/main/research/metrics/impact_stats.md">research/metrics/impact_stats.md</a>.
-  </p>
+<section id="gemma" class="container split">
+  <div>
+    <h2>How Gemma 4 is used</h2>
+    <ul>
+      <li><strong>E2B on Rhizome:</strong> short, bounded local rationales over decisions already closed by deterministic gates. Runs via <code>llama.cpp</code> on Jetson Orin Nano Super.</li>
+      <li><strong>E4B on Pollen:</strong> native audio multimodal on Android via LiteRT-LM (<code>com.google.ai.edge.litertlm:litertlm-android:0.10.1</code>). Voice → validated <code>MissionPatch</code> with no STT pipeline.</li>
+      <li><strong>E4B on Meristem:</strong> tool-calling-assisted policy review on a home laptop via <code>llama.cpp</code>.</li>
+    </ul>
+    <p class="muted">Each node has a different model profile. Configuration is a property of jurisdiction, not a global choice.</p>
+  </div>
+  <blockquote>Gemma proposes language, structure and rationale. The physical layer still owns water.</blockquote>
 </section>
 
-<section class="container section">
-  <h2>How Gemma 4 is used</h2>
-  <p>Sprout uses Gemma 4 in <strong>five concrete ways</strong>, each exploiting a different capability of the model:</p>
-  <ul class="howlist">
-    <li>
-      <strong>Multimodal audio native</strong> — Pollen feeds raw 16 kHz <code>.wav</code> to
-      Gemma 4 E4B via LiteRT-LM <em>without a separate STT pipeline</em>. The voice
-      <em>"riega un poco menos, esta planta aguanta más seca de lo que crees"</em> compiles
-      into a structured <code>MissionPatch</code> — in the farmer's pocket, no network.
-      Validated end-to-end against real microphone input.
-    </li>
-    <li>
-      <strong>Native tool calling</strong> — Meristem uses Gemma 4 E4B with native tool calling
-      for <code>compose_policy(...)</code>, <code>validate_bundle(...)</code> and <code>compare_targets(...)</code>.
-      The deterministic logic decides; the LLM only writes the rationale.
-      Runtime end-to-end validated with <code>tool_calls_recovered_from_text=1</code>.
-    </li>
-    <li>
-      <strong>Three-node routing</strong> — three Gemma 4 instances (E2B + E4B + E4B), three
-      jurisdictions, no cloud roundtrip. Model choice is per-node, not global:
-      <strong>E2B for direct answers (Rhizome), E4B for tool-calling reasoning (Pollen + Meristem)</strong>.
-    </li>
-    <li>
-      <strong>Bilingual narrator in Rhizome</strong> — endpoints
-      <code>GET /summary/since?locale=es|en</code> and <code>GET /explain/decision/&lt;id&gt;?locale=es|en</code>
-      operational in production. Gemma 4 E2B improves the <code>rationale_short</code> over a decision
-      <strong>already closed</strong> by deterministic logic — never changes action, never authorizes water,
-      never invents facts. The system speaks two languages in production.
-    </li>
-    <li>
-      <strong>Approach C i18n localization</strong> — official project standard.
-      Edge nodes (Rhizome, ESP32) think in stable English Tech; Pollen + Gemma 4 E4B local translates to
-      the UI language before rendering. Hardware-agnostic, ready for minority-language fine-tuning
-      (Pular, Wolof, Swahili, Quechua, Catalan, Basque).
-    </li>
-  </ul>
-  <p><strong>The final decision is never signed by the LLM.</strong> The deterministic Evaluator decides; Gemma 4 writes the rationale and adapts the surface language.</p>
-  <p>
-    <a class="btn btn-ghost" href="https://github.com/zigiella/sprout/blob/main/writeup/draft.md">Read the full technical writeup →</a>
-  </p>
-</section>
-
-<section class="container section bg-soft">
-  <h2>Safety &amp; Trust — the three invariants</h2>
-  <p>Sprout is built around three non-negotiable invariants. Any change to the system has to preserve them:</p>
-  <ol class="invariants">
-    <li>
-      <strong>"Physical layer prevails. Rhizome arbitrates. Pollen mediates. Meristem refines."</strong>
-      The ESP32 firmware owns critical sensors and actuators; nothing touches water without its veto.
-      The higher a piece sits in the hierarchy, the less physical authority it has.
-    </li>
-    <li>
-      <strong>"Every intelligence has jurisdiction. And expiry."</strong>
-      Every <code>MissionPatch</code> carries a short TTL. Every <code>PolicyPacket</code> carries a validity window.
-      Every <code>WeatherDigest</code> expires before going stale. Expired objects get
-      <code>EXPIRED → REJECTED</code> with legible reason in the <code>DecisionReceipt</code>.
-      <strong>No criterion stays silently valid past its window.</strong> This rule is what avoids the most
-      common failure of autonomous systems: accepting old orders as if they were new.
-    </li>
-    <li>
-      <strong>No <code>PolicyPacket</code> from Meristem can reduce the firmware's hard limits</strong>
-      — it can only recommend more conservative behavior. Authority over physical safety inverts the
-      hierarchy.
-    </li>
+<section id="safety" class="container safety">
+  <h2>Safety &amp; Trust</h2>
+  <ol>
+    <li><strong>Physical layer prevails.</strong> The ESP32 firmware enforces five hard rules (<code>JETSON_HEARTBEAT_LOST</code>, <code>TANK_LOW</code>, <code>EVENT_DURATION_OUT_OF_RANGE</code>, <code>NO_FLOW_DETECTED</code>, <code>ALERT_LATCHED</code>). No LLM can weaken them.</li>
+    <li><strong>Every intelligence has jurisdiction.</strong> Rhizome arbitrates in minutes. Pollen mediates within visit TTL. Meristem refines in days.</li>
+    <li><strong>Every criterion expires.</strong> <code>MissionPatch</code>, <code>WeatherDigest</code> and <code>PolicyPacket</code> carry TTL or validity windows. Late objects are rejected, not silently obeyed.</li>
+    <li><strong>Refusal is a feature.</strong> When Pollen does not understand a voice instruction, it asks for rephrasing. When Rhizome sees an expired policy, it rejects. When the ESP32 detects an unsafe condition, it blocks.</li>
+    <li><strong>A second local voice audits without authority.</strong> <code>ShadowSkeptic</code> records objections inside Rhizome with <code>affects_decision=false</code>. Even skepticism has jurisdiction.</li>
   </ol>
-  <p>
-    <strong>Refusal is a feature, not a failure.</strong> When the system isn't confident, it says so and
-    asks the human to rephrase or step in. Validated empirically: Pollen rejects agricultural-nonsense
-    sentences with <code>REFUSE_RETRY</code> instead of fabricating an action.
-  </p>
 </section>
 
-<footer class="footer">
-  <div class="container">
-    <p>
-      <strong>Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.</strong>
-      This project is not affiliated with or endorsed by Google.
-    </p>
-    <p class="muted small">
-      Apache 2.0 · maintained by <a href="https://github.com/zigiella">zigiella</a> ·
-      <a href="https://github.com/zigiella/sprout">github.com/zigiella/sprout</a>
-    </p>
-  </div>
+<section class="container">
+  <h2>What comes next</h2>
+  <ul>
+    <li><strong>A second voice with bounded authority</strong> — promote <code>ShadowSkeptic</code> to a Gemma 4 auditor that can question without overriding.</li>
+    <li><strong>The farmer's language</strong> — fine-tune Gemma 4 E4B for minority agricultural languages.</li>
+    <li><strong>More senses</strong> — vision, multi-zone irrigation, local weather station, solar power.</li>
+    <li><strong>Talkback</strong> — full-duplex voice, two-way conversation in the field.</li>
+  </ul>
+  <p><a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/ROADMAP.md">Read the full roadmap →</a></p>
+</section>
+
+</main>
+
+<footer>
+  <p>
+    <strong>zigiella</strong> · Apache 2.0 · <a href="https://github.com/zigiella/sprout">github.com/zigiella/sprout</a><br>
+    Built on Gemma 4 by Google. Gemma is a trademark of Google LLC. This project is not affiliated with or endorsed by Google.
+  </p>
 </footer>
 
+<script src="js/api.js"></script>
+<script src="js/landing.js"></script>
 </body>
 </html>
+</content>

--- a/landing-demo/index_old.html
+++ b/landing-demo/index_old.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sprout — local-first water optimization for plots the network forgets</title>
+  <meta name="description" content="Local-first AI water optimization for plots the network and the human can't always reach. Three nodes (Rhizome, Pollen, Meristem) + an ESP32 safety coprocessor. Every intelligence has jurisdiction and expiry.">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+<header class="hero">
+  <div class="container">
+    <p class="kicker">Local-first AI · open-source</p>
+    <h1>Sprout</h1>
+    <p class="tagline-en">When network is absent — and the human is far — local criteria still irrigate.</p>
+    <p class="tagline-es" lang="es"><em>Cuando la red no llega y nadie está cerca, el criterio sigue regando.</em></p>
+    <p class="lede">
+      Sprout is a local-first AI architecture for <strong>water optimization</strong> in remote plots —
+      places where the field, the person and the network rarely coincide in time.
+      Three nodes with distinct jurisdictions, an ESP32 safety coprocessor that vetoes physically,
+      and Gemma 4 doing what it does best on each layer. <em>Every intelligence has jurisdiction. And expiry.</em>
+    </p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="#try-it">Try the system</a>
+      <a class="btn btn-ghost" href="https://github.com/zigiella/sprout">View source on GitHub</a>
+    </div>
+  </div>
+</header>
+
+<section id="try-it" class="container section">
+  <h2>Try the three nodes hands-on</h2>
+  <p class="muted">
+    Each demo runs against <strong>deterministic mocks</strong> in your browser — no cloud, no API key,
+    no model download. <strong>This is intentional and coherent with the thesis:</strong> the real
+    system runs Gemma 4 fully local on Jetson, Pixel and laptop with no network dependency, and we
+    want you to be able to probe the architecture exactly the same way — from any browser, without
+    network. To see Gemma 4 actually running, watch the video, install the APK
+    (Pollen <code>demo</code> flavor), or run <code>make test</code> on the repo. The mock code is
+    public and easy to read: <a href="https://github.com/zigiella/sprout/blob/main/landing-demo/js/api.js">js/api.js</a>.
+  </p>
+
+  <div class="grid cards-3">
+    <article class="card">
+      <h3>Rhizome</h3>
+      <p class="card-meta">Plot node · Gemma 4 E2B · jurisdiction: minutes</p>
+      <p>The autonomous brain that lives next to the sensors. Decides offline whether to irrigate, defer, skip or block. Never moves water directly: an ESP32 with custom firmware enforces hard safety limits.</p>
+      <a class="btn btn-secondary" href="try/rhizome.html">Try Rhizome →</a>
+    </article>
+    <article class="card">
+      <h3>Pollen</h3>
+      <p class="card-meta">Mobile node · Gemma 4 E4B · jurisdiction: visit TTL</p>
+      <p>The roaming brain on the farmer's Android. Multimodal: feeds raw audio to Gemma 4 directly. Compiles human intent into a <code>MissionPatch</code> that the field can use immediately, federates context between plots without direct network.</p>
+      <a class="btn btn-secondary" href="try/pollen.html">Try Pollen →</a>
+    </article>
+    <article class="card">
+      <h3>Meristem</h3>
+      <p class="card-meta">Slow brain · Gemma 4 E4B · jurisdiction: days</p>
+      <p>The kitchen-table brain. Receives bundles from Pollen, evaluates with deterministic logic, emits durable policies. The LLM only writes the rationale — the decision is always auditable down to a concrete rule.</p>
+      <a class="btn btn-secondary" href="try/meristem.html">Try Meristem →</a>
+    </article>
+  </div>
+</section>
+
+<section class="container section bg-soft">
+  <h2>Why local-first AI matters here</h2>
+  <p>
+    In 2023, <strong>48% of the world's land area suffered at least one month of extreme drought</strong> —
+    the second largest extent since 1951.<sup>[1]</sup>
+    Drought affects 1.8 billion people and costs $300 billion per year.<sup>[1]</sup>
+    But the field for which we design doesn't live in continuous connectivity:
+    only 58% of the rural population worldwide uses internet — in low-income countries, 14%.<sup>[2]</sup>
+  </p>
+  <p>
+    The bottleneck isn't data. It's the <strong>lag</strong> between what happens in the plot and the
+    decision that should correct it. When the network fails or the farmer isn't there, that lag is days.
+    Closing it requires <strong>moving the decision where the water is</strong> — not the other way around.
+  </p>
+
+  <p class="muted small">
+    Sources: [1] UNCCD Global Drought Hotspots 2023-2025 + OECD Global Drought Outlook 2025.
+    [2] ITU Facts and Figures 2025. Full references in
+    <a href="https://github.com/zigiella/sprout/blob/main/research/metrics/impact_stats.md">research/metrics/impact_stats.md</a>.
+  </p>
+</section>
+
+<section class="container section">
+  <h2>How Gemma 4 is used</h2>
+  <p>Sprout uses Gemma 4 in <strong>five concrete ways</strong>, each exploiting a different capability of the model:</p>
+  <ul class="howlist">
+    <li>
+      <strong>Multimodal audio native</strong> — Pollen feeds raw 16 kHz <code>.wav</code> to
+      Gemma 4 E4B via LiteRT-LM <em>without a separate STT pipeline</em>. The voice
+      <em>"riega un poco menos, esta planta aguanta más seca de lo que crees"</em> compiles
+      into a structured <code>MissionPatch</code> — in the farmer's pocket, no network.
+      Validated end-to-end against real microphone input.
+    </li>
+    <li>
+      <strong>Native tool calling</strong> — Meristem uses Gemma 4 E4B with native tool calling
+      for <code>compose_policy(...)</code>, <code>validate_bundle(...)</code> and <code>compare_targets(...)</code>.
+      The deterministic logic decides; the LLM only writes the rationale.
+      Runtime end-to-end validated with <code>tool_calls_recovered_from_text=1</code>.
+    </li>
+    <li>
+      <strong>Three-node routing</strong> — three Gemma 4 instances (E2B + E4B + E4B), three
+      jurisdictions, no cloud roundtrip. Model choice is per-node, not global:
+      <strong>E2B for direct answers (Rhizome), E4B for tool-calling reasoning (Pollen + Meristem)</strong>.
+    </li>
+    <li>
+      <strong>Bilingual narrator in Rhizome</strong> — endpoints
+      <code>GET /summary/since?locale=es|en</code> and <code>GET /explain/decision/&lt;id&gt;?locale=es|en</code>
+      operational in production. Gemma 4 E2B improves the <code>rationale_short</code> over a decision
+      <strong>already closed</strong> by deterministic logic — never changes action, never authorizes water,
+      never invents facts. The system speaks two languages in production.
+    </li>
+    <li>
+      <strong>Approach C i18n localization</strong> — official project standard.
+      Edge nodes (Rhizome, ESP32) think in stable English Tech; Pollen + Gemma 4 E4B local translates to
+      the UI language before rendering. Hardware-agnostic, ready for minority-language fine-tuning
+      (Pular, Wolof, Swahili, Quechua, Catalan, Basque).
+    </li>
+  </ul>
+  <p><strong>The final decision is never signed by the LLM.</strong> The deterministic Evaluator decides; Gemma 4 writes the rationale and adapts the surface language.</p>
+  <p>
+    <a class="btn btn-ghost" href="https://github.com/zigiella/sprout/blob/main/writeup/draft.md">Read the full technical writeup →</a>
+  </p>
+</section>
+
+<section class="container section bg-soft">
+  <h2>Safety &amp; Trust — the three invariants</h2>
+  <p>Sprout is built around three non-negotiable invariants. Any change to the system has to preserve them:</p>
+  <ol class="invariants">
+    <li>
+      <strong>"Physical layer prevails. Rhizome arbitrates. Pollen mediates. Meristem refines."</strong>
+      The ESP32 firmware owns critical sensors and actuators; nothing touches water without its veto.
+      The higher a piece sits in the hierarchy, the less physical authority it has.
+    </li>
+    <li>
+      <strong>"Every intelligence has jurisdiction. And expiry."</strong>
+      Every <code>MissionPatch</code> carries a short TTL. Every <code>PolicyPacket</code> carries a validity window.
+      Every <code>WeatherDigest</code> expires before going stale. Expired objects get
+      <code>EXPIRED → REJECTED</code> with legible reason in the <code>DecisionReceipt</code>.
+      <strong>No criterion stays silently valid past its window.</strong> This rule is what avoids the most
+      common failure of autonomous systems: accepting old orders as if they were new.
+    </li>
+    <li>
+      <strong>No <code>PolicyPacket</code> from Meristem can reduce the firmware's hard limits</strong>
+      — it can only recommend more conservative behavior. Authority over physical safety inverts the
+      hierarchy.
+    </li>
+  </ol>
+  <p>
+    <strong>Refusal is a feature, not a failure.</strong> When the system isn't confident, it says so and
+    asks the human to rephrase or step in. Validated empirically: Pollen rejects agricultural-nonsense
+    sentences with <code>REFUSE_RETRY</code> instead of fabricating an action.
+  </p>
+</section>
+
+<footer class="footer">
+  <div class="container">
+    <p>
+      <strong>Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC.</strong>
+      This project is not affiliated with or endorsed by Google.
+    </p>
+    <p class="muted small">
+      Apache 2.0 · maintained by <a href="https://github.com/zigiella">zigiella</a> ·
+      <a href="https://github.com/zigiella/sprout">github.com/zigiella/sprout</a>
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/landing-demo/js/landing.js
+++ b/landing-demo/js/landing.js
@@ -1,0 +1,57 @@
+// Sprout landing · interactive demo for the home page.
+// Uses the deterministic mock functions from js/api.js.
+
+(function () {
+  const output = document.getElementById('output');
+
+  const demos = {
+    rhizome: async () => {
+      output.textContent = 'Rhizome reading local state...\n';
+      const state = {
+        soil_pct: 18,
+        tank_pct: 65,
+        heartbeat_age_s: 4
+      };
+      const result = await rhizomeDecideMock(state);
+      output.textContent = JSON.stringify(result, null, 2);
+    },
+
+    pollen: async () => {
+      output.textContent = 'Pollen compiling voice...\n';
+      const transcript = "Vuelvo el viernes. Esta planta aguanta más seca de lo que crees, riega un poco menos.";
+      const result = await pollenCompileMock(transcript);
+      output.textContent = JSON.stringify(result, null, 2);
+    },
+
+    meristem: async () => {
+      output.textContent = 'Meristem evaluating bundle...\n';
+      const bundle = {
+        recent_decisions: [
+          { action: 'irrigate', confidence: 0.88 },
+          { action: 'skip', confidence: 0.91 },
+          { action: 'block', confidence: 0.95 }
+        ],
+        avg_confidence: 0.91
+      };
+      const result = await meristemEvaluateMock(bundle);
+      output.textContent = JSON.stringify(result, null, 2);
+    }
+  };
+
+  document.querySelectorAll('[data-demo]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const which = btn.getAttribute('data-demo');
+      if (demos[which]) {
+        btn.disabled = true;
+        const originalText = btn.textContent;
+        btn.textContent = 'Running...';
+        try {
+          await demos[which]();
+        } finally {
+          btn.disabled = false;
+          btn.textContent = originalText;
+        }
+      }
+    });
+  });
+})();

--- a/media/README.md
+++ b/media/README.md
@@ -1,0 +1,33 @@
+# Media gallery
+
+Stable assets for submission, README embedding and Kaggle media gallery.
+
+## Diagrams (SVG)
+
+| File | Use | Caption |
+|------|-----|---------|
+| `architecture_overview.svg` | First technical image in writeup / media gallery | Sprout distributes irrigation criteria across three Gemma 4 nodes with different jurisdictions and one physical veto layer. |
+| `authority_stack.svg` | Safety & Trust proof image | The farther a node is from the water, the less physical authority it has. The ESP32 can always say no. *Every intelligence has jurisdiction. And expiry.* |
+| `pollen_visit_cycle.svg` | Pollen mediator visualization | A human visit becomes an expiring MissionPatch on Android via LiteRT-LM. Visits move context between disconnected Rhizomes. |
+| `data_contracts.svg` | Contracts inventory | Ten JSON contracts of the MVP with explicit authority and expiry. |
+| `double_agent.svg` | Dual-agent pattern in Rhizome | ShadowSkeptic audits without authority. Even skepticism has jurisdiction. |
+
+## Recommended Kaggle media gallery set (5 images max)
+
+1. **Cover** — `sprout-cover-local-first-ai.png` (TBD: composed image with terrace/pot/hardware + architecture overlay, 16:9, 1920×1080). *Pending: Bea provides photo from Castellar.*
+2. `architecture_overview.svg` → can be exported to PNG `sprout-architecture-overview.png` for Kaggle.
+3. `authority_stack.svg` → `sprout-authority-stack.png`.
+4. `sprout-physical-build.jpg` — TBD: real photo of Jetson / Rhizome box / ESP32 / pump / pot.
+5. `sprout-pollen-missionpatch.png` — Pollen Android screenshot showing voice → MissionPatch → validation.
+
+## Optional 6th image
+
+`sprout-esp32-decisionreceipt.png` — terminal log showing one safety path (either `DRY_RUN logged` for the autonomous contract, or `PUMP_PULSE 3000ms` + `SOIL_READ raw=2278 → raw=1289` for the supervised hardware proof).
+
+## Naming convention
+
+```text
+sprout-<topic>-<modifier>.png
+```
+
+Lowercase, kebab-case, descriptive. No timestamps in filename.

--- a/media/architecture_overview.svg
+++ b/media/architecture_overview.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+<style>.bg{fill:#f3ede4}.box{fill:#fffaf2;stroke:#1a1a18;stroke-width:2}.dark{fill:#1a1a18}.txt{font-family:Arial,sans-serif;fill:#1a1a18}.white{fill:#f3ede4}.seed{fill:#c5f26b}.muted{fill:#6e665f}.arrow{stroke:#1a1a18;stroke-width:3;fill:none;marker-end:url(#m)}</style>
+<defs><marker id="m" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto"><path d="M2,2 L10,6 L2,10 Z" fill="#1a1a18"/></marker></defs>
+<rect class="bg" width="1280" height="720"/>
+<text x="60" y="70" class="txt" font-size="42" font-weight="800">Sprout architecture</text>
+<text x="60" y="110" class="muted" font-size="22">A safety-bounded Gemma 4 decision network for water under absence</text>
+<rect x="60" y="190" width="240" height="150" rx="22" class="box"/>
+<text x="90" y="235" class="txt" font-size="30" font-weight="700">Pollen</text>
+<text x="90" y="270" class="txt" font-size="18">Android · Gemma 4 E4B</text>
+<text x="90" y="300" class="muted" font-size="18">visit TTL · MissionPatch</text>
+<rect x="520" y="160" width="250" height="190" rx="22" class="box"/>
+<text x="550" y="210" class="txt" font-size="30" font-weight="700">Rhizome</text>
+<text x="550" y="245" class="txt" font-size="18">Jetson · Gemma 4 E2B</text>
+<text x="550" y="275" class="muted" font-size="18">minutes · local decision</text>
+<text x="550" y="310" class="muted" font-size="18">writes DecisionReceipt</text>
+<rect x="970" y="160" width="250" height="190" rx="22" class="dark"/>
+<text x="1000" y="210" class="white" font-size="30" font-weight="700">ESP32</text>
+<text x="1000" y="245" class="white" font-size="18">firmware hard rules</text>
+<text x="1000" y="275" class="seed" font-size="18">physical veto</text>
+<text x="1000" y="310" class="white" font-size="18">pump · relay · sensors</text>
+<rect x="520" y="490" width="250" height="150" rx="22" class="box"/>
+<text x="550" y="535" class="txt" font-size="30" font-weight="700">Meristem</text>
+<text x="550" y="570" class="txt" font-size="18">home laptop · Gemma 4 E4B</text>
+<text x="550" y="600" class="muted" font-size="18">days · durable policy</text>
+<path d="M300 260 C390 250,430 245,520 245" class="arrow"/>
+<text x="345" y="225" class="txt" font-size="17">MissionPatch + context</text>
+<path d="M770 245 C850 245,890 245,970 245" class="arrow"/>
+<text x="805" y="220" class="txt" font-size="17">candidate command</text>
+<path d="M970 295 C890 330,850 335,770 305" class="arrow"/>
+<text x="805" y="360" class="txt" font-size="17">ACK / REJECT</text>
+<path d="M300 305 C390 410,425 520,520 565" class="arrow"/>
+<text x="315" y="465" class="txt" font-size="17">SyncBundle carried home</text>
+<path d="M645 490 L645 350" class="arrow"/>
+<text x="665" y="430" class="txt" font-size="17">PolicyPacket via Pollen</text>
+<rect x="60" y="650" width="1160" height="44" rx="20" class="dark"/>
+<text x="90" y="680" class="seed" font-size="20" font-weight="700">Physical layer prevails · Rhizome arbitrates · Pollen mediates · Meristem refines</text>
+</svg>

--- a/media/authority_stack.svg
+++ b/media/authority_stack.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+<style>.bg{fill:#1a1a18}.layer{stroke:#f3ede4;stroke-width:2}.txt{font-family:Arial,sans-serif;fill:#f3ede4}.seed{fill:#c5f26b}.muted{fill:#c9beb2}</style>
+<rect class="bg" width="1280" height="720"/>
+<text x="80" y="82" class="txt" font-size="46" font-weight="800">Authority stack</text>
+<text x="80" y="125" class="muted" font-size="23">The farther a node is from water, the less physical authority it has.</text>
+<rect x="180" y="160" width="920" height="90" rx="18" fill="#3b3b36" class="layer"/>
+<text x="220" y="215" class="txt" font-size="30" font-weight="700">Meristem refines</text><text x="590" y="215" class="muted" font-size="23">days · durable policy · no direct actuation</text>
+<rect x="180" y="270" width="920" height="90" rx="18" fill="#4b4a43" class="layer"/>
+<text x="220" y="325" class="txt" font-size="30" font-weight="700">Pollen mediates</text><text x="590" y="325" class="muted" font-size="23">visit TTL · MissionPatch · context ferry</text>
+<rect x="180" y="380" width="920" height="90" rx="18" fill="#605d55" class="layer"/>
+<text x="220" y="435" class="txt" font-size="30" font-weight="700">Rhizome arbitrates</text><text x="590" y="435" class="muted" font-size="23">minutes · local state · signed receipts</text>
+<rect x="180" y="490" width="920" height="110" rx="18" fill="#c5f26b"/>
+<text x="220" y="555" fill="#1a1a18" font-family="Arial,sans-serif" font-size="34" font-weight="800">Physical layer prevails</text><text x="670" y="555" fill="#1a1a18" font-family="Arial,sans-serif" font-size="23">ESP32 firmware · hard veto · pump/sensors</text>
+<text x="180" y="650" class="seed" font-size="26" font-weight="700">Every intelligence has jurisdiction. And expiry.</text>
+</svg>

--- a/media/data_contracts.svg
+++ b/media/data_contracts.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+<style>.bg{fill:#fffaf2}.txt{font-family:Arial,sans-serif;fill:#1a1a18}.muted{fill:#6e665f}.box{fill:#f3ede4;stroke:#1a1a18;stroke-width:2}.seed{fill:#c5f26b}.danger{fill:#b94a3d}.arrow{stroke:#1a1a18;stroke-width:3;fill:none;marker-end:url(#m)}</style>
+<defs><marker id="m" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto"><path d="M2,2 L10,6 L2,10 Z" fill="#1a1a18"/></marker></defs>
+<rect class="bg" width="1280" height="720"/>
+<text x="70" y="80" class="txt" font-size="46" font-weight="800">Contract flow</text>
+<text x="70" y="120" class="muted" font-size="22">Authority and expiry travel with every object.</text>
+<rect x="70" y="190" width="250" height="90" rx="18" class="box"/><text x="100" y="245" class="txt" font-size="24" font-weight="700">MissionPatch</text><text x="100" y="270" class="muted" font-size="16">Pollen · short TTL</text>
+<rect x="70" y="310" width="250" height="90" rx="18" class="box"/><text x="100" y="365" class="txt" font-size="24" font-weight="700">WeatherDigest</text><text x="100" y="390" class="muted" font-size="16">carried context · expires</text>
+<rect x="70" y="430" width="250" height="90" rx="18" class="box"/><text x="100" y="485" class="txt" font-size="24" font-weight="700">PolicyPacket</text><text x="100" y="510" class="muted" font-size="16">Meristem · valid window</text>
+<rect x="500" y="280" width="260" height="150" rx="24" fill="#1a1a18"/><text x="545" y="340" fill="#f3ede4" font-family="Arial" font-size="30" font-weight="800">Rhizome</text><text x="540" y="375" fill="#c5f26b" font-family="Arial" font-size="18">admission gate</text><text x="540" y="405" fill="#f3ede4" font-family="Arial" font-size="17">expiry · authority · safety</text>
+<rect x="950" y="220" width="250" height="90" rx="18" class="box"/><text x="980" y="275" class="txt" font-size="24" font-weight="700">DecisionReceipt</text><text x="980" y="300" class="muted" font-size="16">accepted action / rationale</text>
+<rect x="950" y="410" width="250" height="90" rx="18" fill="#b94a3d"/><text x="980" y="465" fill="#fffaf2" font-family="Arial" font-size="24" font-weight="700">Rejected</text><text x="980" y="490" fill="#fffaf2" font-family="Arial" font-size="16">expired · unsafe · wrong authority</text>
+<path d="M320 235 C400 250,440 300,500 330" class="arrow"/><path d="M320 355 L500 355" class="arrow"/><path d="M320 475 C400 460,440 410,500 385" class="arrow"/>
+<path d="M760 330 C835 300,875 270,950 265" class="arrow"/><path d="M760 395 C840 420,890 445,950 455" class="arrow"/>
+<text x="70" y="620" class="txt" font-size="28" font-weight="800">No old criterion silently governs water.</text>
+</svg>

--- a/media/double_agent.svg
+++ b/media/double_agent.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+<style>.bg{fill:#f3ede4}.txt{font-family:Arial,sans-serif;fill:#1a1a18}.muted{fill:#6e665f}.box{fill:#fffaf2;stroke:#1a1a18;stroke-width:2}.seed{fill:#c5f26b}.arrow{stroke:#1a1a18;stroke-width:3;fill:none;marker-end:url(#m)}</style>
+<defs><marker id="m" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto"><path d="M2,2 L10,6 L2,10 Z" fill="#1a1a18"/></marker></defs>
+<rect class="bg" width="1280" height="720"/>
+<text x="70" y="80" class="txt" font-size="46" font-weight="800">Local dual-agent pattern</text>
+<text x="70" y="120" class="muted" font-size="22">Measure disagreement before granting authority.</text>
+<rect x="80" y="270" width="250" height="120" rx="22" class="box"/><text x="115" y="325" class="txt" font-size="26" font-weight="700">State bundle</text><text x="115" y="355" class="muted" font-size="17">telemetry · policy · TTL</text>
+<rect x="500" y="190" width="270" height="120" rx="22" class="box"/><text x="535" y="245" class="txt" font-size="26" font-weight="700">Operational agent</text><text x="535" y="275" class="muted" font-size="17">decides inside safe envelope</text>
+<rect x="500" y="410" width="270" height="120" rx="22" class="box"/><text x="535" y="465" class="txt" font-size="26" font-weight="700">ShadowSkeptic</text><text x="535" y="495" class="muted" font-size="17">objects · no authority</text>
+<rect x="930" y="190" width="260" height="120" rx="22" fill="#1a1a18"/><text x="965" y="245" fill="#f3ede4" font-family="Arial" font-size="26" font-weight="700">DecisionReceipt</text><text x="965" y="275" fill="#c5f26b" font-family="Arial" font-size="17">action + rationale</text>
+<rect x="930" y="410" width="260" height="120" rx="22" class="box"/><text x="965" y="465" class="txt" font-size="26" font-weight="700">Disagreement log</text><text x="965" y="495" class="muted" font-size="17">affects_decision=false</text>
+<path d="M330 320 C410 270,425 250,500 250" class="arrow"/><path d="M330 340 C410 400,425 470,500 470" class="arrow"/><path d="M770 250 L930 250" class="arrow"/><path d="M770 470 L930 470" class="arrow"/>
+<text x="260" y="620" class="txt" font-size="30" font-weight="800">A second voice without physical authority.</text>
+</svg>

--- a/media/pollen_visit_cycle.svg
+++ b/media/pollen_visit_cycle.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+<style>.bg{fill:#f3ede4}.txt{font-family:Arial,sans-serif;fill:#1a1a18}.muted{fill:#6e665f}.box{fill:#fffaf2;stroke:#1a1a18;stroke-width:2}.seed{fill:#c5f26b}.arrow{stroke:#1a1a18;stroke-width:3;fill:none;marker-end:url(#m)}</style>
+<defs><marker id="m" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto"><path d="M2,2 L10,6 L2,10 Z" fill="#1a1a18"/></marker></defs>
+<rect class="bg" width="1280" height="720"/>
+<text x="70" y="80" class="txt" font-size="46" font-weight="800">Pollen visit cycle</text>
+<text x="70" y="120" class="muted" font-size="22">The phone arrives before the network; the visit becomes computational.</text>
+<rect x="80" y="230" width="180" height="110" rx="20" class="box"/><text x="120" y="285" class="txt" font-size="26" font-weight="700">Farmer</text><text x="110" y="315" class="muted" font-size="17">voice note</text>
+<rect x="330" y="210" width="210" height="150" rx="20" class="box"/><text x="385" y="265" class="txt" font-size="26" font-weight="700">Pollen</text><text x="360" y="300" class="muted" font-size="17">Gemma 4 E4B</text><text x="360" y="325" class="muted" font-size="17">MissionPatch + TTL</text>
+<rect x="610" y="210" width="210" height="150" rx="20" class="box"/><text x="655" y="265" class="txt" font-size="26" font-weight="700">Rhizome</text><text x="640" y="300" class="muted" font-size="17">local state</text><text x="640" y="325" class="muted" font-size="17">DecisionReceipt</text>
+<rect x="890" y="210" width="210" height="150" rx="20" fill="#1a1a18"/><text x="945" y="265" fill="#f3ede4" font-family="Arial" font-size="26" font-weight="700">ESP32</text><text x="925" y="300" fill="#c5f26b" font-family="Arial" font-size="17">ACK / REJECT</text><text x="925" y="325" fill="#f3ede4" font-family="Arial" font-size="17">physical veto</text>
+<rect x="520" y="500" width="240" height="120" rx="20" class="box"/><text x="575" y="555" class="txt" font-size="26" font-weight="700">Meristem</text><text x="555" y="590" class="muted" font-size="17">policy at home</text>
+<path d="M260 285 L330 285" class="arrow"/><path d="M540 285 L610 285" class="arrow"/><path d="M820 285 L890 285" class="arrow"/>
+<path d="M610 330 C520 410,510 470,560 500" class="arrow"/><text x="420" y="430" class="txt" font-size="17">FieldVisit + SyncBundle</text>
+<path d="M760 540 C920 480,980 400,1000 360" class="arrow"/><text x="850" y="515" class="txt" font-size="17">Policy returns via Pollen</text>
+<circle cx="330" cy="285" r="8" class="seed"/><circle cx="610" cy="285" r="8" class="seed"/><circle cx="890" cy="285" r="8" class="seed"/>
+</svg>


### PR DESCRIPTION
## Resumen

Cascada de docs aplicando auditoría 2ª pasada (doc 02) + inputs de Endo y Floema.

## Cambios

- **README root**: sustituido por versión auditora (hero, invariants, tabla layer/time-scale, architecture diagram, language note). Link writeup a `writeup/draft.md`.
- **SUBMISSION.md**: URL landing real `zigiella.com/sprout`, writeup actualizado a 1467 palabras.
- **code/rhizome/README.md**: abstract EN al top (párrafo confirmado por Endo) + Rol + Stack actualizados al MVP real.
- **code/pollen/README.md**: abstract EN al top (bloque consolidado por Floema) + Build flavors detallados.
- **hardware/firmware_esp32/README.md**: abstract EN + caja 'Submission status' explicitando WATER vs PUMP_PULSE.
- **CITATION.cff**: nuevo, Apache-2.0, keywords completos.
- **ROADMAP.md**: nuevo, 7 ejes de trabajo futuro + 'out of scope' explícito.

## Pendiente para otra rama

- Meristem README top (esperando párrafo de Meristem).
- README.es.md espejo en castellano (mantener el existente o reescribir corto).
- Foto física hardware en `media/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)