### PR TITLE
[landing] Venation SVGs v1 + fix workflow Pages para servir /media/

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'landing-demo/**'
+      - 'media/**'
       - '.github/workflows/deploy-landing.yml'
   workflow_dispatch:
 
@@ -30,13 +31,18 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
-      - name: Upload landing artifact
+      - name: Stage site (landing + media)
+        run: |
+          mkdir -p _site
+          cp -r landing-demo/. _site/
+          mkdir -p _site/media
+          cp -r media/. _site/media/
+
+      - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./landing-demo
+          path: ./_site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/landing-demo/css/style.css
+++ b/landing-demo/css/style.css
@@ -80,6 +80,8 @@ code {
   font-size: clamp(44px, 8vw, 92px);
   line-height: 0.95;
   margin: 20px 0;
+  text-wrap: pretty;
+  max-width: 840px;
 }
 
 .tagline {

--- a/media/architecture_overview.svg
+++ b/media/architecture_overview.svg
@@ -1,37 +1,147 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
-<style>.bg{fill:#f3ede4}.box{fill:#fffaf2;stroke:#1a1a18;stroke-width:2}.dark{fill:#1a1a18}.txt{font-family:Arial,sans-serif;fill:#1a1a18}.white{fill:#f3ede4}.seed{fill:#c5f26b}.muted{fill:#6e665f}.arrow{stroke:#1a1a18;stroke-width:3;fill:none;marker-end:url(#m)}</style>
-<defs><marker id="m" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto"><path d="M2,2 L10,6 L2,10 Z" fill="#1a1a18"/></marker></defs>
-<rect class="bg" width="1280" height="720"/>
-<text x="60" y="70" class="txt" font-size="42" font-weight="800">Sprout architecture</text>
-<text x="60" y="110" class="muted" font-size="22">A safety-bounded Gemma 4 decision network for water under absence</text>
-<rect x="60" y="190" width="240" height="150" rx="22" class="box"/>
-<text x="90" y="235" class="txt" font-size="30" font-weight="700">Pollen</text>
-<text x="90" y="270" class="txt" font-size="18">Android · Gemma 4 E4B</text>
-<text x="90" y="300" class="muted" font-size="18">visit TTL · MissionPatch</text>
-<rect x="520" y="160" width="250" height="190" rx="22" class="box"/>
-<text x="550" y="210" class="txt" font-size="30" font-weight="700">Rhizome</text>
-<text x="550" y="245" class="txt" font-size="18">Jetson · Gemma 4 E2B</text>
-<text x="550" y="275" class="muted" font-size="18">minutes · local decision</text>
-<text x="550" y="310" class="muted" font-size="18">writes DecisionReceipt</text>
-<rect x="970" y="160" width="250" height="190" rx="22" class="dark"/>
-<text x="1000" y="210" class="white" font-size="30" font-weight="700">ESP32</text>
-<text x="1000" y="245" class="white" font-size="18">firmware hard rules</text>
-<text x="1000" y="275" class="seed" font-size="18">physical veto</text>
-<text x="1000" y="310" class="white" font-size="18">pump · relay · sensors</text>
-<rect x="520" y="490" width="250" height="150" rx="22" class="box"/>
-<text x="550" y="535" class="txt" font-size="30" font-weight="700">Meristem</text>
-<text x="550" y="570" class="txt" font-size="18">home laptop · Gemma 4 E4B</text>
-<text x="550" y="600" class="muted" font-size="18">days · durable policy</text>
-<path d="M300 260 C390 250,430 245,520 245" class="arrow"/>
-<text x="345" y="225" class="txt" font-size="17">MissionPatch + context</text>
-<path d="M770 245 C850 245,890 245,970 245" class="arrow"/>
-<text x="805" y="220" class="txt" font-size="17">candidate command</text>
-<path d="M970 295 C890 330,850 335,770 305" class="arrow"/>
-<text x="805" y="360" class="txt" font-size="17">ACK / REJECT</text>
-<path d="M300 305 C390 410,425 520,520 565" class="arrow"/>
-<text x="315" y="465" class="txt" font-size="17">SyncBundle carried home</text>
-<path d="M645 490 L645 350" class="arrow"/>
-<text x="665" y="430" class="txt" font-size="17">PolicyPacket via Pollen</text>
-<rect x="60" y="650" width="1160" height="44" rx="20" class="dark"/>
-<text x="90" y="680" class="seed" font-size="20" font-weight="700">Physical layer prevails · Rhizome arbitrates · Pollen mediates · Meristem refines</text>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 520" role="img" aria-label="Sprout architecture overview · three jurisdictions, one water decision">
+  <title>Three jurisdictions. One water decision.</title>
+  <desc>Sprout architecture: Rhizome and ESP32 in the field, Pollen on mobile, Meristem at home. Visits ferry MissionPatch out and DecisionReceipt back. The valve only opens after ESP32 validates.</desc>
+
+  <defs>
+    
+    <marker id="arrtip" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L6,4 L0,8 z" class="arrow-tip"></path>
+    </marker>
+  </defs>
+
+  
+  <rect class="bg" width="1180" height="520"></rect>
+
+  
+  <text class="t-eyebrow" x="32" y="46">Architecture · overview</text>
+  <text class="t-title" x="32" y="80">Three jurisdictions. One water decision.</text>
+
+  
+  
+  <g transform="translate(32,118)">
+    <line class="hairline" x1="0" y1="0" x2="540" y2="0"></line>
+    <text class="t-group" x="0" y="-8">Field · plot</text>
+    <text class="t-group" x="540" y="-8" text-anchor="end">offline by design</text>
+  </g>
+  
+  <g transform="translate(596,118)">
+    <line class="hairline" x1="0" y1="0" x2="262" y2="0"></line>
+    <text class="t-group" x="0" y="-8">Mobile · visit</text>
+  </g>
+  
+  <g transform="translate(884,118)">
+    <line class="hairline" x1="0" y1="0" x2="262" y2="0"></line>
+    <text class="t-group" x="0" y="-8">Home · slow</text>
+  </g>
+
+  
+  <g transform="translate(32,140)">
+    <rect class="card-graphite" width="262" height="170" rx="3"></rect>
+    
+    <circle class="seed" cx="246" cy="16" r="4"></circle>
+    <circle class="seed-stroke" cx="246" cy="16" r="9" opacity="0.35"></circle>
+    <text class="t-cardid" x="20" y="32">01 · Field node</text>
+    <text class="t-cardname" x="20" y="60">Rhizome</text>
+    <text class="t-role" x="20" y="86">Decides offline.</text>
+    <text class="t-role" x="20" y="104">Reads soil and local state.</text>
+    <text class="t-role" x="20" y="122">Issues candidate_action.</text>
+    <line class="hairline" x1="20" y1="138" x2="242" y2="138" stroke="rgba(243,237,228,0.18)"></line>
+    <text class="t-seed" x="20" y="156" fill="#C5F26B">Gemma 3 · 4B edge</text>
+  </g>
+
+  
+  <g transform="translate(310,140)">
+    <rect class="card" width="262" height="170" rx="3"></rect>
+    <text class="t-cardid-dark" x="20" y="32">02 · Field safety</text>
+    <text class="t-cardname-dark" x="20" y="60">ESP32</text>
+    <text class="t-role-dark" x="20" y="86">Validates tank level.</text>
+    <text class="t-role-dark" x="20" y="104">Caps actuation timing.</text>
+    <text class="t-role-dark" x="20" y="122">Has physical veto.</text>
+    <line class="hairline" x1="20" y1="138" x2="242" y2="138"></line>
+    <text class="t-flow-em" x="20" y="156">Final → valve</text>
+  </g>
+
+  
+  <g transform="translate(596,140)">
+    <rect class="card-graphite" width="262" height="170" rx="3"></rect>
+    <circle class="seed" cx="246" cy="16" r="4"></circle>
+    <circle class="seed-stroke" cx="246" cy="16" r="9" opacity="0.35"></circle>
+    <text class="t-cardid" x="20" y="32">03 · Mobile</text>
+    <text class="t-cardname" x="20" y="60">Pollen</text>
+    <text class="t-role" x="20" y="86">Lives on Android.</text>
+    <text class="t-role" x="20" y="104">Turns the visit into</text>
+    <text class="t-role" x="20" y="122">a MissionPatch.</text>
+    <line class="hairline" x1="20" y1="138" x2="242" y2="138" stroke="rgba(243,237,228,0.18)"></line>
+    <text class="t-seed" x="20" y="156" fill="#C5F26B">Gemma 3 · 4B mobile</text>
+  </g>
+
+  
+  <g transform="translate(884,140)">
+    <rect class="card" width="262" height="170" rx="3"></rect>
+    <text class="t-cardid-dark" x="20" y="32">04 · Home</text>
+    <text class="t-cardname-dark" x="20" y="60">Meristem</text>
+    <text class="t-role-dark" x="20" y="86">Slow consolidation.</text>
+    <text class="t-role-dark" x="20" y="104">Refines policy when</text>
+    <text class="t-role-dark" x="20" y="122">an uplink exists.</text>
+    <line class="hairline" x1="20" y1="138" x2="242" y2="138"></line>
+    <text class="t-flow-em" x="20" y="156">Eventual · best-effort</text>
+  </g>
+
+  
+
+  
+  <g transform="translate(572,140)">
+    
+    <path class="arrow" d="M 24 50 L 0 50" marker-end="url(#arrtip)"></path>
+    <text class="t-flow" x="12" y="40" text-anchor="middle">MissionPatch</text>
+    
+    <path class="arrow" d="M 0 110 L 24 110" marker-end="url(#arrtip)"></path>
+    <text class="t-flow" x="12" y="132" text-anchor="middle">DecisionReceipt</text>
+  </g>
+
+  
+  <g transform="translate(860,140)">
+    
+    <path class="arrow dashed" d="M 0 50 L 24 50" marker-end="url(#arrtip)"></path>
+    <text class="t-flow" x="12" y="40" text-anchor="middle">Bundle</text>
+    
+    <path class="arrow dashed" d="M 24 110 L 0 110" marker-end="url(#arrtip)"></path>
+    <text class="t-flow" x="12" y="132" text-anchor="middle">PolicyDiff</text>
+  </g>
+
+  
+  <g transform="translate(32,360)">
+    <line class="hairline" x1="0" y1="0" x2="1116" y2="0"></line>
+    <text class="t-eyebrow" x="0" y="22">Authority</text>
+    <text class="t-flow" x="0" y="46">
+      <tspan>Rhizome proposes</tspan>
+      <tspan class="t-flow-em">  ·  </tspan>
+      <tspan>ESP32 validates</tspan>
+      <tspan class="t-flow-em">  ·  </tspan>
+      <tspan>the valve only opens after ACK</tspan>
+    </text>
+    <text class="t-flow" x="0" y="66">
+      <tspan>Pollen ferries context between Rhizomes</tspan>
+      <tspan class="t-flow-em">  ·  </tspan>
+      <tspan>Meristem refines policies offline-eventual, never authoritative in the field</tspan>
+    </text>
+
+    
+    <g transform="translate(820,18)">
+      <rect x="0" y="0" width="10" height="10" class="card-graphite"></rect>
+      <text class="t-flow" x="18" y="9">AI present</text>
+      <circle class="seed" cx="98" cy="5" r="3"></circle>
+      <text class="t-flow" x="108" y="9">signal.seed</text>
+      <rect x="200" y="0" width="10" height="10" fill="#FAF6EF" stroke="#CDBBAA"></rect>
+      <text class="t-flow" x="218" y="9">deterministic</text>
+    </g>
+    <g transform="translate(820,46)">
+      <line class="arrow" x1="0" y1="5" x2="22" y2="5" marker-end="url(#arrtip)"></line>
+      <text class="t-flow" x="32" y="9">synchronous handoff</text>
+      <line class="arrow dashed" x1="200" y1="5" x2="222" y2="5" marker-end="url(#arrtip)"></line>
+      <text class="t-flow" x="232" y="9">eventual sync</text>
+    </g>
+  </g>
+
 </svg>

--- a/media/authority_stack.svg
+++ b/media/authority_stack.svg
@@ -1,15 +1,92 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
-<style>.bg{fill:#1a1a18}.layer{stroke:#f3ede4;stroke-width:2}.txt{font-family:Arial,sans-serif;fill:#f3ede4}.seed{fill:#c5f26b}.muted{fill:#c9beb2}</style>
-<rect class="bg" width="1280" height="720"/>
-<text x="80" y="82" class="txt" font-size="46" font-weight="800">Authority stack</text>
-<text x="80" y="125" class="muted" font-size="23">The farther a node is from water, the less physical authority it has.</text>
-<rect x="180" y="160" width="920" height="90" rx="18" fill="#3b3b36" class="layer"/>
-<text x="220" y="215" class="txt" font-size="30" font-weight="700">Meristem refines</text><text x="590" y="215" class="muted" font-size="23">days · durable policy · no direct actuation</text>
-<rect x="180" y="270" width="920" height="90" rx="18" fill="#4b4a43" class="layer"/>
-<text x="220" y="325" class="txt" font-size="30" font-weight="700">Pollen mediates</text><text x="590" y="325" class="muted" font-size="23">visit TTL · MissionPatch · context ferry</text>
-<rect x="180" y="380" width="920" height="90" rx="18" fill="#605d55" class="layer"/>
-<text x="220" y="435" class="txt" font-size="30" font-weight="700">Rhizome arbitrates</text><text x="590" y="435" class="muted" font-size="23">minutes · local state · signed receipts</text>
-<rect x="180" y="490" width="920" height="110" rx="18" fill="#c5f26b"/>
-<text x="220" y="555" fill="#1a1a18" font-family="Arial,sans-serif" font-size="34" font-weight="800">Physical layer prevails</text><text x="670" y="555" fill="#1a1a18" font-family="Arial,sans-serif" font-size="23">ESP32 firmware · hard veto · pump/sensors</text>
-<text x="180" y="650" class="seed" font-size="26" font-weight="700">Every intelligence has jurisdiction. And expiry.</text>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 360" role="img" aria-label="Sprout authority stack · AI proposes, ESP32 validates">
+  <title>AI proposes. ESP32 validates.</title>
+  <desc>The Gemma model and Rhizome controller propose a candidate irrigation action. ESP32 validates the physical envelope — tank, timing, actuation limits — and produces the final action. The valve only opens after ACK.</desc>
+
+  <defs>
+    
+    <marker id="atip" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L7,4.5 L0,9 z" class="arrow-tip"></path>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1180" height="360"></rect>
+
+  
+  <text class="t-eyebrow" x="32" y="40">Safety floor · authority stack</text>
+  <text class="t-title" x="32" y="72">AI proposes. ESP32 validates.</text>
+
+  
+  
+
+  
+  <g transform="translate(32,120)">
+    <rect class="card-graphite" width="260" height="180" rx="3"></rect>
+    <circle class="seed" cx="244" cy="16" r="4"></circle>
+    <text class="t-step t-cap-dim" x="20" y="30" fill="rgba(243,237,228,0.55)">Stage 01 · propose</text>
+    <text class="t-stage t-stage-light" x="20" y="58">Gemma · Rhizome</text>
+    <text class="t-payload t-payload-light" x="20" y="92">decision_type: WATER</text>
+    <text class="t-payload t-payload-light" x="20" y="112">candidate_action: 30s</text>
+    <text class="t-payload t-payload-dim" x="20" y="132">why: soil &lt; 30</text>
+    <text class="t-payload t-payload-dim" x="20" y="152">budget_cap_ml: 900</text>
+    <line x1="20" y1="166" x2="240" y2="166" stroke="rgba(243,237,228,0.18)"></line>
+  </g>
+
+  
+  <g transform="translate(292,210)">
+    <line class="arrow" x1="0" y1="0" x2="60" y2="0" marker-end="url(#atip)"></line>
+    <text class="t-cap t-cap-dim" x="30" y="-12" text-anchor="middle">candidate</text>
+  </g>
+
+  
+  <g transform="translate(360,120)">
+    <rect class="card" width="260" height="180" rx="3"></rect>
+    
+    <line x1="0" y1="42" x2="260" y2="42" class="rule-strong"></line>
+    <text class="t-step t-cap-dim" x="20" y="30">Stage 02 · validate</text>
+    <text class="t-stage t-stage-dark" x="20" y="70">ESP32</text>
+    <text class="t-payload" x="20" y="98">tank_level &gt; min   ✓</text>
+    <text class="t-payload" x="20" y="118">duty_cycle ≤ cap   ✓</text>
+    <text class="t-payload" x="20" y="138">flow_rate ≤ 6L/min</text>
+    <text class="t-payload" x="20" y="158">override: capped</text>
+    <line class="hairline" x1="20" y1="166" x2="240" y2="166"></line>
+  </g>
+
+  
+  <g transform="translate(620,210)">
+    <line class="arrow" x1="0" y1="0" x2="60" y2="0" marker-end="url(#atip)"></line>
+    <text class="t-cap t-cap-ok" x="30" y="-12" text-anchor="middle">final · ACK</text>
+  </g>
+
+  
+  <g transform="translate(688,120)">
+    <rect class="card" width="260" height="180" rx="3"></rect>
+    <text class="t-step t-cap-dim" x="20" y="30">Stage 03 · actuate</text>
+    <text class="t-stage t-stage-dark" x="20" y="58">Valve</text>
+    <text class="t-payload" x="20" y="92">final_action: 12s</text>
+    <text class="t-payload" x="20" y="112">esp32_outcome:</text>
+    <text class="t-payload" x="40" y="130">ACK · limited</text>
+    <text class="t-payload" x="20" y="156">why_short: tank cap</text>
+    <line class="hairline" x1="20" y1="166" x2="240" y2="166"></line>
+  </g>
+
+  
+  <g transform="translate(976,120)">
+    <rect class="card" width="172" height="180" rx="3"></rect>
+    <text class="t-step t-cap-dim" x="16" y="30">Receipt</text>
+    <text class="t-stage t-stage-dark" x="16" y="58" font-size="14px">DecisionReceipt</text>
+    <text class="t-payload" x="16" y="82" font-size="10px">candidate 30s</text>
+    <text class="t-payload" x="16" y="100" font-size="10px">final 12s</text>
+    <text class="t-payload" x="16" y="118" font-size="10px">limited by tank</text>
+    <line class="hairline" x1="16" y1="132" x2="156" y2="132"></line>
+    
+    <g transform="translate(16,148)">
+      <rect width="56" height="22" fill="none" stroke="#4F8A5B" stroke-width="1.4"></rect>
+      <text x="28" y="15" class="t-cap t-cap-ok" text-anchor="middle" font-size="9px">ACK</text>
+    </g>
+  </g>
+
+  
+  <line class="hairline" x1="32" y1="324" x2="1148" y2="324"></line>
+  <text class="t-eyebrow" x="32" y="346">Invariant · the model never touches the valve directly</text>
 </svg>


### PR DESCRIPTION
PR #2 del paquete landing-assets-v1 de Venation **+** fix crítico de bug visual detectado en la landing en vivo.

## Commits

1. **`1da3fe9` (Venation)** — SVGs nuevos alineados con paleta del proyecto:
   - `architecture_overview.svg` (1180×520): tres jurisdicciones FIELD / MOBILE / HOME, cards graphite donde corre Gemma con signal.seed dot, conectores etiquetados.
   - `authority_stack.svg` (1180×360): stack horizontal Gemma → ESP32 → valve con payloads reales del DecisionReceipt + invariante final.

2. **`407ef6e` (Cambium)** — fix crítico workflow Pages:
   - El workflow anterior solo subía `landing-demo/` al deploy. Los SVGs en `media/` salían **HTTP 404** en sprout.zigiella.com, y en la landing aparecían como **texto alt** en lugar de imágenes renderizadas (bug detectado por Bea al ver la landing en vivo).
   - Workflow ahora copia landing-demo/ + media/ a `_site/` antes del upload. Los SVGs serán accesibles en `/media/architecture_overview.svg` y `/media/authority_stack.svg`.
   - Trigger del workflow extendido a `media/**` (no solo landing-demo/**).
   - `text-wrap: pretty + max-width: 840px` en `.hero h1` (ajuste opcional propuesto por Venation en INSTRUCCIONES § opción A).

Tras merge, la landing en vivo mostrará los dos SVGs renderizados correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)