### PR TITLE
[fix] SVG authority_stack: contraste t-payload sobre cards claras

### DIFF
--- a/media/authority_stack.svg
+++ b/media/authority_stack.svg
@@ -13,12 +13,16 @@
       .t-stage { font: 700 14px/1 'Manrope', system-ui, sans-serif; }
       .t-stage-light { fill: #f3ede4; }
       .t-stage-dark { fill: #1a1a18; }
-      .t-payload { font: 500 11px/1.4 'IBM Plex Mono', ui-monospace, monospace; fill: rgba(243,237,228,0.72); }
+      .t-payload { font: 500 11px/1.4 'IBM Plex Mono', ui-monospace, monospace; fill: rgba(26,26,24,0.78); }
+      .t-payload-light { fill: rgba(243,237,228,0.92); }
+      .t-payload-dim { fill: rgba(243,237,228,0.55); }
+      .t-cap { font: 500 11px/1 'IBM Plex Mono', ui-monospace, monospace; fill: rgba(243,237,228,0.78); letter-spacing: 0.04em; }
+      .t-cap-dim { fill: rgba(243,237,228,0.55); }
       .hairline { stroke: rgba(243,237,228,0.18); stroke-width: 1; fill: none; }
       .rule-strong { stroke: #c5f26b; stroke-width: 2; fill: none; }
       .seed { fill: #c5f26b; }
-      .arrow { stroke: rgba(243,237,228,0.42); stroke-width: 1.5; fill: none; }
-      .arrow-tip { fill: rgba(243,237,228,0.6); }
+      .arrow { stroke: rgba(243,237,228,0.55); stroke-width: 1.5; fill: none; }
+      .arrow-tip { fill: rgba(243,237,228,0.65); }
     </style>
     <marker id="atip" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
       <path d="M0,0 L7,4.5 L0,9 z" class="arrow-tip"></path>


### PR DESCRIPTION
Bug visual: textos de Stage 02 / 03 / Receipt invisibles porque .t-payload por defecto era claro (asumi cards oscuras). Convencion implicita de Venation: .t-payload sin color por defecto, modificadores -light/-dim deciden.

Fix:
- .t-payload default ahora oscuro (para cards claras)
- .t-payload-light claro (Stage 01 propose, card oscura)
- .t-payload-dim tenue claro (Stage 01 etiquetas secundarias)
- .t-cap / .t-cap-dim añadidas (etiquetas sobre flechas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)