### PR TITLE
[pollen] Android config drift: minSdk 31 + pin LiteRT-LM 0.10.1

### DIFF
--- a/code/pollen/app/build.gradle.kts
+++ b/code/pollen/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId = "net.sprout.pollen"
-        minSdk = 29
+        minSdk = 31
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
@@ -75,7 +75,7 @@ dependencies {
     // Kotlinx Serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
-    "deviceImplementation"("com.google.ai.edge.litertlm:litertlm-android:+")
+    "deviceImplementation"("com.google.ai.edge.litertlm:litertlm-android:0.10.1")
 
     // Retrofit para conexión con Rhizome (Jetson/ESP32)
     implementation("com.squareup.retrofit2:retrofit:2.11.0")


### PR DESCRIPTION
Cierra los dos puntos de Android config drift que detectó la auditora 2ª pasada (doc 02, P0 #5).

## Cambios

- **`minSdk = 29` → `minSdk = 31`** — alineamos con el claim del README ("Android 12 / API 31+") y con los requisitos reales de LiteRT-LM para Gemma 4 E4B.
- **`com.google.ai.edge.litertlm:litertlm-android:+` → `com.google.ai.edge.litertlm:litertlm-android:0.10.1`** — pin a versión explícita para reproducibilidad. Esta es la versión que documentamos en nuestros research docs como la que parcheaba los fallos de decode en GPU para Gemma 4.

## Test plan

- [x] Rebase contra `main` post PR #167 (resolved minor workflow conflict, force-pushed clean).
- [ ] CI Pollen verde tras merge.
- [ ] Tras merge, Floema regenera `demoRelease` + `deviceRelease` APKs y sustituye en `demo/`.

Floema queda en standby para regenerar APKs en cuanto este PR mergee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)