### PR TITLE
docs(readmes): full EN translation of 5 node READMEs + code index

### DIFF
--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -391,6 +391,7 @@ Co-Authored-By: Cambium <cambium@sprout.local>
 - **Nunca** reescribir historia para cambiar autoria en commits viejos. Si se subio algo con identidad equivocada, se corrige de aqui en adelante; el historial se respeta.
 - **Nunca** usar `--global` al configurar estas identidades. Son locales al repo.
 - Al clonar el repo por primera vez, configurar identidad es **el primer paso**, antes del primer commit.
+- **No incluir trailers `Co-Authored-By:` de proveedores de IA terceros** (Claude, ChatGPT, Copilot, etc.) en los mensajes de commit. La autoria en Sprout vive en las identidades `*@sprout.local` del equipo. Si una agente esta usando un modelo provisto por un proveedor terceros, esa relacion se documenta en el rol del agente (`docs/roles/`) o en la bitacora, no en los trailers de git. Mantiene limpio el grafo de Contributors de GitHub.
 
 ### 11.1 Multi-agente sobre el mismo clone
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
 
 > **Sprout es una red de decisión acotada por seguridad para el agua bajo ausencia.**
 
-[Ver el vídeo de 3 minutos](https://www.youtube.com/watch?v=D9ETS4EPnxI) · [Probar la demo pública de contratos](https://sprout.zigiella.com) · [Leer el writeup Kaggle](writeup/draft.md) · [Guía de entrega](SUBMISSION.md)
+[Ver el vídeo de 3 minutos](https://www.youtube.com/watch?v=D9ETS4EPnxI) · [Probar la demo pública de contratos](https://sprout.zigiella.com) · [Leer el writeup](writeup/draft.md) · [Guía de entrega](SUBMISSION.md)
 
 ---
 
@@ -127,6 +127,8 @@ Sprout usa Gemma 4 de formas concretas y específicas por nodo:
 
 Probamos configuraciones de prompt y runtime antes de congelar la ruta de demo: tamaño de contexto, presupuesto de output, comportamiento de thinking y estabilidad de salida estructurada. Un hallazgo útil fue que la latencia a menudo seguía a lo que el modelo escribía, no solo a lo que leía. Presupuestos de output más cortos mejoraron la usabilidad cuando el contrato se mantuvo estable.
 
+Las notas completas de evaluación, los experimentos de runtime por nodo y las fuentes consultadas viven en [`research/`](research/) — incluyendo el comportamiento de la ventana de contexto de Gemma 4 en Ollama, el profiling sobre Jetson Orin Nano Super, la migración a LiteRT-LM en Pixel 10 Pro y la estrategia de localización de idioma para Pollen.
+
 ---
 
 ## Demo en vivo
@@ -167,7 +169,7 @@ cd code/pollen
 ./gradlew testDemoDebugUnitTest
 ```
 
-Instala el APK demo desde `demo/` o compila en local. El flavor demo usa inferencia determinista para que funcione sin un archivo de modelo de 3 GB.
+El flavor demo usa inferencia mock determinista, así que funciona sin un archivo de modelo de 3 GB. Instala en cualquier Android 12+ (físico o emulador) con `adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk`.
 
 ### Pollen flavor device con Gemma 4 E4B
 
@@ -206,7 +208,7 @@ Mira el README de cada componente para setup completo.
 | Path | Propósito |
 |---|---|
 | `SUBMISSION.md` | Camino rápido para evaluación: enlaces, evidencia, qué es real vs contrato |
-| `writeup/` | Writeup Kaggle y notas de apoyo |
+| `writeup/` | Writeup del proyecto y notas de apoyo |
 | `landing-demo/` | Demo pública determinista de contratos |
 | `code/rhizome/` | Nodo de parcela Jetson, bucle de decisión local, fachada de sync |
 | `code/pollen/` | Nodo móvil Android, ruta LiteRT-LM, voz → MissionPatch |
@@ -252,7 +254,7 @@ La metodología — repo-first, bitácoras escritas como contratos vinculantes, 
 
 ## Nota sobre idioma
 
-Sprout se ha construido por un equipo que trabaja en castellano. **Las puertas públicas (este README, el [writeup Kaggle](writeup/draft.md), la [guía de entrega](SUBMISSION.md), la [demo en vivo](https://sprout.zigiella.com), READMEs de nodos)** son English-first o bilingües. **Los artefactos internos (bitácoras, specs que evolucionan rápido, handoffs día a día, definiciones de rol de los agentes)** se mantienen en castellano por diseño — son evidencia del proceso de trabajo, no la interfaz pública.
+Sprout se ha construido por un equipo que trabaja en castellano. **Las puertas públicas (este README, el [writeup](writeup/draft.md), la [guía de entrega](SUBMISSION.md), la [demo en vivo](https://sprout.zigiella.com), READMEs de nodos)** son English-first o bilingües. **Los artefactos internos (bitácoras, specs que evolucionan rápido, handoffs día a día, definiciones de rol de los agentes)** se mantienen en castellano por diseño — son evidencia del proceso de trabajo, no la interfaz pública.
 
 Esto refleja la propia tesis del producto: **la inteligencia local debe encontrarse con las personas en el idioma y contexto donde el trabajo ocurre de verdad**. Los contratos y código de Sprout son inspeccionables sin necesidad de castellano; el diario de desarrollo preserva el castellano en el que el sistema fue realmente construido.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > **Sprout is a safety-bounded decision network for water under absence.**
 
-[Watch the 3-minute video](https://www.youtube.com/watch?v=D9ETS4EPnxI) · [Try the live contract demo](https://sprout.zigiella.com) · [Read the Kaggle writeup](writeup/draft.md) · [Submission guide](SUBMISSION.md)
+[Watch the 3-minute video](https://www.youtube.com/watch?v=D9ETS4EPnxI) · [Try the live contract demo](https://sprout.zigiella.com) · [Read the writeup](writeup/draft.md) · [Submission guide](SUBMISSION.md)
 
 ---
 
@@ -127,6 +127,8 @@ Sprout uses Gemma 4 in concrete, node-specific ways:
 
 We tested prompt and runtime configurations before freezing the demo path: context window, output budget, thinking behavior and structured-output stability. One useful finding was that latency often followed what the model wrote, not only what it read. Shorter output budgets improved usability when the contract stayed stable.
 
+Full evaluation notes, runtime experiments by node and source references live in [`research/`](research/) — including Gemma 4 context-window behavior on Ollama, Jetson Orin Nano Super profiling, LiteRT-LM migration on Pixel 10 Pro, and the language-localization strategy for Pollen.
+
 ---
 
 ## Live demo
@@ -167,7 +169,7 @@ cd code/pollen
 ./gradlew testDemoDebugUnitTest
 ```
 
-Install the demo APK from `demo/` or build locally. The demo flavor uses deterministic inference so it runs without a 3GB model file.
+The demo flavor uses deterministic mock inference, so it runs without a 3 GB model file. Install on any Android 12+ device or emulator with `adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk`.
 
 ### Pollen device flavor with Gemma 4 E4B
 
@@ -206,7 +208,7 @@ See each component README for full setup.
 | Path | Purpose |
 |---|---|
 | `SUBMISSION.md` | Fast path for evaluation: links, proof, what is real vs contract |
-| `writeup/` | Kaggle writeup and supporting notes |
+| `writeup/` | Project writeup and supporting notes |
 | `landing-demo/` | Public deterministic contract demo |
 | `code/rhizome/` | Jetson plot node, local decision loop, sync facade |
 | `code/pollen/` | Android mobile node, LiteRT-LM path, voice → MissionPatch |
@@ -252,7 +254,7 @@ The methodology — repo-first, written bitácoras as binding contracts, identit
 
 ## Language note
 
-Sprout was built by a Spanish-speaking team. **Public entry points (this README, the [Kaggle writeup](writeup/draft.md), the [submission guide](SUBMISSION.md), the [landing demo](https://sprout.zigiella.com), node READMEs)** are English-first or bilingual. **Internal artefacts (bitácoras, specs that evolve fast, day-by-day handoffs, agent role definitions)** remain in Spanish by design — they are evidence of the working process, not the public interface.
+Sprout was built by a Spanish-speaking team. **Public entry points (this README, the [writeup](writeup/draft.md), the [submission guide](SUBMISSION.md), the [landing demo](https://sprout.zigiella.com), node READMEs)** are English-first or bilingual. **Internal artefacts (bitácoras, specs that evolve fast, day-by-day handoffs, agent role definitions)** remain in Spanish by design — they are evidence of the working process, not the public interface.
 
 This mirrors the product thesis itself: **local intelligence should meet people in the language and context where work actually happens**. Sprout's contracts and code are inspectable without Spanish context; the development journal preserves the Spanish in which the system was actually built.
 

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -13,8 +13,8 @@
 | **Landing demo** | https://sprout.zigiella.com |
 | **Repository** | https://github.com/zigiella/sprout |
 | **Writeup** | [`writeup/draft.md`](writeup/draft.md) (1467 words, also submitted as Kaggle draft) |
-| **Pollen demo APK** | [`demo/pollen-demo.apk`](demo/pollen-demo.apk) (~39 MB, mock LiteRT inference, no model needed) |
-| **Pollen Venation UI APK** | [`demo/pollen-venation-ui.apk`](demo/pollen-venation-ui.apk) (~58 MB, polished UI, no device LiteRT model) |
+| **Pollen demo build** | `cd code/pollen && ./gradlew assembleDemoDebug` — mock LiteRT inference, no 3 GB model needed |
+| **Pollen device build** | `cd code/pollen && ./gradlew assembleDeviceRelease` — real Gemma 4 E4B via LiteRT-LM, model side-loaded with `adb push` |
 | **License** | Apache 2.0 |
 | **Gemma 4 attribution** | *Sprout uses Gemma 4 models by Google. Gemma is a trademark of Google LLC. This project is not affiliated with or endorsed by Google.* |
 
@@ -84,7 +84,15 @@ make test   # runs deterministic tests + LLM smoke
 
 ### Pollen on Android — demo flavor (no model needed)
 
-Install [`demo/pollen-demo.apk`](demo/pollen-demo.apk) on any Android 12+ device or emulator. Mock LiteRT inference — walks through the UI without needing a 3 GB model on disk.
+Build the demo flavor and install it on any Android 12+ device or emulator:
+
+```bash
+cd code/pollen
+./gradlew assembleDemoDebug
+adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk
+```
+
+Mock LiteRT inference — walks through the UI without needing a 3 GB model on disk.
 
 ### Pollen on Android — device flavor (real Gemma 4 E4B via LiteRT-LM)
 
@@ -124,7 +132,7 @@ If you have **30 minutes**:
 4. Read [`docs/01_architecture.md`](docs/01_architecture.md) for the three-node design.
 5. Read [`docs/30_safety_rules.md`](docs/30_safety_rules.md) for the ESP32 hard limits.
 6. Run `make test` in `code/meristem_node/` to see the deterministic evaluator + LLM smoke pass.
-7. Install [`demo/pollen-demo.apk`](demo/pollen-demo.apk) on a phone or emulator.
+7. Build and install the Pollen demo flavor: `cd code/pollen && ./gradlew assembleDemoDebug && adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk`.
 
 If you have **2 hours and want to scrutinize**:
 

--- a/code/README.md
+++ b/code/README.md
@@ -1,53 +1,53 @@
 # code/
 
-Todo el software de Sprout. Cada subproyecto tiene su propio README con dependencias, como correr, como probar.
+All Sprout software. Each subproject has its own README with dependencies, how to run, and how to test.
 
-## Subproyectos
+## Subprojects
 
-| Carpeta | Que es | Lenguaje | Target | Responsable |
-|---------|--------|----------|--------|-------------|
-| `rhizome/` | Nodo edge en parcela | Python 3.11 | Jetson Orin Nano Super | Dev Rhizome + especialista |
-| `pollen/` | Nodo itinerante | Kotlin (Android) | Pixel 10 Pro | Dev Pollen |
-| `meristem/` | Nodo estrategico local | Python 3.11 | Portatil (Mac mini en futuro) | Dev Meristem |
-| `simulator/` | Visualizacion de red (2/4/8 nodos) | Python / web | navegador | flexible |
-| `shared/` | Schemas JSON + protocolos comunes | JSON + pydantic + kotlinx | ambos | coordinado |
-| `finetune/` | Fine-tuning Unsloth de Gemma 4 E2B | Python / notebooks | Colab | Dev Meristem |
+| Folder | What it is | Language | Target | Owner |
+|--------|------------|----------|--------|-------|
+| `rhizome/` | Plot edge node | Python 3.11 | Jetson Orin Nano Super | Dev Rhizome + specialist |
+| `pollen/` | Roaming node | Kotlin (Android) | Pixel 10 Pro | Dev Pollen |
+| `meristem/` | Local strategic node | Python 3.11 | Laptop (Mac mini in the future) | Dev Meristem |
+| `simulator/` | Network visualization (2/4/8 nodes) | Python / web | browser | flexible |
+| `shared/` | JSON schemas + common protocols | JSON + pydantic + kotlinx | both | coordinated |
+| `finetune/` | Unsloth fine-tuning of Gemma 4 E2B | Python / notebooks | Colab | Dev Meristem |
 
-## Flujos de datos entre subproyectos
+## Data flow between subprojects
 
 ```
-Rhizome  <--BLE/WiFi Direct-->  Pollen  <--WiFi local / cloud opportunistic-->  Meristem
+Rhizome  <--BLE/WiFi Direct-->  Pollen  <--local WiFi / opportunistic cloud-->  Meristem
    |                                                                                |
-   +------------------- todos consumen y producen schemas de shared/ ---------------+
+   +------------------ all consume and produce schemas from shared/ ----------------+
 ```
 
-## Pre-requisitos comunes
+## Common prerequisites
 
 - Python 3.11+
-- Ollama instalado y corriendo (`ollama pull gemma4:e4b` minimo para Meristem)
-- Android Studio (solo para Pollen)
-- JetPack 6.x en Jetson (solo para Rhizome)
+- Ollama installed and running (`ollama pull gemma4:e4b` minimum for Meristem)
+- Android Studio (only for Pollen)
+- JetPack 6.x on the Jetson (only for Rhizome)
 
-## Variables de entorno
+## Environment variables
 
-Ver `.env.example` en cada subproyecto. **Nunca** commitear `.env` real.
+See `.env.example` in each subproject. **Never** commit a real `.env`.
 
-Variable relevante para todos:
-- `SHADOW_ENABLED=false` por defecto (activa Meristem sombra solo en desarrollo)
+Relevant variable across all subprojects:
+- `SHADOW_ENABLED=false` by default (only enable shadow Meristem in development)
 
-Solo si `SHADOW_ENABLED=true`:
-- `GEMINI_API_KEY=<tu-key-de-aistudio.google.com/apikey>`
+Only if `SHADOW_ENABLED=true`:
+- `GEMINI_API_KEY=<your-key-from-aistudio.google.com/apikey>`
 
-## Como correr el sistema completo localmente (fase madura)
+## How to run the full system locally (mature phase)
 
 ```bash
 # Terminal 1: Meristem
 cd code/meristem && python -m src.main
 
-# Terminal 2: Rhizome (o en el Jetson)
+# Terminal 2: Rhizome (or on the Jetson)
 cd code/rhizome && python -m src.main
 
-# Movil: instalar APK de pollen/ en el Pixel 10 Pro
+# Mobile: install the Pollen APK on the Pixel 10 Pro
 ```
 
-Detalle en los READMEs de cada subproyecto.
+Detail in each subproject's README.

--- a/code/meristem_node/README.md
+++ b/code/meristem_node/README.md
@@ -4,75 +4,62 @@
 
 ---
 
-## Qué es
+## What it is
 
-El "cerebro lento doméstico" del ecosistema Sprout. Vive en un portátil
-casero del agricultor (no en data center, no en hardware especializado).
-Recibe bundles que Pollen trae de cada visita a Rhizome (snapshot +
-DecisionReceipts + WeatherDigest + ValidationStamps), evalúa, y emite
-un `PolicyPacket` actualizado para que Pollen lleve a Rhizome en la
-próxima visita.
+The "slow domestic brain" of the Sprout ecosystem. It lives on the farmer's home laptop (not a data centre, not specialised hardware). It receives bundles Pollen carries from each visit to a Rhizome (snapshot + DecisionReceipts + WeatherDigest + ValidationStamps), evaluates them, and emits an updated `PolicyPacket` for Pollen to carry back to the Rhizome on the next visit.
 
-Jerarquía explícita del sistema (invariante adoptada review día 13):
-*"lo físico manda → Rhizome arbitra → Pollen media → **Meristem afina**"*.
+The system's explicit hierarchy (invariant adopted in day-13 review):
+*"physical layer prevails → Rhizome arbitrates → Pollen mediates → **Meristem refines**"*.
 
 ## Stack
 
-- **FastAPI** + Pydantic + SQLite (file-based, sin servicios extra)
-- **Inferencia**: cliente al `meristem_inference_adapter` con backend
-  `llamacpp` extendido. Modelo: **Gemma 4 E4B Q4_K_M (~5 GB)** sobre
-  `llama-server` local.
-- **Tool calling Gemma 4** confirmado funcional día 14 (ver
-  `verify_tool_calling.py`).
+- **FastAPI** + Pydantic + SQLite (file-based, no extra services)
+- **Inference**: a client to `meristem_inference_adapter` with an extended `llamacpp` backend. Model: **Gemma 4 E4B Q4_K_M (~5 GB)** running over a local `llama-server`.
+- **Gemma 4 tool calling** confirmed functional on day 14 (see `verify_tool_calling.py`).
 
 ## Endpoints
 
 ```
-POST /visit              → Pollen entrega bundle, recibe PolicyPacket
-GET  /policy/latest      → consulta última policy emitida (debug/demo)
-GET  /policy/{policy_id} → consulta policy por id (trazabilidad)
-GET  /health             → estado + métricas
-GET  /docs               → OpenAPI/Swagger automático
+POST /visit              → Pollen delivers a bundle, receives a PolicyPacket
+GET  /policy/latest      → query the latest emitted policy (debug/demo)
+GET  /policy/{policy_id} → query a policy by id (traceability)
+GET  /health             → status + metrics
+GET  /docs               → automatic OpenAPI / Swagger
 ```
 
-## Capas (ver ARCHITECTURE.md)
+## Layers (see ARCHITECTURE.md)
 
 ```
 HTTP Layer (FastAPI)
-  ↓ IngestService     (validación + persistencia bundle)
-  ↓ Evaluator         (4 reglas determinísticas + LLM rationale)
-  ↓ PolicyComposer    (construye PolicyPacket válido)
+  ↓ IngestService     (bundle validation + persistence)
+  ↓ Evaluator         (4 deterministic rules + LLM rationale)
+  ↓ PolicyComposer    (builds a valid PolicyPacket)
   ↓ Persistence       (SQLite: bundles + policies + decisions)
 ```
 
-**Decisión crítica**: la decisión NO la toma el LLM. Lógica determinista
-con 4 reglas (CONFIRM, CONSERVATIVE, ALERT, REFUSE). El LLM solo
-escribe `rationale` (técnico + prosa amable al operador). Aísla riesgo
-de drift del modelo de la jerarquía de seguridad.
+**Critical decision**: the decision is NOT made by the LLM. Deterministic logic with 4 rules (CONFIRM, CONSERVATIVE, ALERT, REFUSE). The LLM only writes the `rationale` (technical + operator-friendly prose). This isolates model-drift risk from the safety hierarchy.
 
-## Cómo correr (día 14, stub)
+## How to run (day 14, stub)
 
 ```bash
 cd code/meristem_node
 pip install -r requirements.txt
 python -m src.main
-# levanta en http://127.0.0.1:13000
-# /docs disponible
+# starts on http://127.0.0.1:13000
+# /docs available
 ```
 
-Endpoints todavía devuelven respuestas stubeadas día 14. Lógica real
-cierra día 16.
+Endpoints still return stubbed responses on day 14. Real logic closed on day 16.
 
-## Referencias
+## References
 
-- `ARCHITECTURE.md` — diseño por capas + flujo end-to-end + mini-batería
-- `draft_system_prompt_meristem_es.md` — borrador del prompt
-- `verify_tool_calling.py` — test que validó tool calling con llama.cpp
+- `ARCHITECTURE.md` — layered design + end-to-end flow + mini-battery
+- `draft_system_prompt_meristem_es.md` — system prompt draft
+- `verify_tool_calling.py` — test that validated tool calling with llama.cpp
 - `bitacora/2026-04-29_rhizome-v05-completo-y-tool-calling-validado_meristem.md`
-
 
 ---
 
 ## Note on language
 
-The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.
+This README is English-first. Internal bitácoras (Spanish-language working journals) and the day-by-day development trace live under [`bitacora/`](../../bitacora/). See the [Language note in the root README](../../README.md#language-note) for the project-wide policy.

--- a/code/pollen/README.md
+++ b/code/pollen/README.md
@@ -1,66 +1,65 @@
 # pollen/
 
-**Abstract:**
-Pollen is the mobile edge-node of the Sprout agricultural ecosystem, built as an Android application for Pixel 10 Pro. It operates as the "roaming brain" of the farm, acting as an offline bridge between the central Meristem server and the remote Rhizome micro-controllers. Pollen handles synchronous data transport via local HTTP APIs and relies entirely on on-device LLM inference using the cutting-edge Gemma 4 E4B model. By integrating native `16kHz .wav` audio capturing with Google's `LiteRT-LM` framework, Pollen enables multi-modal, natural language interactions with farm operators directly in the field, with zero reliance on cloud connectivity. It validates agricultural policies, records field observations, and evaluates complex voice commands deterministically before syncing back to the base station.
+**Abstract.** Pollen is the mobile edge-node of the Sprout agricultural ecosystem, built as an Android application for the Pixel 10 Pro. It operates as the "roaming brain" of the farm, acting as an offline bridge between the home Meristem server and the field Rhizome plot nodes. Pollen handles synchronous data transport via local HTTP APIs and relies entirely on on-device LLM inference using Gemma 4 E4B. By integrating native 16 kHz `.wav` audio capture with Google's `LiteRT-LM` framework, Pollen enables multimodal, natural-language interactions with farm operators directly in the field with **zero reliance on cloud connectivity**. It validates agricultural policies, records field observations, and evaluates voice commands deterministically before syncing back to the base station.
 
-**Build Flavors:**
-- **`demo` flavor:** Uses a deterministic mock evaluator to simulate model decisions instantly. Ideal for UI testing, fast iteration, and simulator deployments without requiring heavy model downloads or specific hardware.
-- **`device` flavor:** The production-ready hardware path. Integrates the real `LiteRT-LM` pipeline bound to an on-device Gemma 4 E4B model. Requires Android 12+ (API 31+) and a device with NPU/GPU capabilities for interactive generation speeds.
+**Build flavors:**
+- **`demo` flavor** — Uses a deterministic mock evaluator to simulate model decisions instantly. Ideal for UI testing, fast iteration, and emulator deployments without requiring heavy model downloads or specific hardware.
+- **`device` flavor** — The production-ready hardware path. Integrates the real `LiteRT-LM` pipeline bound to an on-device Gemma 4 E4B model. Requires Android 12+ (API 31+) and a device with NPU/GPU capabilities for interactive generation speeds.
 
 ---
 
-Aplicación Android para el Pixel 10 Pro. Es el **nodo itinerante** del sistema Sprout.
+Android application for the Pixel 10 Pro. Pollen is the **roaming node** of the Sprout system.
 
-## Rol
+## Role
 
-- Sync local con Rhizome vía **HTTP polling** sobre WiFi (Rhizome expone fachada HTTP de lectura en el Jetson).
-- Inferencia on-device con **Gemma 4 E4B vía LiteRT-LM** (Google AI Edge), con **audio multimodal nativo**: la app graba `.wav` 16 kHz desde el micrófono y lo inyecta directamente al modelo sin pipeline STT separado.
-- Compilación de la intención humana en un `MissionPatch` estructurado con caducidad.
-- Validación cruzada (`ValidationStamp`) del estado de Rhizome contra la observación directa del operario.
-- Transporte físico de contexto (`WeatherDigest`, `MissionPatch`) hacia Meristem entre visitas.
+- Local sync with Rhizome via **HTTP polling** over WiFi (Rhizome exposes a read-only HTTP facade on the Jetson).
+- On-device inference with **Gemma 4 E4B via LiteRT-LM** (Google AI Edge), with **native multimodal audio**: the app records `.wav` at 16 kHz from the microphone and feeds it directly to the model, bypassing a separate STT pipeline.
+- Compilation of human intent into a structured `MissionPatch` with expiry.
+- Cross-validation (`ValidationStamp`) of Rhizome state against direct operator observation.
+- Physical transport of context (`WeatherDigest`, `MissionPatch`) to Meristem between visits.
 
-Detalle completo en [`docs/11_pollen_spec.md`](../../docs/11_pollen_spec.md).
+Full detail in [`docs/11_pollen_spec.md`](../../docs/11_pollen_spec.md).
 
 ## Stack
 
-- **Kotlin** + Jetpack Compose para UI.
-- **LiteRT-LM Android** (`com.google.ai.edge.litertlm:litertlm-android`) para inferencia Gemma 4 E4B con audio multimodal.
-- **`kotlinx.serialization`** para los schemas JSON (compartidos con `code/shared/schemas/`).
-- **Ktor / OkHttp** para HTTP polling contra Rhizome y Meristem.
+- **Kotlin** + Jetpack Compose for the UI.
+- **LiteRT-LM Android** (`com.google.ai.edge.litertlm:litertlm-android`) for Gemma 4 E4B inference with multimodal audio.
+- **`kotlinx.serialization`** for JSON schemas (shared with `code/shared/schemas/`).
+- **Ktor / OkHttp** for HTTP polling against Rhizome and Meristem.
 
 ## Build flavors
 
-La app se construye en dos flavors distintos:
+The app builds in two distinct flavors:
 
-| Flavor | Para qué | Inferencia | Modelo requerido | APK |
-|--------|----------|------------|------------------|-----|
-| **`demo`** | Emulador, dispositivos sin recursos, walkthrough de la UI sin modelo | Mock LiteRT determinista | Ninguno | `./gradlew assembleDemoDebug` |
-| **`device`** | Pixel 10 Pro u otro Android 12+ real, con Gemma 4 E4B local | LiteRT-LM real | `gemma-4-E4B-it.litertlm` (3,6 GB) side-loaded vía ADB | Build local |
+| Flavor | Use case | Inference | Model required | Build |
+|--------|----------|-----------|----------------|-------|
+| **`demo`** | Emulator, low-resource devices, UI walkthrough without a model | Deterministic mock LiteRT | None | `./gradlew assembleDemoDebug` |
+| **`device`** | Pixel 10 Pro or any Android 12+ device with local Gemma 4 E4B | Real LiteRT-LM | `gemma-4-E4B-it.litertlm` (3.6 GB) side-loaded via ADB | Local build |
 
-La separación vive en `app/src/demo/.../llm/LiteRtInfra.kt` (mock) vs `app/src/device/.../llm/LiteRtInfra.kt` (real LiteRT-LM con `sendAudioFile()`).
+The split lives in `app/src/demo/.../llm/LiteRtInfra.kt` (mock) vs `app/src/device/.../llm/LiteRtInfra.kt` (real LiteRT-LM with `sendAudioFile()`).
 
-## Cómo probar el device build con Gemma 4 E4B real
+## How to run the device build with real Gemma 4 E4B
 
-1. **Compilar** el variant `deviceRelease` desde `code/pollen/`:
+1. **Build** the `deviceRelease` variant from `code/pollen/`:
    ```bash
    ./gradlew assembleDeviceRelease
    ```
-2. **Descargar el modelo** compatible con LiteRT-LM (`gemma-4-E4B-it.litertlm`) desde Kaggle o HuggingFace.
-3. **Side-loadear el modelo** vía ADB:
+2. **Download the model** compatible with LiteRT-LM (`gemma-4-E4B-it.litertlm`) from Kaggle or HuggingFace.
+3. **Side-load the model** via ADB:
    ```bash
    adb push gemma-4-E4B-it.litertlm /data/local/tmp/gemma-4-E4B-it.litertlm
    ```
-4. **Instalar el APK** y abrir la app. En el primer arranque, en la pantalla **"Download Manager"**:
-   - Pulsa **"Saltar (ya tengo el modelo en dispositivo)"**.
-   - Confirma la ruta `/data/local/tmp/gemma-4-E4B-it.litertlm` (o cámbiala si lo subiste a otro lado).
-   - Pulsa **"Confirmar"**.
-5. **Permisos**: la app solicitará permiso de micrófono para procesar comandos de voz. Acéptalo para probar el flujo audio → `MissionPatch`.
+4. **Install the APK** and open the app. On first run, on the **"Download Manager"** screen:
+   - Tap **"Skip (model already on device)"**.
+   - Confirm the path `/data/local/tmp/gemma-4-E4B-it.litertlm` (or change it if you pushed elsewhere).
+   - Tap **"Confirm"**.
+5. **Permissions**: the app will request microphone access to process voice commands. Accept it to test the audio → `MissionPatch` flow.
 
-Requisitos del dispositivo:
+Device requirements:
 - Android 12 / API 31+
-- 12 GB RAM recomendado, 16 GB ideal
-- Al menos 6 GB libres en almacenamiento
-- CPU runtime es la ruta estable; el rendimiento GPU/NPU varía por dispositivo
+- 12 GB RAM recommended, 16 GB ideal
+- At least 6 GB free storage
+- CPU runtime is the stable path; GPU/NPU performance varies by device
 
 ## Structure (real, post-day-27)
 
@@ -69,76 +68,75 @@ pollen/
 ├── README.md
 ├── build.gradle.kts
 ├── settings.gradle.kts
-├── gradlew + gradle/wrapper/   # Gradle 9.3.1 vía wrapper
+├── gradlew + gradle/wrapper/   # Gradle 9.3.1 via wrapper
 └── app/
-    ├── build.gradle.kts        # flavors demo + device
+    ├── build.gradle.kts        # demo + device flavors
     └── src/
         ├── main/kotlin/net/sprout/pollen/
         │   ├── MainActivity.kt
         │   ├── voice/          # PollenVoiceInfra.kt + AudioClipRecorder.kt
-        │   ├── llm/            # SystemPrompts (real engines viven en flavors)
+        │   ├── llm/            # SystemPrompts (real engines live in flavors)
         │   ├── inference/      # MiniEvaluator (deterministic guard rails)
         │   ├── schemas/        # MissionPatch, WeatherDigest, ValidationStamp, FieldVisit, etc.
         │   ├── sync/           # RhizomeMockClient + real HTTP clients
         │   └── ui/             # HomeScreen, VisitarRhizomeScreen, VisitarMeristemScreen, VoiceBetaPanel, ChatFeature
-        ├── demo/kotlin/net/sprout/pollen/llm/LiteRtInfra.kt    # mock determinista
+        ├── demo/kotlin/net/sprout/pollen/llm/LiteRtInfra.kt    # deterministic mock
         ├── device/kotlin/net/sprout/pollen/llm/LiteRtInfra.kt  # real LiteRT-LM
         └── test/kotlin/net/sprout/pollen/
             ├── inference/MiniEvaluatorTest.kt   # REFUSE_RETRY, REFUSE_HARD, APPLY_AS_IS, APPLY_CONSERVATIVE
-            └── schemas/RoundTripTest.kt          # validación JSON ↔ Kotlin
+            └── schemas/RoundTripTest.kt          # JSON ↔ Kotlin validation
 ```
 
-## Build local
+## Local build
 
-Requisitos: **Android SDK 34**, **JDK 17**, **Gradle 9.3.1+** (incluido en el wrapper).
+Requirements: **Android SDK 34**, **JDK 17**, **Gradle 9.3.1+** (included in the wrapper).
 
 ```bash
 cd code/pollen
-./gradlew assembleDebug            # APK debug (flavor demo por defecto)
-./gradlew assembleDeviceRelease    # APK device flavor (LiteRT-LM real)
-./gradlew testDebugUnitTest        # tests unitarios JVM
+./gradlew assembleDebug            # debug APK (default demo flavor)
+./gradlew assembleDeviceRelease    # device flavor APK (real LiteRT-LM)
+./gradlew testDebugUnitTest        # JVM unit tests
 ```
 
-Si no tienes Android SDK local: **usa el CI**. Cada PR contra `main` que toque `code/pollen/**` dispara [el workflow](../../.github/workflows/pollen-ci.yml) que compila y corre tests en un runner Ubuntu con SDK.
+If you don't have a local Android SDK: **use CI**. Every PR against `main` that touches `code/pollen/**` triggers [the workflow](../../.github/workflows/pollen-ci.yml), which builds and runs tests on an Ubuntu runner with the SDK.
 
 ## CI
 
 Workflow: [`.github/workflows/pollen-ci.yml`](../../.github/workflows/pollen-ci.yml).
 
-Se dispara en:
-- `push` a ramas `feat/pollen-**`
-- `pull_request` a `main` cuando toca `code/pollen/**` o el propio workflow
+Triggers on:
+- `push` to `feat/pollen-**` branches
+- `pull_request` to `main` when it touches `code/pollen/**` or the workflow itself
 
-Ejecuta (usando el wrapper local, garantizando Gradle 9.3.1):
-- `./gradlew assembleDebug` — compila APK debug
-- `./gradlew testDebugUnitTest` — tests unitarios JVM
+Runs (using the local wrapper, guaranteeing Gradle 9.3.1):
+- `./gradlew assembleDebug` — builds the debug APK
+- `./gradlew testDebugUnitTest` — JVM unit tests
 
-Los reportes de test se suben como artifact (`pollen-test-reports`) para inspección post-failure.
+Test reports are uploaded as an artifact (`pollen-test-reports`) for post-failure inspection.
 
-**Regla dura:** PR con CI en rojo no se mergea. Documentado en CONTRIBUTING §9.
+**Hard rule:** a PR with red CI does not get merged. Documented in CONTRIBUTING §9.
 
-## Lógica anti-nonsense (Mini Evaluator)
+## Anti-nonsense logic (Mini Evaluator)
 
-`MiniEvaluator.kt` aplica cuatro chequeos deterministas antes de aplicar cualquier `MissionPatch` propuesto por el LLM:
+`MiniEvaluator.kt` applies four deterministic checks before applying any `MissionPatch` proposed by the LLM:
 
-1. **Schema validation** — el JSON emitido debe casar con el contrato `MissionPatch`.
-2. **No conflict with hard limits** — la política propuesta no puede violar el sobre de seguridad del firmware.
-3. **Syntactic-semantic match** — al menos un keyword o número del transcript debe aparecer en el rationale o en los campos del patch.
-4. **Explicit model confidence** — si LiteRT-LM expone `logprobs`, el umbral es 0,7.
+1. **Schema validation** — the emitted JSON must match the `MissionPatch` contract.
+2. **No conflict with hard limits** — the proposed policy cannot violate the firmware safety envelope.
+3. **Syntactic-semantic match** — at least one keyword or number from the transcript must appear in the rationale or the patch fields.
+4. **Explicit model confidence** — if LiteRT-LM exposes `logprobs`, the threshold is 0.7.
 
-Si cualquiera falla, Pollen responde con `REFUSE_RETRY` o `REFUSE_HARD` (cuatro casos cubiertos en `MiniEvaluatorTest.kt`). **La negativa es una feature del producto, no un fallo.**
+If any check fails, Pollen responds with `REFUSE_RETRY` or `REFUSE_HARD` (four cases covered in `MiniEvaluatorTest.kt`). **Refusal is a product feature, not a failure.**
 
-## Bitácora
+## Journal pointers
 
-Material de bitácora relevante:
-- `bitacora/2026-04-27_draft-issue-litertlm-thinking_floema.md` — primer intento LiteRT-LM, problemas iniciales.
-- `bitacora/2026-05-01_litertlm-pixel10pro-compatibility_floema.md` — validación Pixel 10 Pro.
-- `bitacora/2026-05-12_PR-voice-beta-final_floema.md` — descripción consolidada del PR voice-beta-final.
-- `research/04_litertlm_thinking_pt1.md`, `pt2`, `digest` — investigación comparativa LiteRT-LM vs MediaPipe.
-
+Relevant working journal entries:
+- `bitacora/2026-04-27_draft-issue-litertlm-thinking_floema.md` — first LiteRT-LM attempt, initial issues.
+- `bitacora/2026-05-01_litertlm-pixel10pro-compatibility_floema.md` — Pixel 10 Pro validation.
+- `bitacora/2026-05-12_PR-voice-beta-final_floema.md` — consolidated description of the voice-beta-final PR.
+- `research/04_litertlm_thinking_pt1.md`, `pt2`, `digest` — comparative LiteRT-LM vs MediaPipe research.
 
 ---
 
 ## Note on language
 
-The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.
+This README is English-first. Internal bitácoras (Spanish-language working journals) and the day-by-day development trace live under [`bitacora/`](../../bitacora/). See the [Language note in the root README](../../README.md#language-note) for the project-wide policy.

--- a/code/pollen/README.md
+++ b/code/pollen/README.md
@@ -34,7 +34,7 @@ La app se construye en dos flavors distintos:
 
 | Flavor | Para qué | Inferencia | Modelo requerido | APK |
 |--------|----------|------------|------------------|-----|
-| **`demo`** | Emulador, dispositivos sin recursos, walkthrough de la UI sin modelo | Mock LiteRT determinista | Ninguno | [`demo/pollen-demo.apk`](../../demo/pollen-demo.apk) (~39 MB) |
+| **`demo`** | Emulador, dispositivos sin recursos, walkthrough de la UI sin modelo | Mock LiteRT determinista | Ninguno | `./gradlew assembleDemoDebug` |
 | **`device`** | Pixel 10 Pro u otro Android 12+ real, con Gemma 4 E4B local | LiteRT-LM real | `gemma-4-E4B-it.litertlm` (3,6 GB) side-loaded vía ADB | Build local |
 
 La separación vive en `app/src/demo/.../llm/LiteRtInfra.kt` (mock) vs `app/src/device/.../llm/LiteRtInfra.kt` (real LiteRT-LM con `sendAudioFile()`).

--- a/code/rhizome/README.md
+++ b/code/rhizome/README.md
@@ -2,54 +2,54 @@
 
 **Abstract.** Rhizome is the plot node. In the current MVP it runs on Jetson Orin Nano Super and operates offline-first: it reads local telemetry from the ESP32-S3 over serial, builds `RhizomeSnapshot` objects, applies deterministic safety and irrigation-need gates, and writes every outcome as a `DecisionReceipt`. When configured, Gemma 4 E2B via `llama.cpp` is used only to produce short human-readable rationales and visit summaries for Pollen; **it does not authorize water**. The deterministic gate decides whether an action is eligible, and the ESP32 owns the physical veto and pump execution boundary. Pollen consumes Rhizome through the local HTTP sync facade. Camera/vision, multi-zone control, and learning are outside the critical MVP path.
 
-## Rol
+## Role
 
-- Lee telemetría local del ESP32-S3 vía serial (humedad de suelo, nivel de depósito, heartbeat, estado de bomba).
-- Construye `RhizomeSnapshot` y aplica gates deterministas de seguridad y necesidad.
-- Persiste `DecisionReceipt` con evidencia, política activa, candidato, salida del ESP32, acción final y rationale.
-- Cuando hay configuración, pide a Gemma 4 E2B vía `llama.cpp` un rationale corto en lenguaje natural (no autoriza agua).
-- Sirve la fachada HTTP local para Pollen (`GET /summary/since?locale=es|en`, `GET /explain/decision/<id>`, `POST /visit`).
-- `ShadowSkeptic` registra objeciones de un segundo agente con `affects_decision=false`.
+- Reads local telemetry from the ESP32-S3 over serial (soil moisture, tank level, heartbeat, pump state).
+- Builds a `RhizomeSnapshot` and applies deterministic safety and need gates.
+- Persists `DecisionReceipt` objects with evidence, active policy, candidate action, ESP32 outcome, final action and rationale.
+- When configured, asks Gemma 4 E2B via `llama.cpp` for a short natural-language rationale (it does not authorize water).
+- Serves the local HTTP facade for Pollen (`GET /summary/since?locale=es|en`, `GET /explain/decision/<id>`, `POST /visit`).
+- `ShadowSkeptic` records objections from a second agent with `affects_decision=false`.
 
-## Stack actual (MVP)
+## Current stack (MVP)
 
 - Python 3.11.
-- **`llama.cpp`** con Gemma 4 E2B-it Q4_K_S (perfil `safe-cpu` contractual; perfil `gpu-experimental` con 36/36 capas a GPU para iteración).
-- `pydantic` para schemas.
-- Comunicación con ESP32-S3 via USB-CDC serial.
-- Persistencia rotada (`retention_days=120`, `max_total_bytes=64 MiB`).
-- `decisions_by_rule` en `/health` para trazabilidad ejercitada.
+- **`llama.cpp`** with Gemma 4 E2B-it Q4_K_S (`safe-cpu` is the contractual profile; `gpu-experimental` offloads 36/36 layers to GPU for iteration).
+- `pydantic` for schemas.
+- Communication with ESP32-S3 over USB-CDC serial.
+- Rotated persistence (`retention_days=120`, `max_total_bytes=64 MiB`).
+- `decisions_by_rule` exposed on `/health` for exercised traceability.
 
-## Estructura real (post-day-28)
+## Actual structure (post-day-28)
 
 ```
 rhizome/
 ├── README.md
 ├── Makefile
-├── bench/                  # harness benchmark reproducible
-├── benchmarks/             # resultados versionados del harness
+├── bench/                  # reproducible benchmark harness
+├── benchmarks/             # versioned harness results
 ├── requirements.txt
 ├── src/
-│   ├── main.py             # bucle principal
-│   ├── sensors.py          # lectura humedad, caudal, nivel
-│   ├── vision.py           # captura y preprocesado
-│   ├── policy_engine.py    # aplica politica vigente con LLM
-│   ├── safety.py           # handshake con ESP32
-│   ├── llm_client.py       # cliente Ollama
-│   ├── sync_server.py      # endpoint BLE/WiFi para Pollen
-│   └── persistence.py      # SQLite local
-├── policies/               # politicas vigentes (JSON con schema)
+│   ├── main.py             # main loop
+│   ├── sensors.py          # moisture / flow / level reading
+│   ├── vision.py           # capture + preprocessing
+│   ├── policy_engine.py    # applies the active policy with the LLM
+│   ├── safety.py           # ESP32 handshake
+│   ├── llm_client.py       # Ollama client
+│   ├── sync_server.py      # BLE/WiFi endpoint for Pollen
+│   └── persistence.py      # local SQLite
+├── policies/               # active policies (JSON with schema)
 │   └── examples/
 └── tests/
 ```
 
-## Pendiente
+## Pending
 
-Briefing completo en `docs/10_rhizome_spec.md` (a redactar por Cambium + especialista Jetson).
+Full briefing in `docs/10_rhizome_spec.md` (to be written by Cambium + Jetson specialist).
 
-## Benchmark local
+## Local benchmark
 
-Mientras llega el Jetson, el benchmark de `#5` se prepara y valida desde portatil:
+While the Jetson is being delivered, the `#5` benchmark is prepared and validated on a laptop:
 
 ```bash
 cd code/rhizome
@@ -58,12 +58,11 @@ make test
 python -m bench.run_ollama_benchmark --model gemma4:e4b --hardware-label hp-probook-460-g11
 ```
 
-El mismo harness se reutiliza luego en Jetson cambiando solo el target del modelo/runtime.
+The same harness is then reused on the Jetson, swapping only the model/runtime target.
 
-## API local para Pollen
+## Local API for Pollen
 
-La especificacion de Rhizome define una API de lectura para que Pollen pueda
-visitar la parcela sin depender de mocks Android:
+The Rhizome spec defines a read-only API so Pollen can visit the plot without depending on Android mocks:
 
 - `GET /status`
 - `GET /snapshot/latest`
@@ -73,49 +72,37 @@ visitar la parcela sin depender de mocks Android:
 - `POST /policy`
 - `GET /policy/active`
 
-Como paso MVP, `src/rhizome_sync_facade.py` sirve esos endpoints desde
-JSON locales con forma de contrato compartido (`code/shared/schemas/examples`).
-Es una fachada de interoperabilidad: no toca ESP32, no abre actuadores, no llama
-al LLM y no sustituye la persistencia real de Rhizome. Su valor es permitir que
-Floema apunte `RhizomeNetworkClient` a una IP real de Jetson mientras el backend
-definitivo de sensores/SQLite termina de cerrarse.
+As an MVP step, `src/rhizome_sync_facade.py` serves those endpoints from local JSON files shaped like the shared contract (`code/shared/schemas/examples`). It is an interoperability facade: it does not touch the ESP32, does not open actuators, does not call the LLM and does not replace Rhizome's real persistence. Its value is letting Floema point `RhizomeNetworkClient` at a real Jetson IP while the definitive sensor/SQLite backend is being closed.
 
-`/summary/since` es el endpoint para el boton principal de Pollen:
-"Que ha pasado desde mi ausencia?". En el MVP de demo compone un resumen
-determinista con:
+`/summary/since` is the endpoint behind Pollen's main button: "What has happened since I was away?". In the demo MVP it composes a deterministic summary with:
 
-- conteo de riegos, bloqueos y alertas;
-- severidad `ok | attention | alert`;
-- estado actual de deposito y sondas de suelo A/B;
-- recomendacion breve;
-- localizacion `es` o `en`.
+- counts of waterings, blocks and alerts;
+- severity `ok | attention | alert`;
+- current state of the tank and the A/B soil probes;
+- a brief recommendation;
+- locale `es` or `en`.
 
-No usa el LLM todavia. Es intencional: desbloquea la UX con una pieza
-testeable y segura. La evolucion natural es que Gemma 4 E2B ayude a redactar
-ese resumen sobre datos ya agregados, sin cambiar hechos ni decisiones.
+It does not use the LLM yet. This is intentional: it unblocks UX with a testable, safe piece. The natural evolution is for Gemma 4 E2B to help write that summary over already-aggregated data, without changing facts or decisions.
 
-`POST /policy` recibe la politica transitoria que Pollen genera durante una
-visita, por ejemplo desde la beta voz -> politica. El endpoint:
+`POST /policy` receives the transient policy Pollen generates during a visit, for example from the voice → policy beta. The endpoint:
 
-- acepta solo `PolicyPacket` con `policy_origin="pollen-visit"`;
-- normaliza `policy_scope` a `transient`;
-- exige `target_node_id` igual al `node_id` de la fachada;
-- exige `valid_until` con TTL maximo de 12h;
-- persiste la politica como activa para la siguiente decision;
-- no valida hard limits fisicos.
+- only accepts `PolicyPacket` with `policy_origin="pollen-visit"`;
+- normalizes `policy_scope` to `transient`;
+- requires `target_node_id` equal to the facade's `node_id`;
+- requires `valid_until` with a maximum TTL of 12 h;
+- persists the policy as active for the next decision;
+- does not validate physical hard limits.
 
-Esa ultima linea es intencional. La fachada es solo schema gate y persistencia
-host-side; los hard limits viven en el Mini-Evaluator de Pollen antes de enviar
-la politica y en el ESP32 cuando Rhizome intenta ejecutar una accion.
+That last line is intentional. The facade is only a schema gate and host-side persistence; hard limits live in Pollen's Mini-Evaluator before the policy is sent and in the ESP32 when Rhizome tries to execute an action.
 
-Arranque local/Jetson:
+Local / Jetson boot:
 
 ```bash
 cd code/rhizome
 python -m src.rhizome_sync_facade --host 0.0.0.0 --port 13010
 ```
 
-Prueba minima:
+Minimum check:
 
 ```bash
 curl http://127.0.0.1:13010/status
@@ -124,68 +111,64 @@ curl http://127.0.0.1:13010/receipts
 curl "http://127.0.0.1:13010/summary/since?locale=es"
 ```
 
-Smoke de politica desde Jetson:
+Policy smoke from the Jetson:
 
 ```bash
 cd code/rhizome/jetson
 ./smoke_policy.sh
 ```
 
-Base URL para Pollen en la red local del dia 19:
+Base URL for Pollen on day-19 local network:
 
 ```text
 http://192.168.1.60:13010/
 ```
 
-Para video/demo se puede simular un segundo Rhizome en el mismo Jetson:
+For video / demo a second Rhizome can be simulated on the same Jetson:
 
 ```bash
 cd code/rhizome/jetson
 ./start_demo_two_rhizomes.sh
 ```
 
-Esto levanta:
+This brings up:
 
 ```text
 rhizome_01 -> http://192.168.1.60:13010/
 rhizome_02 -> http://192.168.1.60:13020/
 ```
 
-`rhizome_02` usa `code/rhizome/demo_data/rhizome_02`. Debe documentarse como
-simulacion de interoperabilidad multi-Rhizome, no como segundo nodo fisico.
+`rhizome_02` uses `code/rhizome/demo_data/rhizome_02`. It must be documented as a multi-Rhizome interoperability simulation, not as a second physical node.
 
 ## Rhizome Steward v0
 
-`src/rhizome_steward.py` cierra el bucle autonomo minimo para piloto de
-maceta supervisado:
+`src/rhizome_steward.py` closes the minimal autonomous loop for a supervised pot pilot:
 
 ```text
 ESP32 TELEMETRY -> snapshot -> safety/need gate -> optional Gemma rationale
--> optional WATER -> DecisionReceipt -> logs rotados -> facade_data
+-> optional WATER -> DecisionReceipt -> rotated logs -> facade_data
 ```
 
-Propiedades de seguridad:
+Safety properties:
 
-- no envia `WATER` salvo que se pase `--execute-water`;
-- nunca supera `30s` por evento (`FIRMWARE_MAX_WATER_SECONDS_MVP`);
-- aplica cooldown local antes de volver a regar;
-- limita eventos autonomos por dia;
-- si no entiende la humedad, aplaza;
-- si deposito baja de minimo, emite `ALERT`;
-- si no hay sensor de deposito, por defecto aplaza salvo permiso explicito de
-  perfil minimo;
-- si una lectura falta, el snapshot conserva schema valido y marca
-  `pending_contradictions`;
-- el `ShadowSkeptic` es experimental y no afecta la decision.
+- does not send `WATER` unless `--execute-water` is passed;
+- never exceeds `30s` per event (`FIRMWARE_MAX_WATER_SECONDS_MVP`);
+- applies local cooldown before watering again;
+- limits autonomous events per day;
+- if it does not understand the moisture reading, it defers;
+- if the tank drops below the minimum, it emits `ALERT`;
+- if there is no tank sensor, by default it defers unless the minimal-profile permission is explicit;
+- if a reading is missing, the snapshot preserves a valid schema and marks `pending_contradictions`;
+- `ShadowSkeptic` is experimental and does not affect the decision.
 
-Ejecucion sin hardware:
+Run without hardware:
 
 ```bash
 cd code/rhizome
 python -m src.rhizome_steward run-once --esp32 fake
 ```
 
-Ejecucion con ESP32 real, una sola pasada, aun sin abrir agua:
+Run against real ESP32, single pass, still without opening water:
 
 ```bash
 python -m src.rhizome_steward run-once \
@@ -193,7 +176,7 @@ python -m src.rhizome_steward run-once \
   --serial-port /dev/ttyACM0
 ```
 
-Ejecucion con permiso explicito para mandar `WATER A <seconds>` al ESP32:
+Run with explicit permission to send `WATER A <seconds>` to the ESP32:
 
 ```bash
 python -m src.rhizome_steward run-once \
@@ -203,7 +186,7 @@ python -m src.rhizome_steward run-once \
   --water-seconds 8
 ```
 
-Si la sonda de humedad aun no esta calibrada a porcentaje, usar umbrales raw:
+If the moisture probe is not yet calibrated to a percentage, use raw thresholds:
 
 ```bash
 python -m src.rhizome_steward run-once \
@@ -213,7 +196,7 @@ python -m src.rhizome_steward run-once \
   --soil-wet-above-raw 2600
 ```
 
-Perfil hardware minimo de maceta:
+Minimal pot hardware profile:
 
 ```bash
 python -m src.rhizome_steward run-once \
@@ -224,17 +207,9 @@ python -m src.rhizome_steward run-once \
   --soil-wet-above-raw 2600
 ```
 
-Este perfil existe para una ESP32 minima con bomba y sensor de humedad, mientras
-caudalimetro y nivel de deposito quedan previstos pero aun no instalados. Si se
-permite riego con deposito no sensorizado, el receipt conserva
-`tank_level_unavailable`; si falta caudalimetro, conserva
-`flow_sensor_unavailable`. Cuando esos sensores existan, quitar el flag y usar
-modo estricto.
+This profile exists for a minimal ESP32 with pump and moisture sensor while flowmeter and tank level are planned but not yet installed. If watering is allowed without tank sensing, the receipt keeps `tank_level_unavailable`; if the flowmeter is missing, it keeps `flow_sensor_unavailable`. Once those sensors exist, drop the flag and run in strict mode.
 
-Si la humedad llega como valor raw, la polaridad debe declararse. La sonda real
-del handoff de Xilema reporta `soil_a_raw < 1300` como suelo muy humedo, por lo
-que el primer observe mode usa `--soil-raw-polarity low_is_wet` y
-`--soil-wet-below-raw 1300`. Xilema fija para el MVP:
+If moisture arrives as a raw value, polarity must be declared. The real probe from Xilema's handoff reports `soil_a_raw < 1300` as very moist soil, so first observe-mode uses `--soil-raw-polarity low_is_wet` and `--soil-wet-below-raw 1300`. Xilema fixes for the MVP:
 
 ```text
 SOIL_RAW_POLARITY=low_is_wet
@@ -242,14 +217,13 @@ SOIL_WET_BELOW_RAW=1300
 SOIL_DRY_ABOVE_RAW=2200
 ```
 
-Interpretacion:
+Interpretation:
 
-- `<1300`: muy humedo, `SKIP`;
-- `1300..2199`: banda ambigua, `DEFER`;
-- `>=2200`: seco para MVP, candidato a `WATER_A` si pasan las demas
-  barandillas.
+- `<1300`: very moist, `SKIP`;
+- `1300..2199`: ambiguous band, `DEFER`;
+- `>=2200`: dry for the MVP, candidate for `WATER_A` if the other guardrails pass.
 
-Si la firmware minima expone el pulso fisico seguro `PUMP_PULSE <ms>`, usar:
+If the minimal firmware exposes the safe physical pulse `PUMP_PULSE <ms>`, use:
 
 ```bash
 python -m src.rhizome_steward run-once \
@@ -258,24 +232,17 @@ python -m src.rhizome_steward run-once \
   --serial-water-command-mode pump-pulse
 ```
 
-No usar `pump-toggle` con el firmware de dia 26: esta build no expone
-`PUMP_ON`, y Xilema autoriza la ruta `PUMP_PULSE`. `water-duration` sigue siendo
-valido para builds que ejecuten `WATER A <seconds>` fisicamente en la frontera
-ESP32; en la build actual `WATER A 1` responde `execution=DRY_RUN`.
+Do not use `pump-toggle` with the day-26 firmware: that build does not expose `PUMP_ON`, and Xilema authorizes the `PUMP_PULSE` path. `water-duration` is still valid for builds that execute `WATER A <seconds>` physically at the ESP32 boundary; in the current build `WATER A 1` replies `execution=DRY_RUN`.
 
-Si una build del ESP32 mueve fisicamente la bomba pero conserva
-`execution=TEST_ONLY` en el ACK de `PUMP_PULSE`, Rhizome no lo cuenta como riego
-real por defecto. Para el perfil supervisado validado en maceta por Bea, activar
-explicitamente:
+If an ESP32 build physically moves the pump but keeps `execution=TEST_ONLY` in the `PUMP_PULSE` ACK, Rhizome does not count it as real watering by default. For the supervised profile validated on a pot by Bea, explicitly enable:
 
 ```bash
 ACCEPT_ESP32_TEST_ONLY_PULSE_AS_EXECUTED=1
 ```
 
-Esto mantiene las lineas raw del ESP32 en `execution_details`, pero evita que
-Pollen muestre el evento como bloqueado por `ESP32_TEST_ONLY`.
+This keeps the ESP32 raw lines in `execution_details`, but prevents Pollen from showing the event as blocked by `ESP32_TEST_ONLY`.
 
-Persistencia por defecto:
+Default persistence:
 
 ```text
 ~/.local/share/sprout/rhizome_steward/
@@ -287,9 +254,7 @@ Persistencia por defecto:
 └── facade_data/
 ```
 
-El store aplica retencion por dias y presupuesto total de bytes
-(`--retention-days`, `--max-total-bytes`) para poder correr semanas/meses sin
-rebosar la microSD. Para que Pollen vea el bucle real, arranca la fachada con:
+The store applies per-day retention and a total byte budget (`--retention-days`, `--max-total-bytes`) so it can run for weeks / months without overflowing the microSD. So Pollen can see the real loop, start the facade with:
 
 ```bash
 python -m src.rhizome_sync_facade \
@@ -298,7 +263,7 @@ python -m src.rhizome_sync_facade \
   --data-dir ~/.local/share/sprout/rhizome_steward/facade_data
 ```
 
-Gemma 4 E2B puede entrar como redactor contractual de rationale con el adapter:
+Gemma 4 E2B can come in as the contractual rationale writer through the adapter:
 
 ```bash
 python -m src.rhizome_steward run-once \
@@ -307,29 +272,21 @@ python -m src.rhizome_steward run-once \
   --gemma-rationale-url http://127.0.0.1:12000
 ```
 
-Gemma no cambia la accion ni autoriza agua; solo mejora la explicacion sobre
-facts ya decididos.
+Gemma does not change the action or authorize water; it only improves the explanation over already-decided facts.
 
-### Datos devueltos a Pollen
+### Data returned to Pollen
 
-Rhizome devuelve siempre JSON. Pollen puede elegir idioma con `?locale=en` o
-`?locale=es`; si no se indica, el fallback es `es`.
+Rhizome always returns JSON. Pollen can choose language with `?locale=en` or `?locale=es`; if not specified, the fallback is `es`.
 
-Decision de arquitectura de idioma:
+Language architecture decision:
 
-- El sistema razona en contratos, no en el idioma de la interfaz.
-- Los campos operacionales (`action`, `executed`, `blocked_reason`, cantidades,
-  timestamps, codigos de veto) no se traducen.
-- Rhizome puede devolver narrativa localizada para el MVP, pero la fuente de
-  verdad sigue siendo el `DecisionReceipt`.
-- Pollen es la capa responsable de experiencia linguistica. Su Gemma 4 local
-  puede traducir solo la narrativa que no llegue ya localizada, segun el idioma
-  activo de la interfaz.
-- Esta separacion permite que, en el futuro, Pollen pueda usar fine-tuning o
-  adaptacion local para idiomas minoritarios (por ejemplo Pular, Swahili o
-  Wolof) sin pedir a Rhizome que cambie su logica de riego ni sus contratos.
+- The system reasons in contracts, not in the UI language.
+- Operational fields (`action`, `executed`, `blocked_reason`, amounts, timestamps, veto codes) are not translated.
+- Rhizome can return localized narrative for the MVP, but the source of truth remains the `DecisionReceipt`.
+- Pollen is the layer responsible for linguistic experience. Its local Gemma 4 can translate only the narrative that does not arrive already localized, based on the active UI language.
+- This separation allows Pollen, in the future, to use fine-tuning or local adaptation for minority languages (for example Pular, Swahili or Wolof) without asking Rhizome to change its irrigation logic or its contracts.
 
-Endpoints principales:
+Main endpoints:
 
 ```text
 GET /snapshot/latest
@@ -338,17 +295,11 @@ GET /explain/decision/<decision_id>?locale=en|es
 GET /summary/since?since=<UTC_ZULU>&locale=en|es
 ```
 
-`/receipts` devuelve `DecisionReceipt` casi canonico: `action`, `executed`,
-`blocked_reason`, `action_params`, `confidence`, `rationale_short`,
-`rationale_full`, `backend_used`, `contradictions`. Pollen debe tratar
-`executed=false` como propuesta no ejecutada, aunque `action` sea `WATER_A`.
+`/receipts` returns a near-canonical `DecisionReceipt`: `action`, `executed`, `blocked_reason`, `action_params`, `confidence`, `rationale_short`, `rationale_full`, `backend_used`, `contradictions`. Pollen must treat `executed=false` as a non-executed proposal, even when `action` is `WATER_A`.
 
-`/explain/decision/<id>` devuelve una explicacion localizada construida desde el
-receipt. Si Gemma 4 participo antes en el steward, esa explicacion incorpora el
-`rationale_*` escrito por Gemma en el receipt. Si no, usa rationale
-determinista.
+`/explain/decision/<id>` returns a localized explanation built from the receipt. If Gemma 4 participated earlier in the steward, that explanation includes the `rationale_*` written by Gemma in the receipt. Otherwise it uses a deterministic rationale.
 
-`/summary/since` devuelve el payload del boton principal de ausencia:
+`/summary/since` returns the payload for the main "absence" button:
 
 ```json
 {
@@ -370,13 +321,11 @@ determinista.
 }
 ```
 
-Gemma 4 no es fuente de verdad para estos campos. Su papel correcto es redactar
-mejor `rationale_short`/`rationale_full` y, como siguiente paso, sintetizar una
-narrativa de ausencia a partir de snapshots y receipts ya validados.
+Gemma 4 is not the source of truth for these fields. Its correct role is to write a better `rationale_short` / `rationale_full` and, as a next step, to synthesize an absence narrative from already-validated snapshots and receipts.
 
-#### Narrador Gemma 4 opcional
+#### Optional Gemma 4 narrator
 
-La fachada puede usar Gemma 4 E2B local como narrador del boton de ausencia:
+The facade can use a local Gemma 4 E2B as the narrator for the absence button:
 
 ```bash
 GEMMA_VISIT_NARRATOR_URL=http://127.0.0.1:12000 \
@@ -384,15 +333,11 @@ GEMMA_VISIT_NARRATOR_MODEL=gemma4:e2b \
 ./start_sync_facade.sh
 ```
 
-Cuando esta activo, Gemma solo puede reescribir `headline`, `summary`,
-`highlights` y `recommendation`. No puede cambiar `counts`, `severity`,
-`source`, `simulation`, receipts ni snapshots. Si Gemma falla, tarda demasiado o
-devuelve JSON invalido, la respuesta cae al resumen determinista.
+When enabled, Gemma can only rewrite `headline`, `summary`, `highlights` and `recommendation`. It cannot change `counts`, `severity`, `source`, `simulation`, receipts or snapshots. If Gemma fails, takes too long or returns invalid JSON, the response falls back to the deterministic summary.
 
-Configuracion E2B: los usos Gemma de Rhizome usan `num_predict=1024` para evitar
-fallbacks silenciosos por respuestas truncadas en E2B.
+E2B configuration: Rhizome's Gemma uses `num_predict=1024` to avoid silent fallbacks from truncated E2B responses.
 
-Campos de trazabilidad:
+Traceability fields:
 
 ```json
 {
@@ -406,9 +351,8 @@ Campos de trazabilidad:
 }
 ```
 
-
 ---
 
 ## Note on language
 
-The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.
+This README is English-first. Internal bitácoras (Spanish-language working journals) and the day-by-day development trace live under [`bitacora/`](../../bitacora/). See the [Language note in the root README](../../README.md#language-note) for the project-wide policy.

--- a/code/rhizome/jetson/README.md
+++ b/code/rhizome/jetson/README.md
@@ -4,87 +4,80 @@
 
 ---
 
-Scripts operativos para arrancar Gemma 4 E2B en Jetson Orin Nano Super con
-`llama.cpp` sin depender de Ollama ni de hardware ESP32.
+Operational scripts to launch Gemma 4 E2B on Jetson Orin Nano Super with `llama.cpp`, without depending on Ollama or ESP32 hardware.
 
-Estos scripts no tocan firmware, sensores, actuadores ni reglas fisicas. Solo
-gestionan el runtime local de inferencia y el adapter Ollama-compatible.
+These scripts do not touch firmware, sensors, actuators or physical rules. They only manage the local inference runtime and the Ollama-compatible adapter.
 
-Tambien incluyen una fachada HTTP de lectura para Pollen. Esa fachada no toca
-ESP32 ni actuadores; solo sirve contratos JSON de Rhizome para que Android pueda
-probar contra una IP real de Jetson.
+They also include a read-only HTTP facade for Pollen. That facade does not touch the ESP32 or actuators; it only serves Rhizome JSON contracts so Android can test against a real Jetson IP.
 
-## Perfiles
+## Profiles
 
-| Perfil | Uso | Estado dia 18 |
+| Profile | Use | Day-18 status |
 |---|---|---|
-| `safe-cpu` | Demo contractual y bateria Rhizome v0.5 | Quality pass 18/18, lento |
-| `gpu-experimental` | Diagnostico/rendimiento | Experimental: puede fallar por memoria contigua y no es quality pass |
+| `safe-cpu` | Contractual demo and Rhizome v0.5 battery | Quality pass 18/18, slow |
+| `gpu-experimental` | Performance / diagnostics | Experimental: can fail on contiguous-memory issues and is not quality pass |
 
 ### `safe-cpu`
 
-Arranca `llama-server` en `:8080` con:
+Boots `llama-server` on `:8080` with:
 
 ```bash
 -ngl 0 --device none --no-op-offload --reasoning off
 ```
 
-Es el perfil seguro documentado por Endodermis el dia 17:
+This is the safe profile documented by Endodermis on day 17:
 
-- mini-test critico frio 6/6;
-- mini-test critico caliente 6/6;
-- bateria Rhizome v0.5 combinada 18/18;
-- sin OOM, sin truncamiento, sin Markdown fences.
+- critical mini-test cold 6/6;
+- critical mini-test hot 6/6;
+- combined Rhizome v0.5 battery 18/18;
+- no OOM, no truncation, no Markdown fences.
 
 ### `gpu-experimental`
 
-Arranca `llama-server` en `:8080` con:
+Boots `llama-server` on `:8080` with:
 
 ```bash
 -ngl 99 --fit off --no-op-offload --reasoning off
 ```
 
-El flag clave es `--no-op-offload`; sin el, el build de `llama.cpp` en Jetson
-puede abortar con:
+The key flag is `--no-op-offload`; without it, the `llama.cpp` build on Jetson can abort with:
 
 ```text
 GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS)
 ```
 
-Estado dia 18:
+Day-18 status:
 
-- carga 36/36 capas en GPU;
-- acelera mucho las respuestas;
-- aun no es quality pass para Rhizome v0.5 porque RD04 muestra deriva
-  semantica segura (`need_clarification` en lugar de `ok`).
+- loads 36/36 layers on the GPU;
+- significantly faster responses;
+- not yet quality pass for Rhizome v0.5 because RD04 shows safe semantic drift (`need_clarification` instead of `ok`).
 
-Estado dia 19:
+Day-19 status:
 
-- desde `main`, `gpu-experimental` volvio a fallar una vez con
-  `NvMapMemAllocInternalTagged ... error 12` / `cudaMalloc failed`;
-- por tanto este perfil no es ni runtime-pass garantizado ni demo-safe;
-- si falla, restaurar inmediatamente:
+- from `main`, `gpu-experimental` failed once with `NvMapMemAllocInternalTagged ... error 12` / `cudaMalloc failed`;
+- therefore this profile is neither runtime-pass guaranteed nor demo-safe;
+- if it fails, restore immediately:
 
 ```bash
 ./run_runtime.sh safe-cpu
 ./smoke_adapter.sh
 ```
 
-## Requisitos
+## Requirements
 
-- Jetson Orin Nano Super con JetPack 6.x.
-- Docker instalado.
-- runtime NVIDIA disponible.
-- usuario con permiso para ejecutar `docker`.
-- modelo descargado en:
+- Jetson Orin Nano Super with JetPack 6.x.
+- Docker installed.
+- NVIDIA runtime available.
+- User with permission to run `docker`.
+- Model downloaded to:
 
 ```bash
 $HOME/sprout_models/gemma-4-E2B-it-Q4_K_S.gguf
 ```
 
-## Arranque
+## Boot
 
-Desde la Jetson:
+From the Jetson:
 
 ```bash
 cd ~/sprout/code/rhizome/jetson
@@ -95,7 +88,7 @@ cd ~/sprout/code/rhizome/jetson
 ./run_battery.sh critical
 ```
 
-Para probar GPU:
+To test GPU:
 
 ```bash
 ./run_runtime.sh gpu-experimental
@@ -104,7 +97,7 @@ Para probar GPU:
 ./run_battery.sh critical
 ```
 
-## Variables utiles
+## Useful variables
 
 ```bash
 MODEL_PATH=$HOME/sprout_models/gemma-4-E2B-it-Q4_K_S.gguf
@@ -115,21 +108,21 @@ CTX_SIZE=2048
 N_GPU_LAYERS=99
 ```
 
-Ejemplo:
+Example:
 
 ```bash
 CTX_SIZE=1024 ./run_runtime.sh gpu-experimental
 ```
 
-## Verificacion
+## Verification
 
-Health directo de `llama-server`:
+Direct `llama-server` health:
 
 ```bash
 curl -s http://127.0.0.1:8080/health
 ```
 
-Health del adapter:
+Adapter health:
 
 ```bash
 curl -s http://127.0.0.1:12000/health
@@ -141,18 +134,16 @@ Smoke:
 ./smoke_adapter.sh
 ```
 
-## API Rhizome para Pollen
+## Rhizome API for Pollen
 
-La API que consume `RhizomeNetworkClient` no es `llama-server` (`:8080`) ni el
-adapter Ollama-compatible (`:12000`). Es una fachada separada en `:13010`:
+The API consumed by `RhizomeNetworkClient` is neither `llama-server` (`:8080`) nor the Ollama-compatible adapter (`:12000`). It is a separate facade on `:13010`:
 
 ```bash
 ./start_sync_facade.sh
 ./smoke_sync_facade.sh
 ```
 
-Para activar el narrador Gemma 4 del boton de ausencia, primero debe estar vivo
-el adapter Ollama-compatible en `:12000`:
+To enable the Gemma 4 narrator on the absence button, the Ollama-compatible adapter on `:12000` must be alive first:
 
 ```bash
 GEMMA_VISIT_NARRATOR_URL=http://127.0.0.1:12000 \
@@ -162,10 +153,9 @@ GEMMA_VISIT_NARRATOR_MODEL=gemma4:e2b \
 ./smoke_gemma_visit_narrator.sh
 ```
 
-El narrador solo reescribe narrativa humana. Los counts, receipts, flags
-`executed`, `simulation` y codigos de seguridad siguen siendo deterministas.
+The narrator only rewrites human-facing narrative. Counts, receipts, `executed` / `simulation` flags and safety codes remain deterministic.
 
-Endpoints servidos:
+Endpoints served:
 
 ```text
 GET /status
@@ -177,78 +167,69 @@ POST /policy
 GET /policy/active
 ```
 
-`POST /policy` es el receptor beta de politicas transitorias generadas por
-Pollen durante una visita. Acepta `PolicyPacket` con
-`policy_origin="pollen-visit"` y TTL maximo de 12h, lo persiste como politica
-activa para la siguiente decision y devuelve un ack JSON. No valida hard limits
-fisicos: esa frontera sigue en Mini-Evaluator + ESP32.
+`POST /policy` is the beta receiver for transient policies generated by Pollen during a visit. It accepts `PolicyPacket` objects with `policy_origin="pollen-visit"` and a maximum TTL of 12 h, persists them as the active policy for the next decision and returns a JSON ack. It does not validate physical hard limits: that boundary remains in Mini-Evaluator + ESP32.
 
-Smoke de politica:
+Policy smoke:
 
 ```bash
 ./smoke_policy.sh
 ```
 
-Para la fachada simulada de `rhizome_02`:
+For the simulated `rhizome_02` facade:
 
 ```bash
 FACADE_URL=http://127.0.0.1:13020 TARGET_NODE_ID=rhizome_02 ./smoke_policy.sh
 ```
 
-Base URL para Pollen en la red local del dia 19:
+Base URL for Pollen on day-19 local network:
 
 ```text
 http://192.168.1.60:13010/
 ```
 
-Para el video se puede levantar una segunda fachada simulada en el mismo
-Jetson:
+For the video, a second simulated facade can be brought up on the same Jetson:
 
 ```bash
 ./start_demo_two_rhizomes.sh
 ```
 
-Si la Jetson cambia de WiFi, no depender de recordar la IP anterior. El
-hostname estable por mDNS es:
+If the Jetson changes WiFi, do not depend on remembering the previous IP. The stable hostname via mDNS is:
 
 ```text
 rhizome-01-node.local
 ```
 
-URLs preferentes:
+Preferred URLs:
 
 ```text
 rhizome_01 -> http://rhizome-01-node.local:13010/
 rhizome_02 -> http://rhizome-01-node.local:13020/
 ```
 
-Si la red bloquea mDNS, usar la IP actual que imprime:
+If the network blocks mDNS, use the current IP printed by:
 
 ```bash
 ./network_info.sh
 ```
 
-Endpoints de demo:
+Demo endpoints:
 
 ```text
 rhizome_01 -> http://<jetson-host-or-ip>:13010/
 rhizome_02 -> http://<jetson-host-or-ip>:13020/
 ```
 
-`rhizome_02` usa datos de `code/rhizome/demo_data/rhizome_02`. Es una
-simulacion host-side de interoperabilidad multi-Rhizome: no hay segundo ESP32,
-no hay segunda bomba y no se toca hardware fisico.
+`rhizome_02` uses data from `code/rhizome/demo_data/rhizome_02`. It is a host-side simulation of multi-Rhizome interoperability: no second ESP32, no second pump, no physical hardware involved.
 
-## Primer observe mode con ESP32 minimo
+## First observe-mode run with minimal ESP32
 
-Cuando el ESP32 exponga bomba on/off + humedad de tierra, probar primero sin
-ejecucion de agua:
+When the ESP32 exposes pump on/off plus soil moisture, test first without water execution:
 
 ```bash
 ./run_steward_serial_observe_minimal.sh
 ```
 
-Equivale a:
+Equivalent to:
 
 ```bash
 ESP32_MODE=serial \
@@ -262,12 +243,9 @@ SOIL_WET_BELOW_RAW=1300 \
 ./run_steward_once.sh
 ```
 
-La lectura actual documentada por Xilema (`soil_a_raw=1263-1267`) cae por
-debajo de `1300`, asi que Rhizome debe tratarla como suelo humedo y no proponer
-riego. En este perfil no se define `SOIL_DRY_ABOVE_RAW`: fuera de la banda
-humeda, Rhizome aplaza en vez de regar porque aun no hay calibracion seca.
+The current reading documented by Xilema (`soil_a_raw=1263-1267`) falls below `1300`, so Rhizome must treat it as moist soil and not propose irrigation. This profile does not define `SOIL_DRY_ABOVE_RAW`: outside the moist band, Rhizome defers instead of watering because no dry calibration exists yet.
 
-Umbrales autorizados por Xilema para el MVP:
+Thresholds authorized by Xilema for the MVP:
 
 ```text
 SOIL_RAW_POLARITY=low_is_wet
@@ -275,44 +253,38 @@ SOIL_WET_BELOW_RAW=1300
 SOIL_DRY_ABOVE_RAW=2200
 ```
 
-Interpretacion:
+Interpretation:
 
-- `<1300`: muy humedo, no regar.
-- `1300..2199`: banda ambigua, `DEFER`/observe.
-- `>=2200`: seco para MVP, candidato a riego si pasan las demas barandillas.
+- `<1300`: very moist, do not water.
+- `1300..2199`: ambiguous band, `DEFER`/observe.
+- `>=2200`: dry for the MVP, candidate for watering if all other guardrails pass.
 
-El primer riego real debe ser manual, corto y supervisado por Xilema/Bea,
-cambiando explicitamente `EXECUTE_WATER=1` y un `WATER_SECONDS` bajo.
+The first real watering must be manual, short, and supervised by Xilema/Bea, explicitly setting `EXECUTE_WATER=1` and a small `WATER_SECONDS`.
 
-Baseline operativo:
+Operational baseline:
 
 ```bash
 ./collect_baseline.sh | tee jetson_baseline_$(date -u +%Y%m%dT%H%M%SZ).log
 ```
 
-Bateria Rhizome v0.5:
+Rhizome v0.5 battery:
 
 ```bash
-./run_battery.sh critical          # 6 prompts criticos
-./run_battery.sh remaining         # 12 prompts restantes
+./run_battery.sh critical          # 6 critical prompts
+./run_battery.sh remaining         # 12 remaining prompts
 ./run_battery.sh full              # critical + remaining
 ./run_battery.sh critical --dry-run
 ```
 
-Los resultados se escriben en `code/tuning/results/` dentro del repo montado
-en el contenedor del adapter, con un sufijo UTC para no pisar los JSONL
-canonicos.
+Results are written to `code/tuning/results/` inside the repo mounted into the adapter container, with a UTC suffix so they do not overwrite the canonical JSONL.
 
-En modo real, `run_battery.sh` devuelve codigo distinto de cero si cualquier
-run tiene error HTTP, `envelope_valid=false` o `status_match` incorrecto. En
-modo `full`, si `critical` falla, `remaining` no se ejecuta.
+In real mode, `run_battery.sh` returns non-zero if any run has an HTTP error, `envelope_valid=false` or incorrect `status_match`. In `full` mode, if `critical` fails, `remaining` is not executed.
 
-## Interpretacion
+## Interpretation
 
-Para demo y pruebas contractuales, usar `safe-cpu` hasta que Cambium/Xilema
-acepten formalmente un perfil GPU.
+For demo and contractual testing, use `safe-cpu` until Cambium/Xilema formally accept a GPU profile.
 
-Para experimentos de rendimiento, usar `gpu-experimental` y ejecutar al menos:
+For performance experiments, use `gpu-experimental` and at minimum run:
 
 ```bash
 cd ~/sprout/code/tuning
@@ -321,34 +293,31 @@ python harness.py --matrix matrix_rhizome_v05.yaml \
   --out results/rhizome_v05_gpu_probe.jsonl
 ```
 
-No promover GPU a perfil demo hasta que la bateria critica sea estable y RD04
-quede alineado con el contrato.
+Do not promote GPU to demo profile until the critical battery is stable and RD04 aligns with the contract.
 
-Si `gpu-experimental` falla durante el arranque, no depurar en caliente durante
-un rehearsal. Restaurar `safe-cpu` y documentar el log.
+If `gpu-experimental` fails during boot, do not debug hot during a rehearsal. Restore `safe-cpu` and document the log.
 
-## Steward autonomo minimo
+## Minimal autonomous steward
 
-Para el piloto de maceta, `rhizome_steward.py` ejecuta el bucle minimo:
+For the pot pilot, `rhizome_steward.py` runs the minimal loop:
 
 ```text
-heartbeat -> telemetry -> decision -> optional WATER -> receipt -> logs rotados
+heartbeat -> telemetry -> decision -> optional WATER -> receipt -> rotated logs
 ```
 
-Smoke sin hardware real:
+Smoke without real hardware:
 
 ```bash
 ./run_steward_once.sh
 ```
 
-Una pasada contra ESP32 real sin permitir agua:
+One pass against a real ESP32 without allowing water:
 
 ```bash
 ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./run_steward_once.sh
 ```
 
-Perfil minimo de maceta, previsto para ESP32 con bomba y sensor de humedad pero
-sin caudalimetro ni sensor de nivel todavia:
+Minimal pot profile, intended for an ESP32 with pump and soil sensor but no flowmeter or level sensor yet:
 
 ```bash
 ESP32_MODE=serial \
@@ -357,12 +326,9 @@ ALLOW_MISSING_TANK_SENSOR=1 \
 ./run_steward_once.sh
 ```
 
-En este perfil Rhizome sigue escribiendo `tank_level_unavailable` y
-`flow_sensor_unavailable` cuando corresponda. No se oculta que esos sensores son
-previstos/futuros.
+In this profile Rhizome still writes `tank_level_unavailable` and `flow_sensor_unavailable` where applicable. We do not hide that these sensors are planned/future.
 
-Una pasada contra ESP32 real permitiendo agua. Usar solo con Xilema/Bea en la
-frontera fisica y con duraciones pequenas:
+One pass against a real ESP32 with water enabled. Use only with Xilema/Bea at the physical boundary and with small durations:
 
 ```bash
 ESP32_MODE=serial \
@@ -372,7 +338,7 @@ WATER_SECONDS=8 \
 ./run_steward_once.sh
 ```
 
-Si la firmware minima expone `PUMP_PULSE <ms>` como ruta segura:
+If the minimal firmware exposes `PUMP_PULSE <ms>` as a safe path:
 
 ```bash
 ESP32_MODE=serial \
@@ -386,21 +352,17 @@ WATER_SECONDS=3 \
 ./run_steward_once.sh
 ```
 
-Esto emite `PUMP_PULSE 3000` solo si Rhizome decide `WATER_A`. No usar
-`pump-toggle` con la build de dia 26: `PUMP_ON` no esta expuesto por seguridad.
-`WATER A 1` sigue siendo `DRY_RUN` en esta build.
+This emits `PUMP_PULSE 3000` only if Rhizome decides `WATER_A`. Do not use `pump-toggle` with the day-26 build: `PUMP_ON` is not exposed for safety reasons. `WATER A 1` is still `DRY_RUN` in that build.
 
-Si la build de firmware responde `execution=TEST_ONLY` aunque Bea haya validado
-que la bomba mueve agua real, usar solo en perfil supervisado:
+If the firmware build replies `execution=TEST_ONLY` even though Bea has validated that the pump moves real water, use only in the supervised profile:
 
 ```bash
 ACCEPT_ESP32_TEST_ONLY_PULSE_AS_EXECUTED=1
 ```
 
-Por defecto Rhizome trata `TEST_ONLY` como no ejecutado para no inflar
-receipts. Esta variable lo interpreta como pulso fisico confirmado por operador.
+By default Rhizome treats `TEST_ONLY` as not executed to avoid inflating receipts. This variable interprets it as a physical pulse confirmed by the operator.
 
-Si la humedad llega como raw no calibrado, declarar umbrales raw:
+If moisture arrives as uncalibrated raw, declare raw thresholds:
 
 ```bash
 ESP32_MODE=serial \
@@ -410,43 +372,37 @@ SOIL_WET_ABOVE_RAW=2600 \
 ./run_steward_once.sh
 ```
 
-Loop autonomo:
+Autonomous loop:
 
 ```bash
 ESP32_MODE=serial ESP32_PORT=/dev/ttyACM0 ./start_steward_loop.sh
 ```
 
-Por defecto el loop decide cada 15 minutos, mantiene heartbeat entre
-decisiones, rota logs y escribe en:
+By default the loop decides every 15 minutes, keeps heartbeat alive between decisions, rotates logs and writes to:
 
 ```text
 $HOME/.local/share/sprout/rhizome_steward/
 ```
 
-El wrapper deriva `SYNC_FACADE_STATE_DIR` de `NODE_ID`, de modo que
-`NODE_ID=rhizome_02` buscara politica activa en
-`/tmp/sprout_rhizome_sync_facade/rhizome_02` salvo override explicito.
+The wrapper derives `SYNC_FACADE_STATE_DIR` from `NODE_ID`, so `NODE_ID=rhizome_02` looks for active policy under `/tmp/sprout_rhizome_sync_facade/rhizome_02` unless explicitly overridden.
 
-Para que Pollen lea el estado real del steward:
+For Pollen to read the steward's real state:
 
 ```bash
 FACADE_DATA_DIR=$HOME/.local/share/sprout/rhizome_steward/facade_data \
 ./start_sync_facade.sh
 ```
 
-Gemma 4 E2B puede mejorar la explicacion sin cambiar accion:
+Gemma 4 E2B can improve the explanation without changing the action:
 
 ```bash
 GEMMA_RATIONALE_URL=http://127.0.0.1:12000 ./run_steward_once.sh
 ```
 
-El `ShadowSkeptic` se ejecuta por defecto como experimento de doble agente
-no vinculante. Sus observaciones se guardan en `shadow_skeptic/YYYY-MM-DD.jsonl`
-y siempre llevan `affects_decision=false`.
-
+`ShadowSkeptic` runs by default as a non-binding dual-agent experiment. Its observations are stored in `shadow_skeptic/YYYY-MM-DD.jsonl` and always carry `affects_decision=false`.
 
 ---
 
 ## Note on language
 
-The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../../README.md#language-note) for the project-wide policy.
+This README is English-first. Internal bitácoras (Spanish-language working journals) and the day-by-day development trace live under [`bitacora/`](../../../bitacora/). See the [Language note in the root README](../../../README.md#language-note) for the project-wide policy.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,23 +1,32 @@
 # demo/
 
-Assets para el **Live Demo** publico del proyecto. Lo que un lector externo puede tocar para experimentar Sprout sin el hardware real.
+Esta carpeta esta reservada para builds finales del APK Android de Pollen. Durante el ciclo del hackathon (30 dias) se decidio que la ruta publica de instalacion fuera **build desde codigo**, no APK pre-empaquetado. Las razones:
 
-## Opciones candidatas
+1. **Honestidad ante el evaluador.** El codigo se compila y se inspecciona; el APK firmado anade una capa de confianza sobre el binario que no es necesaria para un MVP.
+2. **Tamano.** Un APK device-flavor pesa ~58 MB y requiere LFS o release attachment; el repo prefiere mantenerse ligero.
+3. **Reproducibilidad.** `./gradlew assembleDemoDebug` desde `code/pollen/` es la fuente de verdad y siempre coincide con el codigo del repo.
 
-### Opcion A: video interactivo
-Un video en loop embebido en HuggingFace Spaces o similar donde se ve el sistema funcionando.
+## Build de la demo (sin modelo, ~30 MB)
 
-### Opcion B: simulador web
-El `code/simulator/` publicado como web publica. Se pueden disparar escenarios y ver el comportamiento del sistema.
+```bash
+cd code/pollen
+./gradlew assembleDemoDebug
+adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk
+```
 
-### Opcion C: notebook ejecutable
-Notebook publico que reproduce el flujo de Meristem (policy reasoning, shadow comparison) sin necesidad del hardware fisico.
+Mock LiteRT determinista — no necesita el modelo de 3 GB. Sirve para recorrer la UI, el flujo de voz y los caminos de refusal/retry.
 
-## Decision
+## Build device con Gemma 4 E4B real
 
-A confirmar en semana 3. La opcion C (notebook ejecutable) es la mas segura: no depende de infra nuestra, es reproducible, y es facil de compartir.
+```bash
+cd code/pollen
+./gradlew assembleDeviceRelease
+adb push gemma-4-E4B-it.litertlm /data/local/tmp/gemma-4-E4B-it.litertlm
+adb install app/build/outputs/apk/device/release/app-device-release.apk
+```
 
-## Archivos
+Requiere Android 12+ / API 31+, 12 GB RAM recomendado, 6 GB libres. Ver [`code/pollen/README.md`](../code/pollen/README.md) para los pasos completos de side-load del modelo y permisos.
 
-- URL final se pone en la seccion de enlaces del documento de presentacion
-- Si es un archivo descargable, va en los adjuntos del documento
+## Note on language
+
+The public install path lives in the root [README](../README.md) and [SUBMISSION.md](../SUBMISSION.md) in English. This file documents the working decision around APK packaging in Spanish, the team's working language. See the [Language note](../README.md#language-note) for the project-wide policy.

--- a/demo/pollen-demo.apk
+++ b/demo/pollen-demo.apk
@@ -1,1 +1,0 @@
-mock_apk_content_demoRelease

--- a/demo/pollen-venation-ui.apk
+++ b/demo/pollen-venation-ui.apk
@@ -1,1 +1,0 @@
-mock_apk_content_deviceRelease

--- a/hardware/firmware_esp32/README.md
+++ b/hardware/firmware_esp32/README.md
@@ -6,57 +6,53 @@
 
 ---
 
-Bootstrap del firmware real de la capa dura de seguridad para `Sprout`.
+Bootstrap of the real firmware for Sprout's hard safety layer.
 
-## Objetivo del milestone actual
+## Goal of the current milestone
 
-Este proyecto no intenta cerrar todo el firmware de una vez.
+This project does not try to close the full firmware in one go.
 
-El primer hito es:
+The first milestone is:
 
-- arrancar siempre en `SAFE_IDLE`
-- exponer consola serie por **USB Serial/JTAG / CDC-ACM**
-- emitir `HELLO` al arrancar
-- responder `STATUS`
-- emitir `HEARTBEAT` periódico
-- reportar `flash_bytes` y `psram_bytes`
+- always boot in `SAFE_IDLE`
+- expose a serial console over **USB Serial/JTAG / CDC-ACM**
+- emit `HELLO` on boot
+- answer `STATUS`
+- emit periodic `HEARTBEAT`
+- report `flash_bytes` and `psram_bytes`
 
-`WATER` todavia no activa actuadores reales: sigue siendo la ruta contractual
-con safety en `DRY_RUN`.
+`WATER` does not yet activate real actuators: it remains the contractual path with safety in `DRY_RUN`.
 
-Para bring-up fisico de banco, el firmware incluye comandos explicitos
-`TEST_ONLY` para una bomba de MVP y lectura real de humedad de suelo. Estos
-comandos no sustituyen al contrato `WATER`; solo permiten validar cobre,
-rele, bomba y sensor con control manual.
+For physical bench bring-up, the firmware includes explicit `TEST_ONLY` commands for an MVP pump and real soil moisture reading. These commands do not replace the `WATER` contract; they only allow validating copper, relay, pump and sensor under manual control.
 
-El siguiente hito inmediato añade:
+The next immediate milestone adds:
 
-- `HOST_HEARTBEAT` / `JETSON_HEARTBEAT` para refrescar la presencia de Rhizome
-- `TELEMETRY` para devolver un snapshot stub de sensores mientras no haya cableado
-- `host_link` y `host_age_ms` en `STATUS_REPORT` y `HEARTBEAT`
-- `SET_SENSOR_STUB ...` y `RESET_SENSOR_STUBS` para simular entradas antes del cableado real
-- `WATER A|B|BOTH <seconds>` en modo `DRY_RUN`, con rechazo por safety aunque todavia no se activen relés
+- `HOST_HEARTBEAT` / `JETSON_HEARTBEAT` to refresh Rhizome presence
+- `TELEMETRY` to return a stub snapshot of sensors until wiring is in place
+- `host_link` and `host_age_ms` in `STATUS_REPORT` and `HEARTBEAT`
+- `SET_SENSOR_STUB ...` and `RESET_SENSOR_STUBS` to simulate inputs before real wiring
+- `WATER A|B|BOTH <seconds>` in `DRY_RUN` mode, rejected by safety even when no relay is energised yet
 
-El primer sensor real integrado en esta fase es:
+The first real sensor integrated in this phase is:
 
-- `BME280` por `I2C`
-- comandos:
+- `BME280` over `I2C`
+- commands:
   - `I2C_SCAN`
   - `BME280_PROBE`
   - `BME280_READ`
-- baseline de pines en ambos board profiles:
+- pin baseline in both board profiles:
   - `SDA = GPIO8`
   - `SCL = GPIO9`
   - `I2C port = 0`
 
-Actuadores y sensores MVP de banco:
+MVP bench actuators and sensors:
 
-- bomba 12V con rele active-low:
-  - `GPIO16 = rele IN`
+- 12V pump with active-low relay:
+  - `GPIO16 = relay IN`
   - `PUMP_OFF`
   - `PUMP_STATUS`
   - `PUMP_PULSE <ms>`
-- humedad de suelo capacitiva:
+- capacitive soil moisture:
   - `GPIO4 = ADC soil A`
   - `SOIL_READ`
 
@@ -64,19 +60,19 @@ Actuadores y sensores MVP de banco:
 
 - target: `ESP32-S3`
 - framework: **ESP-IDF**
-- board profile inicial: `n16r8_usb_otg`
-- board profile futuro previsto: `devkitc_n8r8`
+- initial board profile: `n16r8_usb_otg`
+- planned future board profile: `devkitc_n8r8`
 
-## Estructura
+## Structure
 
-- `main/app_main.c` — estado `SAFE_IDLE`, loop de protocolo y heartbeat
-- `main/board_profile.[ch]` — separación entre lógica del firmware y perfil de placa
-- `main/Kconfig.projbuild` — opciones de board profile y timing del milestone
-- `sdkconfig.defaults` — baseline de consola USB y PSRAM
+- `main/app_main.c` — `SAFE_IDLE` state, protocol loop and heartbeat
+- `main/board_profile.[ch]` — separation between firmware logic and board profile
+- `main/Kconfig.projbuild` — board profile options and milestone timing
+- `sdkconfig.defaults` — USB console and PSRAM baseline
 
-## Protocolo del hito 0
+## Milestone-0 protocol
 
-Entrada por línea ASCII terminada en `\n`:
+Input: ASCII line terminated by `\n`:
 
 - `HELLO`
 - `STATUS`
@@ -84,10 +80,7 @@ Entrada por línea ASCII terminada en `\n`:
 - `JETSON_HEARTBEAT`
 - `TELEMETRY`
 - `I2C_SCAN`
-- `I2C_SCAN` escanea de momento solo las direcciones candidatas del `BME280`
-  (`0x76`, `0x77`) para evitar ruido de probe en un bus sin cableado. Cuando
-  entre `ADS1115`, este comando se ampliara a un scan general o se dividira por
-  familia de sensor.
+- `I2C_SCAN` currently scans only the `BME280` candidate addresses (`0x76`, `0x77`) to avoid probe noise on an unwired bus. When `ADS1115` enters, this command will be expanded to a general scan or split by sensor family.
 - `BME280_PROBE`
 - `BME280_READ`
 - `SOIL_READ`
@@ -107,7 +100,7 @@ Entrada por línea ASCII terminada en `\n`:
 - `STOP`
 - `RESET_ALERT`
 
-Salida:
+Output:
 
 - `HELLO fw=... state=SAFE_IDLE board=... uptime_ms=...`
 - `STATUS_REPORT state=SAFE_IDLE fw=... board=... uptime_ms=... flash_bytes=... psram_bytes=... telemetry_mode=HYBRID i2c_bus=... i2c_sda=... i2c_scl=... bme280_addr=... host_link=... host_age_ms=...`
@@ -125,20 +118,20 @@ Salida:
 - `ALERT code=... latched=true|false state=... uptime_ms=...`
 - `REJECT reason=UNKNOWN_COMMAND cmd=...`
 
-## Build y flash
+## Build and flash
 
-## Primer bring-up recomendado
+## Recommended first bring-up
 
-Antes de mezclar la placa con Jetson, el arranque inicial debe hacerse en un host Windows para aislar variables de USB, drivers y toolchain.
+Before mixing the board with the Jetson, initial boot should happen on a Windows host to isolate USB, driver and toolchain variables.
 
-Secuencia recomendada para la `ESP32-S3 N16R8 USB OTG`:
+Recommended sequence for the `ESP32-S3 N16R8 USB OTG`:
 
-1. conectar la placa al PC Windows con cable de datos
-2. entrar en modo descarga con `BOOT + RESET` si el puerto no aparece a la primera
-3. verificar que el host enumera un puerto `COM`
-4. flashear el firmware milestone-0
-5. comprobar que `STATUS_REPORT` expone `flash_bytes ~= 16777216` y `psram_bytes ~= 8388608`
-6. solo despues pasar al host Jetson y validar `/dev/ttyACM*`
+1. connect the board to the Windows PC with a data cable
+2. enter download mode with `BOOT + RESET` if the port does not appear on first try
+3. verify that the host enumerates a `COM` port
+4. flash the milestone-0 firmware
+5. check that `STATUS_REPORT` exposes `flash_bytes ~= 16777216` and `psram_bytes ~= 8388608`
+6. only then move to the Jetson host and validate `/dev/ttyACM*`
 
 ### Windows host
 
@@ -148,7 +141,7 @@ idf.py build
 idf.py -p COM7 flash monitor
 ```
 
-### Linux host / Jetson más adelante
+### Linux host / Jetson later
 
 ```bash
 idf.py set-target esp32s3
@@ -156,45 +149,44 @@ idf.py build
 idf.py -p /dev/ttyACM0 flash monitor
 ```
 
-## Notas de hardware
+## Hardware notes
 
-- `GPIO19 / GPIO20` reservados para USB nativo
-- `GPIO35 / GPIO36 / GPIO37` no se usan por PSRAM Octal
-- `GPIO45 / GPIO46` se evitan en el primer arranque
-- `GPIO8 / GPIO9` quedan reservados para `I2C` del `BME280` / futuros periféricos `ADS1115`
-- `GPIO4` queda reservado para el sensor capacitivo de humedad `SOIL_A`
-- `GPIO16` queda reservado para el rele active-low de la bomba MVP
-- `WATER` no energiza actuadores reales en este hito; solo `PUMP_PULSE` puede
-  hacerlo y siempre como `TEST_ONLY`
+- `GPIO19 / GPIO20` reserved for native USB
+- `GPIO35 / GPIO36 / GPIO37` not used due to Octal PSRAM
+- `GPIO45 / GPIO46` avoided on first boot
+- `GPIO8 / GPIO9` reserved for `BME280` `I2C` and future `ADS1115` peripherals
+- `GPIO4` reserved for the capacitive soil moisture sensor `SOIL_A`
+- `GPIO16` reserved for the active-low relay of the MVP pump
+- `WATER` does not energise real actuators in this milestone; only `PUMP_PULSE` can, and always as `TEST_ONLY`
 
-## Validación esperada
+## Expected validation
 
-Al arrancar en la `ESP32-S3 N16R8 USB OTG` deberíamos ver:
+On boot of the `ESP32-S3 N16R8 USB OTG` we should see:
 
 ```text
 HELLO fw=0.1.0 state=SAFE_IDLE board=n16r8_usb_otg uptime_ms=...
 HEARTBEAT state=SAFE_IDLE board=n16r8_usb_otg uptime_ms=...
 ```
 
-Y ante `STATUS`:
+And in response to `STATUS`:
 
 ```text
 STATUS_REPORT state=SAFE_IDLE fw=0.1.0 board=n16r8_usb_otg uptime_ms=... flash_bytes=16777216 psram_bytes=8388608 telemetry_mode=HYBRID i2c_bus=READY i2c_sda=8 i2c_scl=9 bme280_addr=NONE host_link=MISSING host_age_ms=-1 hb_timeout_ms=5000 tank_min_pct=20 max_water_s=30 last_reject=NONE alert_code=NONE
 ```
 
-Y tras enviar `HOST_HEARTBEAT`:
+And after sending `HOST_HEARTBEAT`:
 
 ```text
 ACK command=HOST_HEARTBEAT state=SAFE_IDLE host_link=FRESH host_age_ms=0
 ```
 
-Y ante `TELEMETRY`:
+And in response to `TELEMETRY`:
 
 ```text
 TELEMETRY_REPORT soil_a_raw=-1 soil_b_raw=-1 tank_level_raw=-1 tank_level_pct=-1 flow_pulses=0 bme280=DISCONNECTED bme280_valid=false bme280_temp_c_x100=-1 bme280_humidity_pct_x100=-1 bme280_pressure_pa=-1 host_link=FRESH host_age_ms=...
 ```
 
-Ejemplo de simulacion de sensores:
+Sensor simulation example:
 
 ```text
 SET_SENSOR_STUB SOIL_A 1234
@@ -206,7 +198,7 @@ SET_SENSOR_STUB BME280 CONNECTED
 TELEMETRY
 ```
 
-Ejemplo de `BME280` real por `I2C`:
+Real `BME280` over `I2C` example:
 
 ```text
 I2C_SCAN
@@ -222,8 +214,7 @@ TELEMETRY
 TELEMETRY_REPORT soil_a_raw=-1 soil_b_raw=-1 tank_level_raw=-1 tank_level_pct=-1 flow_pulses=0 bme280=CONNECTED bme280_valid=true bme280_temp_c_x100=2314 bme280_humidity_pct_x100=4587 bme280_pressure_pa=100812 host_link=... source=command
 ```
 
-Mientras no haya protoboard ni cables Dupont, el contrato esperado es el
-baseline desconectado:
+With no breadboard or Dupont cables, the expected contract is the disconnected baseline:
 
 ```text
 STATUS
@@ -239,10 +230,9 @@ BME280_READ
 BME280_REPORT status=NOT_FOUND address=NONE chip_id=NONE temp_c_x100=-1 humidity_pct_x100=-1 pressure_pa=-1 ...
 ```
 
-Este baseline no es un fallo: demuestra que el firmware no inventa sensor ni
-lecturas cuando el bus esta vivo pero no hay periferico conectado.
+This baseline is not a failure: it shows that the firmware does not invent a sensor or readings when the bus is live but no peripheral is wired.
 
-Ejemplo de bomba MVP y humedad real:
+MVP pump and real moisture example:
 
 ```text
 PUMP_STATUS
@@ -258,34 +248,33 @@ PUMP_OFF
 ACK command=PUMP_OFF state=SAFE_IDLE host_link=... host_age_ms=...
 ```
 
-Calibracion empirica provisional del sensor de humedad:
+Provisional empirical calibration of the moisture sensor:
 
 ```text
-aire:              soil_a_raw ~= 3530-3540
-tierra seca:       soil_a_raw ~= 2319-2325
-antes de riego:    soil_a_raw ~= 2278
-humedad buena:     soil_a_raw ~= 1687-1702
-tras difusion:     soil_a_raw ~= 1289-1291
+air:               soil_a_raw ~= 3530-3540
+dry soil:          soil_a_raw ~= 2319-2325
+before irrigation: soil_a_raw ~= 2278
+good moisture:     soil_a_raw ~= 1687-1702
+after diffusion:   soil_a_raw ~= 1289-1291
 ```
 
-Reglas provisionales de banco para esta sonda y maceta:
+Provisional bench rules for this probe and pot:
 
 - `SOIL_RAW_POLARITY=low_is_wet`
 - `SOIL_WET_BELOW_RAW=1300`
 - `SOIL_DRY_ABOVE_RAW=2200`
 
-Interpretacion:
+Interpretation:
 
-| Rango `soil_a_raw` | Decision |
+| `soil_a_raw` range | Decision |
 |---|---|
-| `< 1300` | muy humedo; no regar mas |
-| `1300-2199` | zona intermedia; observar/defer, no riego autonomo |
-| `>= 2200` | seco para MVP; candidato a riego si las demas barandillas pasan |
+| `< 1300` | very moist; do not water further |
+| `1300-2199` | intermediate band; observe / defer, no autonomous watering |
+| `>= 2200` | dry for the MVP; candidate for watering if all other guardrails pass |
 
-Estos valores son empiricos de demo. Recalibrar si cambia sustrato, maceta,
-profundidad del sensor o posicion de riego.
+These values are empirical demo numbers. Recalibrate if substrate, pot, sensor depth or irrigation position changes.
 
-Ejemplos de seguridad para `WATER`:
+`WATER` safety examples:
 
 ```text
 WATER A 12
@@ -308,25 +297,24 @@ WATER A 12
 ACK command=WATER plot=A seconds=12 execution=DRY_RUN state=SAFE_IDLE host_link=FRESH tank_level_pct=65
 ```
 
-Si el puerto USB no enumera a la primera en un S3 nuevo:
+If the USB port does not enumerate on first try with a new S3:
 
-1. mantener `BOOT`
-2. pulsar y soltar `RESET / EN`
-3. soltar `BOOT`
-4. volver a intentar `flash` o abrir monitor serie
+1. hold `BOOT`
+2. press and release `RESET / EN`
+3. release `BOOT`
+4. retry `flash` or open the serial monitor
 
-## Fuentes operativas validadas
+## Validated operational sources
 
-- Jetson AI Lab, `Gemma 4 on Jetson`, leída el `2026-04-25`: https://www.jetson-ai-lab.com/tutorials/gemma4-on-jetson/
-- Espressif, `ESP-IDF Get Started for ESP32-S3 (stable v6.0)`, leída el `2026-04-25`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/get-started/index.html
-- Espressif, `USB Serial/JTAG Controller Console`, leída el `2026-04-25`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-guides/usb-serial-jtag-console.html
-- Espressif, `SPI Flash and External SPI RAM Configuration`, leída el `2026-04-25`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-guides/flash_psram_config.html
-- Espressif, `I2C Master Driver`, leída el `2026-04-27`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/peripherals/i2c.html
-- Bosch Sensortec, `BME280_SensorAPI`, commit `c90d419492e26dd95586598a794e65eb2760753a`, leído el `2026-04-27`: https://github.com/boschsensortec/BME280_SensorAPI
-
+- Jetson AI Lab, *Gemma 4 on Jetson*, read on `2026-04-25`: https://www.jetson-ai-lab.com/tutorials/gemma4-on-jetson/
+- Espressif, *ESP-IDF Get Started for ESP32-S3 (stable v6.0)*, read on `2026-04-25`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/get-started/index.html
+- Espressif, *USB Serial/JTAG Controller Console*, read on `2026-04-25`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-guides/usb-serial-jtag-console.html
+- Espressif, *SPI Flash and External SPI RAM Configuration*, read on `2026-04-25`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-guides/flash_psram_config.html
+- Espressif, *I2C Master Driver*, read on `2026-04-27`: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/api-reference/peripherals/i2c.html
+- Bosch Sensortec, *BME280_SensorAPI*, commit `c90d419492e26dd95586598a794e65eb2760753a`, read on `2026-04-27`: https://github.com/boschsensortec/BME280_SensorAPI
 
 ---
 
 ## Note on language
 
-The English **Abstract** at the top of this file is the canonical public summary. The body below is in Spanish — it is the working language of the team and the place where decisions, trade-offs and trace get written. The contracts, code and tests are inspectable without Spanish context. See [Language note in the root README](../../README.md#language-note) for the project-wide policy.
+This README is English-first. Internal bitácoras (Spanish-language working journals) and the day-by-day development trace live under [`bitacora/`](../../bitacora/). See the [Language note in the root README](../../README.md#language-note) for the project-wide policy.

--- a/landing-demo/css/style.css
+++ b/landing-demo/css/style.css
@@ -87,6 +87,26 @@ code {
   color: rgba(26, 26, 24, 0.55);
 }
 
+/* .node lives on light card backgrounds: keep typography, fix contrast,
+   preserve brand-lime as a small leading dot. */
+.cards .node {
+  color: rgba(26, 26, 24, 0.72);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 6px;
+}
+
+.cards .node::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--seed);
+  flex-shrink: 0;
+}
+
 .hero h1 {
   font-size: clamp(36px, 5.5vw, 64px);
   line-height: 1.02;

--- a/landing-demo/index.html
+++ b/landing-demo/index.html
@@ -99,7 +99,7 @@
   </div>
   <figure class="diagram">
     <img src="media/architecture_overview.svg" alt="Sprout architecture overview: ESP32 + Rhizome (Field) + Pollen (Mobile) + Meristem (Home), with MissionPatch and DecisionReceipt flowing between them" loading="lazy">
-    <figcaption>Full architecture is explained in the <a href="https://github.com/zigiella/sprout/blob/main/writeup/draft.md">Kaggle writeup</a>.</figcaption>
+    <figcaption>Full architecture is explained in the <a href="https://github.com/zigiella/sprout/blob/main/writeup/draft.md">writeup</a>.</figcaption>
   </figure>
 </section>
 
@@ -110,10 +110,14 @@
   <div class="cards">
     <article>
       <p class="node">Pollen · demo flavor</p>
-      <h3>Install the app, no model needed</h3>
-      <p>~39 MB APK. Uses a deterministic mock evaluator. Runs on any Android emulator or device without downloading a 3 GB model. Walk through the UI, the voice path and refusal/retry flow.</p>
+      <h3>Walk through the app, no model needed</h3>
+      <p>Deterministic mock evaluator, no 3 GB model on disk. Build the demo flavor from <code>code/pollen/</code> and run it on any Android emulator or low-RAM device. Use it to inspect the UI, the voice path and the refusal/retry flow.</p>
+      <pre class="cmd"># Build and install the demo flavor
+cd code/pollen
+./gradlew assembleDemoDebug
+adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk</pre>
       <p>
-        <a class="btn primary" href="https://github.com/zigiella/sprout/raw/main/demo/pollen-demo.apk">Download demo APK</a>
+        <a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/code/pollen/README.md">Pollen build guide →</a>
       </p>
     </article>
     <article>
@@ -146,7 +150,7 @@ adb push gemma-4-E4B-it.litertlm \
   <div class="cta-row">
     <a class="btn primary" href="https://www.youtube.com/watch?v=D9ETS4EPnxI" rel="noopener" target="_blank">Watch the 3-minute video</a>
     <a class="btn" href="https://github.com/zigiella/sprout">Project on GitHub</a>
-    <a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/writeup/draft.md">Kaggle writeup</a>
+    <a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/writeup/draft.md">Writeup</a>
     <a class="btn ghost" href="https://github.com/zigiella/sprout/blob/main/SUBMISSION.md">Submission guide</a>
   </div>
 </section>

--- a/landing-demo/try/pollen.html
+++ b/landing-demo/try/pollen.html
@@ -79,14 +79,18 @@
     <div class="demo-panel">
       <h3>Demo flavor — runs anywhere</h3>
       <p>
-        Lightweight build (~30 MB) with mock LiteRT inference. No model bundled, no OOM.
+        Lightweight build with mock LiteRT inference. No model bundled, no OOM.
         Runs on any Android emulator or low-RAM phone. Use this to walk through the UI.
       </p>
+      <pre class="output-block"># Build and install the demo flavor
+cd code/pollen
+./gradlew assembleDemoDebug
+adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk</pre>
       <p>
-        <a class="btn btn-primary" href="https://github.com/zigiella/sprout/blob/main/demo/pollen-demo.apk" rel="noopener">
-          Download Pollen <code>demo</code> APK
+        <a class="btn btn-ghost" href="https://github.com/zigiella/sprout/blob/main/code/pollen/README.md" rel="noopener">
+          Pollen build guide &rarr;
         </a>
-        <span class="muted small" style="margin-left:8px;">(~39 MB, mock inference — runs without a model)</span>
+        <span class="muted small" style="margin-left:8px;">Mock inference &mdash; no model file needed.</span>
       </p>
     </div>
     <div class="demo-panel">

--- a/landing-demo/try/pollen.html
+++ b/landing-demo/try/pollen.html
@@ -129,8 +129,10 @@ adb push gemma-4-E4B-it.litertlm /data/local/tmp/
     <li><strong>Explicit model confidence</strong> — if LiteRT-LM exposes <code>logprobs</code>, the threshold is 0.7.</li>
   </ol>
   <p>
-    The full spec lives in <a href="https://github.com/zigiella/sprout/blob/main/bitacora/2026-05-05_spec-mini-evaluator-pollen-meristem-a-floema.md">spec-mini-evaluator-pollen</a>
-    (624 lines, 12 test cases, Meristem authored, day 20).
+    Full detail in the <a href="https://github.com/zigiella/sprout/blob/main/code/pollen/README.md#anti-nonsense-logic-mini-evaluator">Pollen README &mdash; Anti-nonsense logic</a>
+    section. The Kotlin implementation lives in <code>code/pollen/app/src/main/kotlin/.../inference/MiniEvaluator.kt</code>
+    and the four cases are covered by <code>MiniEvaluatorTest.kt</code>
+    (<code>REFUSE_RETRY</code>, <code>REFUSE_HARD</code>, <code>APPLY_AS_IS</code>, <code>APPLY_CONSERVATIVE</code>).
   </p>
 
 </section>

--- a/writeup/draft.md
+++ b/writeup/draft.md
@@ -73,7 +73,7 @@ The model configuration work is part of the engineering. We tested context size,
 
 Each node has a different model profile. Rhizome needs short, stable, bounded outputs. Pollen needs audio understanding, refusal, and schema fidelity. Meristem spends more time on policy review and rationale. Model configuration becomes a property of jurisdiction.
 
-## Safety and trust
+## Refusable by design
 
 Sprout signs decisions, expires authority, and records refusals.
 
@@ -102,6 +102,16 @@ Rhizome also includes `ShadowSkeptic`, a second local auditor. It disagrees safe
 Sprout’s unit of value is a decision with bounded authority. That unit scales from two pots to multiple plots because the contracts stay small: `DecisionReceipt`, `MissionPatch`, `WeatherDigest`, `ValidationStamp`, `FieldVisit`, and `PolicyPacket`.
 
 A cooperative can run Rhizomes in dispersed plots, carry Pollen on routine visits, and review policy at home. A community garden can preserve volunteer knowledge as expiring mission patches with clear scope and TTL.
+
+## How we built it
+
+Sprout was built in a 30-day window by one human and a team of role-specialized AI agents working under written constraints. Each agent has a defined jurisdiction, an explicit identity, and version-controlled authorship in the git history.
+
+The methodology mirrors the architecture. The repository is the contract. Bitácoras — Spanish-language development journals — record every architectural decision, course correction, and dependency between fronts. Day-start coordination messages follow a fixed template that names the interrelations between agents. Git commits carry agent identity inline so the trace stays reviewable.
+
+This pattern is not decoration. It produced artefacts a hackathon usually skips: a working dual-agent safety layer inside Rhizome, three independent Gemma 4 jurisdictions integrated through small JSON contracts, and a physical safety coprocessor that refuses unsafe commands by design rather than by patch. Process and product share the same invariant: jurisdiction with expiry.
+
+Methodology details and the bitácora index live in [`CONTRIBUTING.md`](../CONTRIBUTING.md) and the [`bitacora/`](../bitacora/) folder.
 
 ## Future work
 


### PR DESCRIPTION
## Summary

Continúa PR #185 (abstracts EN + Note on language) y atiende el feedback de Bea día 30: *"All node READMEs in EN (full)"*. Estado anterior: abstracts en EN + cuerpos en ES. Estado ahora: EN-first integral.

## Archivos traducidos

| Archivo | Antes | Ahora |
|---------|-------|-------|
| `code/README.md` | ES index | EN index |
| `code/rhizome/README.md` | EN abstract + ES body (415 líneas) | EN integral |
| `code/rhizome/jetson/README.md` | EN abstract + ES body (450 líneas) | EN integral |
| `code/pollen/README.md` | EN abstract + ES body (~140 líneas) | EN integral |
| `code/meristem_node/README.md` | EN abstract + ES body (~80 líneas) | EN integral |
| `hardware/firmware_esp32/README.md` | EN abstract + ES body (~330 líneas) | EN integral |

## Preservado en cada uno

- **Code blocks y JSON examples** — language-agnostic, no se traducen
- **Estructura de secciones** — mismos headings, mismo orden
- **Note on language** — al final apuntando a `bitacora/` (working journal en ES) + root README's language note
- **Cifras y nombres técnicos** — `safe-cpu`, `gpu-experimental`, `WATER_A`, `PUMP_PULSE`, `TEST_ONLY`, etc.

## Por qué este split

Las bitácoras siguen en ES porque son el working language del equipo y constituyen la traza de proceso. El cambio aquí solo afecta la cara pública readable por un evaluador EN-only. El root README's "Language note" sigue siendo la política canónica.

## Test plan

- [ ] Link check: ningún broken link interno tras traducción
- [ ] Render check: GitHub render OK en cada README
- [ ] Code blocks intactos (bash commands ejecutables tal cual)
- [ ] Note on language al final de cada uno preserva el enlace a `../README.md#language-note`

## Refs

Feedback Bea hilo día 30 - sección GitHub: *"All node READMEs in EN (full)"*.