### PR TITLE
[fix] LiteRtInfra compile contra litertlm 0.10.0 publica (extraContext era 0.10.1 self-built)

### DIFF
--- a/code/pollen/app/src/device/kotlin/net/sprout/pollen/llm/LiteRtInfra.kt
+++ b/code/pollen/app/src/device/kotlin/net/sprout/pollen/llm/LiteRtInfra.kt
@@ -129,14 +129,15 @@ class LiteRtChatService(
 
     fun sendPrompt(userText: String, isThinkingEnabled: Boolean = false, temperature: Float? = null): Flow<Pair<String, GenerationMetrics?>> = flow {
         val engine = requireNotNull(sessionManager.currentEngine()) { "Engine no inicializado" }
-        
+
+        // TODO: isThinkingEnabled is a no-op on litertlm-android:0.10.0 (the published Maven
+        // version). The `extraContext` parameter that exposes "enable_thinking" + the
+        // "filter_channel_content_from_kv_cache" tweak lives in a self-built 0.10.1 patch
+        // documented in github.com/google-ai-edge/LiteRT-LM/issues/1850. Re-enable when
+        // the runtime patch lands in a public release. The MVP path uses standard
+        // ConversationConfig() and lets the model run without thinking-mode shaping.
         if (activeConversation == null) {
-            val config = com.google.ai.edge.litertlm.ConversationConfig(
-                extraContext = if (isThinkingEnabled) mapOf(
-                    "enable_thinking" to true,
-                    "filter_channel_content_from_kv_cache" to true
-                ) else emptyMap()
-            )
+            val config = com.google.ai.edge.litertlm.ConversationConfig()
             activeConversation = engine.createConversation(config)
         }
         val conversation = activeConversation!!
@@ -182,14 +183,11 @@ class LiteRtChatService(
 
     fun sendAudioFile(audioPath: String, instruction: String, isThinkingEnabled: Boolean = false): Flow<Pair<String, GenerationMetrics?>> = flow {
         val engine = requireNotNull(sessionManager.currentEngine()) { "Engine no inicializado" }
-        
+
+        // See note in sendPrompt(): isThinkingEnabled is a no-op on the published
+        // litertlm-android:0.10.0 runtime. Re-enable when the 0.10.1 patch ships publicly.
         if (activeConversation == null) {
-            val config = com.google.ai.edge.litertlm.ConversationConfig(
-                extraContext = if (isThinkingEnabled) mapOf(
-                    "enable_thinking" to true,
-                    "filter_channel_content_from_kv_cache" to true
-                ) else emptyMap()
-            )
+            val config = com.google.ai.edge.litertlm.ConversationConfig()
             activeConversation = engine.createConversation(config)
         }
         val conversation = activeConversation!!


### PR DESCRIPTION
Cierra CI rojo tras cadena #169 + #171.

## Diagnostico

El `ConversationConfig(extraContext = ...)` que usaba Floema para activar **thinking-mode** (enable_thinking + filter_channel_content_from_kv_cache) solo existe en la API **0.10.1 self-built**. En la `0.10.0` publicada en Google Maven, el parametro `extraContext` no existe → compile error.

## Fix

- `ConversationConfig()` sin params en `sendPrompt()` y `sendAudioFile()`.
- Flag `isThinkingEnabled` queda como **no-op** documentado en device flavor (signature preservada para no romper callers).
- TODO comment apunta a re-activar cuando 0.10.1+ se publique en Maven.

## Impacto en MVP

Ninguno. El thinking-mode era afinaje de calidad de output (Meristem documenta el num_predict finding como mejora analoga). La ruta contractual de Pollen device flavor sigue funcionando en CPU runtime sin esto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)