### PR TITLE
[landing] visual polish 5 fixes feedback Bea (contraste SVGs + terminal + APK btn + header)

### DIFF
--- a/landing-demo/css/style.css
+++ b/landing-demo/css/style.css
@@ -207,6 +207,53 @@ pre {
   line-height: 1.5;
 }
 
+/* --- Terminal-style output (Sprout contract simulator) --- */
+.terminal {
+  margin-top: 24px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #0e0e0c;
+  border: 1px solid rgba(243, 237, 228, 0.18);
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: #1a1a18;
+  border-bottom: 1px solid rgba(243, 237, 228, 0.12);
+}
+
+.terminal-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot-red    { background: #ff5f56; }
+.dot-amber  { background: #ffbd2e; }
+.dot-green  { background: #27c93f; }
+
+.terminal-label {
+  margin-left: 12px;
+  font-family: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 12px;
+  color: rgba(243, 237, 228, 0.55);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.terminal pre {
+  margin: 0;
+  border-radius: 0;
+  background: #0e0e0c;
+  padding: 20px 22px;
+  min-height: 200px;
+  border: 0;
+}
+
 /* --- Gemma split --- */
 .split {
   display: grid;

--- a/landing-demo/index.html
+++ b/landing-demo/index.html
@@ -25,7 +25,7 @@
 
 <header class="hero">
   <nav class="nav">
-    <span class="brand">Sprout</span>
+    <span class="brand">Sprout · project demo page</span>
     <a href="#truth">What is real</a>
     <a href="#demo">Demo</a>
     <a href="#gemma">Gemma 4</a>
@@ -88,7 +88,15 @@
       <p class="deep"><a href="try/meristem.html">Deep dive →</a></p>
     </article>
   </div>
-  <pre id="output">Click a node to inspect a contract.</pre>
+  <div class="terminal">
+    <div class="terminal-header">
+      <span class="terminal-dot dot-red"></span>
+      <span class="terminal-dot dot-amber"></span>
+      <span class="terminal-dot dot-green"></span>
+      <span class="terminal-label" id="terminal-label">SPROUT · contract simulator</span>
+    </div>
+    <pre id="output">Click a node above to inspect a real contract.</pre>
+  </div>
 </section>
 
 <section id="gemma" class="container split">
@@ -106,19 +114,17 @@
 
 <section id="safety" class="container safety">
   <h2>Safety &amp; Trust</h2>
-  <div class="safety-split">
-    <ol>
-      <li><strong>Physical layer prevails.</strong> The ESP32 firmware enforces five hard rules (<code>JETSON_HEARTBEAT_LOST</code>, <code>TANK_LOW</code>, <code>EVENT_DURATION_OUT_OF_RANGE</code>, <code>NO_FLOW_DETECTED</code>, <code>ALERT_LATCHED</code>). No LLM can weaken them.</li>
-      <li><strong>Every intelligence has jurisdiction.</strong> Rhizome arbitrates in minutes. Pollen mediates within visit TTL. Meristem refines in days.</li>
-      <li><strong>Every criterion expires.</strong> <code>MissionPatch</code>, <code>WeatherDigest</code> and <code>PolicyPacket</code> carry TTL or validity windows. Late objects are rejected, not silently obeyed.</li>
-      <li><strong>Refusal is a feature.</strong> When Pollen does not understand a voice instruction, it asks for rephrasing. When Rhizome sees an expired policy, it rejects. When the ESP32 detects an unsafe condition, it blocks.</li>
-      <li><strong>A second local voice audits without authority.</strong> <code>ShadowSkeptic</code> records objections inside Rhizome with <code>affects_decision=false</code>. Even skepticism has jurisdiction.</li>
-    </ol>
-    <figure class="diagram">
-      <img src="media/authority_stack.svg" alt="Authority stack: ESP32 prevails (physical), Rhizome arbitrates (minutes), Pollen mediates (visit TTL), Meristem refines (days)" loading="lazy">
-      <figcaption>The farther a node is from the water, the less physical authority it has. The ESP32 can always say no.</figcaption>
-    </figure>
-  </div>
+  <ol>
+    <li><strong>Physical layer prevails.</strong> The ESP32 firmware enforces five hard rules (<code>JETSON_HEARTBEAT_LOST</code>, <code>TANK_LOW</code>, <code>EVENT_DURATION_OUT_OF_RANGE</code>, <code>NO_FLOW_DETECTED</code>, <code>ALERT_LATCHED</code>). No LLM can weaken them.</li>
+    <li><strong>Every intelligence has jurisdiction.</strong> Rhizome arbitrates in minutes. Pollen mediates within visit TTL. Meristem refines in days.</li>
+    <li><strong>Every criterion expires.</strong> <code>MissionPatch</code>, <code>WeatherDigest</code> and <code>PolicyPacket</code> carry TTL or validity windows. Late objects are rejected, not silently obeyed.</li>
+    <li><strong>Refusal is a feature.</strong> When Pollen does not understand a voice instruction, it asks for rephrasing. When Rhizome sees an expired policy, it rejects. When the ESP32 detects an unsafe condition, it blocks.</li>
+    <li><strong>A second local voice audits without authority.</strong> <code>ShadowSkeptic</code> records objections inside Rhizome with <code>affects_decision=false</code>. Even skepticism has jurisdiction.</li>
+  </ol>
+  <figure class="diagram">
+    <img src="media/authority_stack.svg" alt="Authority stack: ESP32 prevails (physical), Rhizome arbitrates (minutes), Pollen mediates (visit TTL), Meristem refines (days)" loading="lazy">
+    <figcaption>The farther a node is from the water, the less physical authority it has. The ESP32 can always say no.</figcaption>
+  </figure>
 </section>
 
 <section id="get" class="container">
@@ -130,7 +136,7 @@
       <h3>Install the app, no model needed</h3>
       <p>~39 MB APK. Uses a deterministic mock evaluator. Runs on any Android emulator or device without downloading a 3 GB model. Walk through the UI, the voice path and refusal/retry flow.</p>
       <p>
-        <a class="btn primary" href="https://github.com/zigiella/sprout/raw/main/demo/pollen-demo.apk">Download <code>demo</code> APK</a>
+        <a class="btn primary" href="https://github.com/zigiella/sprout/raw/main/demo/pollen-demo.apk">Download demo APK</a>
       </p>
     </article>
     <article>

--- a/landing-demo/js/landing.js
+++ b/landing-demo/js/landing.js
@@ -3,9 +3,17 @@
 
 (function () {
   const output = document.getElementById('output');
+  const label = document.getElementById('terminal-label');
+
+  const labels = {
+    rhizome:  'RHIZOME · DecisionReceipt',
+    pollen:   'POLLEN · MissionPatch',
+    meristem: 'MERISTEM · PolicyPacket'
+  };
 
   const demos = {
     rhizome: async () => {
+      label.textContent = labels.rhizome;
       output.textContent = 'Rhizome reading local state...\n';
       const state = {
         soil_pct: 18,
@@ -17,6 +25,7 @@
     },
 
     pollen: async () => {
+      label.textContent = labels.pollen;
       output.textContent = 'Pollen compiling voice...\n';
       const transcript = "Vuelvo el viernes. Esta planta aguanta más seca de lo que crees, riega un poco menos.";
       const result = await pollenCompileMock(transcript);
@@ -24,6 +33,7 @@
     },
 
     meristem: async () => {
+      label.textContent = labels.meristem;
       output.textContent = 'Meristem evaluating bundle...\n';
       const bundle = {
         recent_decisions: [

--- a/media/architecture_overview.svg
+++ b/media/architecture_overview.svg
@@ -5,8 +5,8 @@
 
   <defs>
     <style>
-      .bg { fill: #1a1a18; }
-      .card-graphite { fill: #0e0e0c; stroke: rgba(243,237,228,0.12); stroke-width: 1; }
+      .bg { fill: #0e0e0c; }
+      .card-graphite { fill: #2a2a26; stroke: rgba(243,237,228,0.22); stroke-width: 1; }
       .card { fill: #fffaf2; stroke: #d8cec2; stroke-width: 1; }
       .t-eyebrow { font: 600 11px/1 'IBM Plex Mono', ui-monospace, monospace; fill: #c5f26b; letter-spacing: 0.14em; text-transform: uppercase; }
       .t-title { font: 700 28px/1.1 'Manrope', system-ui, sans-serif; fill: #f3ede4; }

--- a/media/authority_stack.svg
+++ b/media/authority_stack.svg
@@ -5,8 +5,8 @@
 
   <defs>
     <style>
-      .bg { fill: #1a1a18; }
-      .card-graphite { fill: #0e0e0c; stroke: rgba(243,237,228,0.12); stroke-width: 1; }
+      .bg { fill: #0e0e0c; }
+      .card-graphite { fill: #2a2a26; stroke: rgba(243,237,228,0.22); stroke-width: 1; }
       .card { fill: #fffaf2; stroke: #d8cec2; stroke-width: 1; }
       .t-eyebrow { font: 600 11px/1 'IBM Plex Mono', ui-monospace, monospace; fill: #c5f26b; letter-spacing: 0.14em; text-transform: uppercase; }
       .t-title { font: 700 28px/1.1 'Manrope', system-ui, sans-serif; fill: #f3ede4; }


### PR DESCRIPTION
5 ajustes visuales sobre la landing en vivo, según feedback de Bea:

1. **Cards graphite** en SVGs ahora se diferencian del fondo (bg #0e0e0c, cards #2a2a26 con stroke +visible).
2. **Authority stack** ancho completo en Safety section (quitado split layout).
3. **Output ahora con header terminal-style** (3 dots + label dinámico: RHIZOME · DecisionReceipt / POLLEN · MissionPatch / MERISTEM · PolicyPacket).
4. **Botón APK** sin `<code>` para que no rompa tipografía.
5. **Header**: `Sprout` → `Sprout · project demo page` (más descriptivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)