### PR TITLE
[readmes-nodos] abstract EN jetson + Note on language disclaimer en los 5

### DIFF
--- a/code/meristem_node/README.md
+++ b/code/meristem_node/README.md
@@ -69,3 +69,10 @@ cierra día 16.
 - `draft_system_prompt_meristem_es.md` — borrador del prompt
 - `verify_tool_calling.py` — test que validó tool calling con llama.cpp
 - `bitacora/2026-04-29_rhizome-v05-completo-y-tool-calling-validado_meristem.md`
+
+
+---
+
+## Note on language
+
+The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.

--- a/code/pollen/README.md
+++ b/code/pollen/README.md
@@ -135,3 +135,10 @@ Material de bitácora relevante:
 - `bitacora/2026-05-01_litertlm-pixel10pro-compatibility_floema.md` — validación Pixel 10 Pro.
 - `bitacora/2026-05-12_PR-voice-beta-final_floema.md` — descripción consolidada del PR voice-beta-final.
 - `research/04_litertlm_thinking_pt1.md`, `pt2`, `digest` — investigación comparativa LiteRT-LM vs MediaPipe.
+
+
+---
+
+## Note on language
+
+The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -405,3 +405,10 @@ Campos de trazabilidad:
   }
 }
 ```
+
+
+---
+
+## Note on language
+
+The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -1,5 +1,9 @@
 # Rhizome Jetson Runtime
 
+**Abstract.** Operational scripts to launch Gemma 4 E2B on Jetson Orin Nano Super with `llama.cpp`, independently of Ollama and the ESP32 hardware. These scripts handle local inference runtime and an Ollama-compatible adapter only — they never touch firmware, sensors, actuators or physical rules. The package also includes a read-only HTTP facade that lets Pollen talk to a real Jetson IP. Two profiles are documented: `safe-cpu` (contractual, validated in 18/18 prompt battery) and `gpu-experimental` (36/36 layers offloaded, quality not yet contractual). `ShadowSkeptic` runs by default as a non-binding dual-agent experiment with `affects_decision=false`.
+
+---
+
 Scripts operativos para arrancar Gemma 4 E2B en Jetson Orin Nano Super con
 `llama.cpp` sin depender de Ollama ni de hardware ESP32.
 
@@ -439,3 +443,10 @@ GEMMA_RATIONALE_URL=http://127.0.0.1:12000 ./run_steward_once.sh
 El `ShadowSkeptic` se ejecuta por defecto como experimento de doble agente
 no vinculante. Sus observaciones se guardan en `shadow_skeptic/YYYY-MM-DD.jsonl`
 y siempre llevan `affects_decision=false`.
+
+
+---
+
+## Note on language
+
+The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../../README.md#language-note) for the project-wide policy.

--- a/hardware/firmware_esp32/README.md
+++ b/hardware/firmware_esp32/README.md
@@ -323,3 +323,10 @@ Si el puerto USB no enumera a la primera en un S3 nuevo:
 - Espressif, `SPI Flash and External SPI RAM Configuration`, leída el `2026-04-25`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-guides/flash_psram_config.html
 - Espressif, `I2C Master Driver`, leída el `2026-04-27`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/peripherals/i2c.html
 - Bosch Sensortec, `BME280_SensorAPI`, commit `c90d419492e26dd95586598a794e65eb2760753a`, leído el `2026-04-27`: https://github.com/boschsensortec/BME280_SensorAPI
+
+
+---
+
+## Note on language
+
+The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.


### PR DESCRIPTION
Pasada final READMEs nodos día 30.

- `code/rhizome/jetson/README.md`: añadido abstract EN al top (era el único que no lo tenía).
- Los 5 READMEs de nodos ahora tienen `## Note on language` al final con disclaimer claro: el abstract EN al top es el resumen canónico público; el cuerpo sigue en castellano por diseño (idioma de trabajo del equipo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)