### PR TITLE
[fix] pin LiteRT-LM a 0.10.0 publicada en Maven (no 0.10.1 self-built) — CI verde

### DIFF
--- a/code/pollen/app/build.gradle.kts
+++ b/code/pollen/app/build.gradle.kts
@@ -75,7 +75,11 @@ dependencies {
     // Kotlinx Serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
-    "deviceImplementation"("com.google.ai.edge.litertlm:litertlm-android:0.10.1")
+    // Pinned to 0.10.0 (latest version published on Google Maven at submission time).
+    // 0.10.1 is a self-built patch documented in github.com/google-ai-edge/LiteRT-LM/issues/1850
+    // that fixes GPU decode for Gemma 4 E2B on Pixel 8, but it is not resolvable from public
+    // Maven repositories. The contractual demo path uses CPU runtime, which 0.10.0 handles.
+    "deviceImplementation"("com.google.ai.edge.litertlm:litertlm-android:0.10.0")
 
     // Retrofit para conexión con Rhizome (Jetson/ESP32)
     implementation("com.squareup.retrofit2:retrofit:2.11.0")

--- a/landing-demo/index.html
+++ b/landing-demo/index.html
@@ -96,7 +96,7 @@
     <h2>How Gemma 4 is used</h2>
     <ul>
       <li><strong>E2B on Rhizome:</strong> short, bounded local rationales over decisions already closed by deterministic gates. Runs via <code>llama.cpp</code> on Jetson Orin Nano Super.</li>
-      <li><strong>E4B on Pollen:</strong> native audio multimodal on Android via LiteRT-LM (<code>com.google.ai.edge.litertlm:litertlm-android:0.10.1</code>). Voice → validated <code>MissionPatch</code> with no STT pipeline.</li>
+      <li><strong>E4B on Pollen:</strong> native audio multimodal on Android via LiteRT-LM (<code>com.google.ai.edge.litertlm:litertlm-android:0.10.0</code>). Voice → validated <code>MissionPatch</code> with no STT pipeline.</li>
       <li><strong>E4B on Meristem:</strong> tool-calling-assisted policy review on a home laptop via <code>llama.cpp</code>.</li>
     </ul>
     <p class="muted">Each node has a different model profile. Configuration is a property of jurisdiction, not a global choice.</p>


### PR DESCRIPTION
Cierra el CI rojo post-merge de PR #169.

## Diagnóstico

`0.10.1` es una versión **self-built** documentada en https://github.com/google-ai-edge/LiteRT-LM/issues/1850 que parchea el GPU decode failure de Gemma 4 E2B en Pixel 8. NO está publicada en Maven Central ni en Google Maven.

CI Pollen falla con:
`Could not find com.google.ai.edge.litertlm:litertlm-android:0.10.1`

## Fix

- Pin a **0.10.0** (la última publicada en Google Maven al momento de submission).
- Comentario explicativo en `build.gradle.kts` para que cualquiera entienda el matiz.
- Landing actualizada para reflejar 0.10.0 también.

## Por qué no rompe nada

La ruta contractual del demo path usa **CPU runtime**, donde 0.10.0 funciona correctamente. El 0.10.1 GPU patch solo importa si decidimos exigir GPU decode en Pixel 8 — no es el caso del MVP.

Si el futuro pide 0.10.1, hay que incorporar repositorio self-built o esperar a publicación pública.

🤖 Generated with [Claude Code](https://claude.com/claude-code)