### PR TITLE
[readme] recuperar apartado Team + reforzar Language note (EN+ES)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -219,9 +219,44 @@ Mira el README de cada componente para setup completo.
 
 ---
 
+## Equipo
+
+**zigiella** — desarrolladora humana en solitario, trabajando con un equipo coordinado de agentes de IA especializados. Cada agente tiene un rol definido, una identidad escrita, y autoría git versionada.
+
+### Personas
+
+| Rol | Persona |
+|---|---|
+| Product owner · hardware · cámara · voz humana | **Bea** |
+| Cámara | **Ferran** |
+| Caja Rhizome en el muro · lector del diario | **El padre de Bea** |
+
+### Agentes IA
+
+| Rol | Identidad |
+|---|---|
+| Tech lead · coordinación · constitución | **Cambium** |
+| Dirección creativa · guion | **Corola** |
+| Dirección de arte · cartelas · diagramas | **Venation** |
+| Montaje · Remotion · CapCut · ElevenLabs | **Bract** |
+| Nodo Pollen · Android · LiteRT-LM · Gemma 4 E4B | **Floema** |
+| Firmware ESP32 · hard limits · capa de seguridad | **Xilema** |
+| Nodo Meristem · tuning · `llama.cpp` · Gemma 4 E4B | **Meristem** |
+| Nodo Rhizome · Jetson · `llama.cpp` · Gemma 4 E2B | **Endodermis** |
+
+La metodología — repo-first, bitácoras escritas como contratos vinculantes, autoría git con identidad inline, mensajes de inicio de día con plantilla `Interrelaciones` explícita — está documentada en [`CONTRIBUTING.md`](CONTRIBUTING.md) y discutida en el [writeup](writeup/draft.md).
+
+**Ubicaciones:** Castellar de n'Hug, Cataluña, España · Barcelona, Cataluña, España.
+
+---
+
 ## Nota sobre idioma
 
-Sprout se ha construido por un equipo que trabaja en castellano. Las puertas públicas son English-first o bilingües; las bitácoras internas y specs que evolucionan rápido se mantienen en castellano por diseño. Esto refleja la propia tesis del producto: la inteligencia local debe encontrarse con las personas en el idioma y contexto donde el trabajo ocurre de verdad.
+Sprout se ha construido por un equipo que trabaja en castellano. **Las puertas públicas (este README, el [writeup Kaggle](writeup/draft.md), la [guía de entrega](SUBMISSION.md), la [demo en vivo](https://sprout.zigiella.com), READMEs de nodos)** son English-first o bilingües. **Los artefactos internos (bitácoras, specs que evolucionan rápido, handoffs día a día, definiciones de rol de los agentes)** se mantienen en castellano por diseño — son evidencia del proceso de trabajo, no la interfaz pública.
+
+Esto refleja la propia tesis del producto: **la inteligencia local debe encontrarse con las personas en el idioma y contexto donde el trabajo ocurre de verdad**. Los contratos y código de Sprout son inspeccionables sin necesidad de castellano; el diario de desarrollo preserva el castellano en el que el sistema fue realmente construido.
+
+Si lees código o docs de nivel superior, el inglés te lleva a todas partes. Si quieres leer el proceso vivo, las bitácoras en castellano viven en `bitacora/`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -219,9 +219,44 @@ See each component README for full setup.
 
 ---
 
+## Team
+
+**zigiella** — solo human developer, working with a coordinated team of specialized AI agents. Each agent has a defined role, a written identity, and version-controlled git authorship.
+
+### Humans
+
+| Role | Person |
+|---|---|
+| Product owner · hardware · camera · human voice | **Bea** |
+| Camera | **Ferran** |
+| Rhizome box on the wall · daily journal reader | **Bea's father** |
+
+### AI agents
+
+| Role | Identity |
+|---|---|
+| Tech lead · coordination · constitution | **Cambium** |
+| Creative direction · script | **Corola** |
+| Art direction · cards · diagrams | **Venation** |
+| Editing · Remotion · CapCut · ElevenLabs | **Bract** |
+| Pollen node · Android · LiteRT-LM · Gemma 4 E4B | **Floema** |
+| ESP32 firmware · hard limits · safety layer | **Xilema** |
+| Meristem node · tuning · `llama.cpp` · Gemma 4 E4B | **Meristem** |
+| Rhizome node · Jetson · `llama.cpp` · Gemma 4 E2B | **Endodermis** |
+
+The methodology — repo-first, written bitácoras as binding contracts, identity-inline git authorship, day-start coordination messages with an explicit `Interrelaciones` template — is documented in [`CONTRIBUTING.md`](CONTRIBUTING.md) and discussed in the [writeup](writeup/draft.md).
+
+**Locations:** Castellar de n'Hug, Catalonia, Spain · Barcelona, Catalonia, Spain.
+
+---
+
 ## Language note
 
-Sprout was built by a Spanish-speaking team. Public entry points are English-first or bilingual; internal bitácoras and fast-moving specs remain in Spanish by design. This mirrors the product thesis: local intelligence should meet people in the language and context where work actually happens.
+Sprout was built by a Spanish-speaking team. **Public entry points (this README, the [Kaggle writeup](writeup/draft.md), the [submission guide](SUBMISSION.md), the [landing demo](https://sprout.zigiella.com), node READMEs)** are English-first or bilingual. **Internal artefacts (bitácoras, specs that evolve fast, day-by-day handoffs, agent role definitions)** remain in Spanish by design — they are evidence of the working process, not the public interface.
+
+This mirrors the product thesis itself: **local intelligence should meet people in the language and context where work actually happens**. Sprout's contracts and code are inspectable without Spanish context; the development journal preserves the Spanish in which the system was actually built.
+
+If you are reading code or top-level docs, English will get you everywhere. If you want to read the working process, Spanish bitácoras live in `bitacora/`.
 
 ---
 


### PR DESCRIPTION
Feedback Bea día 30: recuperar el apartado bonito de equipo del README + reforzar el disclaimer de idioma que la auditora apuntaba.

## README.md / README.es.md — nueva sección ## Team

- **Humans**: Bea, Ferran, Bea's father — con sus roles concretos.
- **AI agents**: tabla con los 8 agentes y sus roles canónicos (los del video credits): Cambium, Corola, Venation, Bract, Floema, Xilema, Meristem, Endodermis.
- Apunta a la metodología (CONTRIBUTING + writeup).
- Locations explícitas.

## Language note reforzada

- Lista explícita de qué se mantiene en castellano (bitácoras, specs rápidas, handoffs, definiciones de agentes).
- Lista explícita de qué se traduce a inglés (README, writeup, SUBMISSION, landing, READMEs de nodos).
- Frase de cierre orientativa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)