### PR TITLE
[landing+docs] P1: SVGs embedded + Get apps section + OG/favicon + Meristem README abstract

### DIFF
--- a/code/meristem_node/README.md
+++ b/code/meristem_node/README.md
@@ -1,7 +1,8 @@
 # meristem_node/
 
-**Estado**: día 14, esqueleto FastAPI funcional stubeado. Construcción
-real día 15-17. Demo-ready día 18.
+**Abstract.** Meristem is Sprout's slow brain. It runs on a home laptop (FastAPI + SQLite), ingests bundles that Pollen carries from Rhizome nodes, applies a deterministic evaluator (four rules: confirm / conservative / alert / refuse) and emits durable `PolicyPacket` objects for the next window. Rationale composition and an operator-facing read-only chat use Gemma 4 E4B via `llama.cpp` with tool calling (recent-history lookup, cross-target comparison, previous-policy diff); **the evaluator itself never depends on the model**. Pollen talks to Meristem either over WebSocket or a parallel HTTP fallback (added after a real field test on day 27), discovered via mDNS as `meristem.local:13000`. **Nothing leaves the home network — no cloud, no accounts, no telemetry.**
+
+---
 
 ## Qué es
 

--- a/landing-demo/css/style.css
+++ b/landing-demo/css/style.css
@@ -230,9 +230,40 @@ pre {
   font-style: italic;
 }
 
+/* --- Diagrams --- */
+.diagram {
+  margin: 32px 0 0;
+}
+
+.diagram img {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 18px;
+  display: block;
+}
+
+.diagram figcaption {
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 14px;
+  font-style: italic;
+  text-align: center;
+}
+
 /* --- Safety --- */
 .safety {
   background: var(--soft);
+}
+
+.safety-split {
+  display: grid;
+  grid-template-columns: 1.4fr 0.9fr;
+  gap: 40px;
+  align-items: start;
 }
 
 .safety ol {
@@ -241,6 +272,28 @@ pre {
 
 .safety li {
   margin-bottom: 14px;
+}
+
+.safety-split .diagram {
+  margin-top: 0;
+}
+
+/* --- Inline commands --- */
+pre.cmd {
+  background: #1a1a18;
+  color: var(--seed);
+  padding: 16px;
+  border-radius: 12px;
+  font-size: 12px;
+  margin: 12px 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  min-height: auto;
+  margin-top: 12px;
+}
+
+.small {
+  font-size: 13px;
 }
 
 /* --- Footer --- */
@@ -254,7 +307,7 @@ footer {
 
 /* --- Responsive --- */
 @media (max-width: 760px) {
-  .truth-grid, .cards, .split {
+  .truth-grid, .cards, .split, .safety-split {
     grid-template-columns: 1fr;
   }
   .hero-inner { padding-top: 6vh; }

--- a/landing-demo/index.html
+++ b/landing-demo/index.html
@@ -5,6 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sprout — Local-first AI water optimization</title>
   <meta name="description" content="Sprout is a safety-bounded Gemma 4 decision network for irrigation under absence. Rhizome decides beside the water, Pollen turns visits into expiring criteria, Meristem refines policy at home, and an ESP32 owns the physical veto.">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Sprout — Local-first AI water optimization">
+  <meta property="og:description" content="A safety-bounded Gemma 4 decision network for irrigation under absence. Three local nodes + a physical veto layer. Open source, Apache 2.0.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://sprout.zigiella.com/">
+  <meta property="og:image" content="https://sprout.zigiella.com/media/architecture_overview.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Sprout — Local-first AI water optimization">
+  <meta name="twitter:description" content="A safety-bounded Gemma 4 decision network for irrigation under absence.">
+
+  <!-- Favicon: signal-seed dot on soil-graphite -->
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%231a1a18'/%3E%3Ccircle cx='16' cy='16' r='6' fill='%23c5f26b'/%3E%3C/svg%3E">
+
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -42,6 +56,10 @@
     <div><strong>Meristem</strong><span>Home laptop evaluator + Gemma 4 E4B tool-calling</span></div>
   </div>
   <p class="note">The browser demo below is <strong>deterministic by design</strong>. It lets reviewers inspect contracts, TTLs, receipts and refusal paths instantly; it does not pretend to run Gemma 4 in the browser. Real Gemma 4 execution lives in the Android, Jetson and laptop paths documented in the repo.</p>
+  <figure class="diagram">
+    <img src="media/architecture_overview.svg" alt="Sprout architecture overview: Pollen Android + Rhizome Jetson + ESP32 physical veto + Meristem home laptop" loading="lazy">
+    <figcaption>Sprout distributes irrigation criteria across three Gemma 4 nodes with different jurisdictions and one physical veto layer.</figcaption>
+  </figure>
 </section>
 
 <section id="demo" class="container">
@@ -88,13 +106,55 @@
 
 <section id="safety" class="container safety">
   <h2>Safety &amp; Trust</h2>
-  <ol>
-    <li><strong>Physical layer prevails.</strong> The ESP32 firmware enforces five hard rules (<code>JETSON_HEARTBEAT_LOST</code>, <code>TANK_LOW</code>, <code>EVENT_DURATION_OUT_OF_RANGE</code>, <code>NO_FLOW_DETECTED</code>, <code>ALERT_LATCHED</code>). No LLM can weaken them.</li>
-    <li><strong>Every intelligence has jurisdiction.</strong> Rhizome arbitrates in minutes. Pollen mediates within visit TTL. Meristem refines in days.</li>
-    <li><strong>Every criterion expires.</strong> <code>MissionPatch</code>, <code>WeatherDigest</code> and <code>PolicyPacket</code> carry TTL or validity windows. Late objects are rejected, not silently obeyed.</li>
-    <li><strong>Refusal is a feature.</strong> When Pollen does not understand a voice instruction, it asks for rephrasing. When Rhizome sees an expired policy, it rejects. When the ESP32 detects an unsafe condition, it blocks.</li>
-    <li><strong>A second local voice audits without authority.</strong> <code>ShadowSkeptic</code> records objections inside Rhizome with <code>affects_decision=false</code>. Even skepticism has jurisdiction.</li>
-  </ol>
+  <div class="safety-split">
+    <ol>
+      <li><strong>Physical layer prevails.</strong> The ESP32 firmware enforces five hard rules (<code>JETSON_HEARTBEAT_LOST</code>, <code>TANK_LOW</code>, <code>EVENT_DURATION_OUT_OF_RANGE</code>, <code>NO_FLOW_DETECTED</code>, <code>ALERT_LATCHED</code>). No LLM can weaken them.</li>
+      <li><strong>Every intelligence has jurisdiction.</strong> Rhizome arbitrates in minutes. Pollen mediates within visit TTL. Meristem refines in days.</li>
+      <li><strong>Every criterion expires.</strong> <code>MissionPatch</code>, <code>WeatherDigest</code> and <code>PolicyPacket</code> carry TTL or validity windows. Late objects are rejected, not silently obeyed.</li>
+      <li><strong>Refusal is a feature.</strong> When Pollen does not understand a voice instruction, it asks for rephrasing. When Rhizome sees an expired policy, it rejects. When the ESP32 detects an unsafe condition, it blocks.</li>
+      <li><strong>A second local voice audits without authority.</strong> <code>ShadowSkeptic</code> records objections inside Rhizome with <code>affects_decision=false</code>. Even skepticism has jurisdiction.</li>
+    </ol>
+    <figure class="diagram">
+      <img src="media/authority_stack.svg" alt="Authority stack: ESP32 prevails (physical), Rhizome arbitrates (minutes), Pollen mediates (visit TTL), Meristem refines (days)" loading="lazy">
+      <figcaption>The farther a node is from the water, the less physical authority it has. The ESP32 can always say no.</figcaption>
+    </figure>
+  </div>
+</section>
+
+<section id="get" class="container">
+  <h2>Get the apps and the hardware path</h2>
+  <p class="muted">Beyond the browser simulator, Sprout is real software you can install and real hardware you can build.</p>
+  <div class="cards">
+    <article>
+      <p class="node">Pollen · demo flavor</p>
+      <h3>Install the app, no model needed</h3>
+      <p>~39 MB APK. Uses a deterministic mock evaluator. Runs on any Android emulator or device without downloading a 3 GB model. Walk through the UI, the voice path and refusal/retry flow.</p>
+      <p>
+        <a class="btn primary" href="https://github.com/zigiella/sprout/raw/main/demo/pollen-demo.apk">Download <code>demo</code> APK</a>
+      </p>
+    </article>
+    <article>
+      <p class="node">Pollen · device flavor</p>
+      <h3>Run real Gemma 4 E4B on your phone</h3>
+      <p>Real LiteRT-LM pipeline. Side-load the model and grant microphone permission.</p>
+      <pre class="cmd"># Build the device flavor
+./gradlew assembleDeviceRelease
+
+# Side-load the model
+adb push gemma-4-E4B-it.litertlm \
+  /data/local/tmp/gemma-4-E4B-it.litertlm</pre>
+      <p class="muted small">Requires Android 12+ (API 31+), 12 GB RAM recommended, NPU/GPU capable device. CPU runtime is stable but slow.</p>
+    </article>
+    <article>
+      <p class="node">Hardware proof</p>
+      <h3>Reproduce the Rhizome + ESP32 path</h3>
+      <p>Jetson Orin Nano Super (or Raspberry Pi 5 with adapted build), ESP32-S3 N16R8, 12V pump, relay, capacitive soil sensor, 5L tank. Total bench ~370 €.</p>
+      <p>
+        <a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/code/rhizome/jetson/README.md">Rhizome Jetson setup →</a><br>
+        <a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/hardware/firmware_esp32/README.md">ESP32 firmware →</a>
+      </p>
+    </article>
+  </div>
 </section>
 
 <section class="container">


### PR DESCRIPTION
Cierra dos cosas:

## 1. Landing P1 mejoras estratégicas

Tras revisión de la landing en vivo en https://sprout.zigiella.com/ y cruce con doc 03 de la auditora:

- **Open Graph + Twitter meta tags**: preview al compartir URL.
- **Favicon SVG inline**: dot signal-seed sobre soil-graphite.
- **Embed `architecture_overview.svg`** en sección 'What is real'.
- **Embed `authority_stack.svg`** en sección 'Safety & Trust' (split layout con lista + diagrama).
- **Nueva sección 'Get the apps and the hardware path'** con 3 cards: Pollen demo APK (descarga directa), Pollen device flavor (con `adb push` inline), Hardware proof (links a Jetson + ESP32 setups).
- CSS nuevo para diagram/safety-split/cmd/small + responsive @760px actualizado.

## 2. Meristem README abstract EN

Párrafo consolidado por Meristem en respuesta al barrido pre-auditoría. Cubre: FastAPI+SQLite, evaluator determinista con 4 reglas, Gemma 4 E4B via llama.cpp con tool calling, chat read-only, doble protocolo WebSocket+HTTP fallback, mDNS, privacy story. Frase clave: 'the evaluator itself never depends on the model'.

## Pendiente para futuras pasadas

- YouTube URL cuando vídeo final → cambiar `href='#'` del CTA 'Watch the 3-minute demo'.
- Foto física hardware en sección 'Get'.
- Screenshot Pollen real en sección Pollen demo card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)