### PR TITLE
feat(pollen): demo flavor UX signals (D icon + banner + DI mocks + build scripts)

### DIFF
--- a/code/pollen/app/build.gradle.kts
+++ b/code/pollen/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/code/pollen/app/src/demo/res/drawable/ic_launcher_foreground.xml
+++ b/code/pollen/app/src/demo/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    
+    <!-- Mismo circulo de Pollen base -->
+    <path
+        android:fillColor="#FFEB3B"
+        android:pathData="M54,54m-18,0a18,18 0,1 1,36 0a18,18 0,1 1,-36 0" />
+        
+    <!-- Marca "D" para el Demo Flavor -->
+    <path
+        android:fillColor="#212121"
+        android:pathData="M 45,40 h 10 c 8,0 12,5 12,14 c 0,9 -4,14 -12,14 h -10 z M 49,44 v 20 h 6 c 5,0 8,-3 8,-10 c 0,-7 -3,-10 -8,-10 z" />
+</vector>

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/MainActivity.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
+import androidx.compose.foundation.background
 import net.sprout.pollen.ui.chat.ChatScreen
 import net.sprout.pollen.ui.chat.ChatViewModel
 import net.sprout.pollen.llm.LiteRtEngineFactory
@@ -109,6 +110,22 @@ class MainActivity : ComponentActivity() {
                     }
 
                     Column(modifier = Modifier.fillMaxSize()) {
+                        if (net.sprout.pollen.BuildConfig.FLAVOR == "demo") {
+                            androidx.compose.foundation.layout.Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(MaterialTheme.colorScheme.error),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = "DEMO APP - NO LLM",
+                                    color = MaterialTheme.colorScheme.onError,
+                                    modifier = Modifier.padding(4.dp),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                                )
+                            }
+                        }
                         if (currentScreen != AppScreen.HOME && currentScreen != AppScreen.DOWNLOAD_MODEL) {
                             Row(modifier = Modifier.fillMaxWidth().padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
                                 IconButton(onClick = { currentScreen = AppScreen.HOME }) {

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/VisitarMeristemScreen.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/VisitarMeristemScreen.kt
@@ -40,7 +40,11 @@ fun VisitarMeristemScreen(
     onPolicyDownloaded: (PolicyPacket) -> Unit = {}
 ) {
     val client: MeristemClient = remember { 
-        MeristemNetworkClient("http://192.168.1.36:13000/")
+        if (net.sprout.pollen.BuildConfig.FLAVOR == "demo") {
+            MeristemMockClient()
+        } else {
+            MeristemNetworkClient("http://192.168.1.36:13000/")
+        }
     }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/VisitarRhizomeScreen.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/VisitarRhizomeScreen.kt
@@ -39,8 +39,12 @@ fun VisitarRhizomeScreen(
     onAuditClicked: () -> Unit = {}
 ) {
     val client: RhizomeClient = remember(plotId) { 
-        val port = if (plotId.contains("02")) "13020" else "13010"
-        RhizomeNetworkClient("http://192.168.1.60:$port/")
+        if (net.sprout.pollen.BuildConfig.FLAVOR == "demo") {
+            RhizomeMockClient()
+        } else {
+            val port = if (plotId.contains("02")) "13020" else "13010"
+            RhizomeNetworkClient("http://192.168.1.60:$port/")
+        }
     }
     val scope = rememberCoroutineScope()
     

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/VoiceBetaPanel.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/VoiceBetaPanel.kt
@@ -181,13 +181,18 @@ fun VoiceBetaPanel(client: RhizomeClient, snapshot: RhizomeSnapshot) {
         val speechPrompt = stringResource(R.string.speech_prompt)
         Button(
             onClick = {
-                val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-                    putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-                    putExtra(RecognizerIntent.EXTRA_LANGUAGE, "es-ES")
-                    putExtra(RecognizerIntent.EXTRA_PROMPT, speechPrompt)
+                if (net.sprout.pollen.BuildConfig.FLAVOR == "demo") {
+                    state = "Funcionalidad no disponible"
+                    resultText = "El motor LLM requiere la variante Device y hardware NPU para ejecutar Gemma localmente."
+                } else {
+                    val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                        putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                        putExtra(RecognizerIntent.EXTRA_LANGUAGE, "es-ES")
+                        putExtra(RecognizerIntent.EXTRA_PROMPT, speechPrompt)
+                    }
+                    isRecording = true
+                    speechLauncher.launch(intent)
                 }
-                isRecording = true
-                speechLauncher.launch(intent)
             },
             modifier = Modifier.fillMaxWidth().height(48.dp),
             shape = RoundedCornerShape(14.dp),

--- a/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/chat/ChatFeature.kt
+++ b/code/pollen/app/src/main/kotlin/net/sprout/pollen/ui/chat/ChatFeature.kt
@@ -95,6 +95,10 @@ class ChatViewModel(
     }
 
     fun startListening() {
+        if (net.sprout.pollen.BuildConfig.FLAVOR == "demo") {
+            _uiState.update { it.copy(error = "Funcionalidad no disponible: El motor LLM requiere la variante Device y hardware NPU.") }
+            return
+        }
         if (_uiState.value.isListening) {
             val audioFile = voiceInfra.stopRecording()
             _uiState.update { it.copy(isListening = false) }
@@ -112,6 +116,10 @@ class ChatViewModel(
     }
 
     fun send() {
+        if (net.sprout.pollen.BuildConfig.FLAVOR == "demo") {
+            _uiState.update { it.copy(error = "Funcionalidad no disponible: El motor LLM requiere la variante Device y hardware NPU.") }
+            return
+        }
         val prompt = _uiState.value.prompt.trim()
         if (prompt.isEmpty()) return
 

--- a/scripts/build_apks.ps1
+++ b/scripts/build_apks.ps1
@@ -1,0 +1,9 @@
+$env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
+$env:Path="$env:JAVA_HOME\bin;$env:Path"
+cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
+.\gradlew assembleDemoRelease
+Copy-Item "app\build\outputs\apk\demo\release\app-demo-release-unsigned.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+.\gradlew assembleDeviceRelease
+Copy-Item "app\build\outputs\apk\device\release\app-device-release-unsigned.apk" -Destination "..\..\demo\pollen-venation-ui.apk" -Force
+adb install -r "..\..\demo\pollen-demo.apk"
+adb install -r "..\..\demo\pollen-venation-ui.apk"

--- a/scripts/build_apks2.ps1
+++ b/scripts/build_apks2.ps1
@@ -1,0 +1,7 @@
+$env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
+$env:Path="$env:JAVA_HOME\bin;$env:Path"
+cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
+.\gradlew assembleDemoRelease
+Copy-Item "app\build\outputs\apk\demo\release\app-demo-release-unsigned.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+.\gradlew assembleDeviceRelease
+Copy-Item "app\build\outputs\apk\device\release\app-device-release-unsigned.apk" -Destination "..\..\demo\pollen-venation-ui.apk" -Force

--- a/scripts/build_debug_apks.ps1
+++ b/scripts/build_debug_apks.ps1
@@ -1,0 +1,9 @@
+$env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
+$env:Path="$env:JAVA_HOME\bin;$env:Path"
+cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
+.\gradlew assembleDemoDebug
+Copy-Item "app\build\outputs\apk\demo\debug\app-demo-debug.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+.\gradlew assembleDeviceDebug
+Copy-Item "app\build\outputs\apk\device\debug\app-device-debug.apk" -Destination "..\..\demo\pollen-venation-ui.apk" -Force
+adb install -r "..\..\demo\pollen-demo.apk"
+adb install -r "..\..\demo\pollen-venation-ui.apk"

--- a/scripts/build_demo_only.ps1
+++ b/scripts/build_demo_only.ps1
@@ -1,0 +1,6 @@
+$env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
+$env:Path="$env:JAVA_HOME\bin;$env:Path"
+cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
+.\gradlew assembleDemoDebug
+Copy-Item "app\build\outputs\apk\demo\debug\app-demo-debug.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+adb install -r "..\..\demo\pollen-demo.apk"


### PR DESCRIPTION
## Summary

Floema entrega el set de señales UX que hacen al `demo` flavor inconfundible al instalarlo, y la inyección DI mock-only que permite que la app funcione **offline-first**, sin Jetson ni ESP32 encendidos. Más build scripts PowerShell para automatizar compile + install vía ADB.

Rama abierta por Cambium tras handoff coordinado en [`bitacora/2026-05-15_handoff-rama-update-apks-stale_cambium-a-floema.md`](https://github.com/zigiella/sprout/blob/main/bitacora/2026-05-15_handoff-rama-update-apks-stale_cambium-a-floema.md) (visible tras merge de #186).

## Commits (5, todos `feat` / `fix` / `build`)

| SHA | Commit |
|---|---|
| `8c4fa69` | feat: add 'D' watermark to demo flavor launcher icon |
| `6276bdc` | fix: disable minify in release to avoid missing proguard rules |
| `1adbc20` | feat: use Mock clients in demo flavor for network calls |
| `3c0713b` | feat: add demo flavor banner and disable LLM features |
| `34024bd` | build: add powershell build scripts |

## Qué hace esto

- **`D` watermark en el launcher icon** del flavor demo → imposible confundir con device al ver el grid de apps en el móvil.
- **Banner permanente rojo "DEMO APP — NO LLM"** en lo alto de cada pantalla → los jueces ven en 1 segundo que es la variante sin modelo.
- **DI mock-only** para `RhizomeMockClient` y `MeristemMockClient` → la app funciona standalone, sin Jetson ni ESP32 en red. Crítico para evaluadores que prueben la APK sin acceso al hardware.
- **Botones de voz/chat bloqueados con mensaje claro** apuntando al flavor device + NPU como ruta para inferencia real.
- **`scripts/` (nueva carpeta)** con 4 scripts PowerShell para compile + install ADB (`build_debug_apks.ps1`, `build_apks.ps1`, `build_apks2.ps1`, `build_demo_only.ps1`).

## Por qué rama nueva (no la `chore/update-apks` original)

La rama original divergió de `main` hace ~18 PRs y tenía un commit que rastreaba accidentalmente APKs de 100 MB. El pre-receive hook de GitHub bloqueaba el push. **Cherry-pick a rama limpia desde `origin/main` actual** mantiene solo lo bueno (estos 5 commits) y descarta el lastre. La rama vieja se puede borrar tras merge de esta PR.

## Coordinación con PRs abiertas

| PR | Estado | Conflicto con esta |
|---|---|---|
| #186 (`chore/cambium/day30-feedback-cascada-bea`) | abierto | **Ninguno** — toca `landing-demo/`, `media/`, `writeup/`, `SUBMISSION.md`, `README*.md`, `CONTRIBUTING.es.md`, `bitacora/`. Sin overlap con `code/pollen/app/` ni con `scripts/`. |
| #187 (`chore/cambium/node-readmes-full-en`) | abierto | **Ninguno** — toca `code/pollen/README.md` y otros `*/README.md`. Sin overlap con `code/pollen/app/`. |

Orden de merge sugerido: cualquiera. No hay dependencias.

## Test plan

- [ ] Build `assembleDemoDebug` produce APK con icono D y banner rojo visible al arrancar.
- [ ] APK demo arranca sin Jetson/ESP32 en red (mocks inyectados).
- [ ] Pulsar voice/chat en demo muestra mensaje "requiere device + NPU".
- [ ] Build `assembleDeviceRelease` sigue compilando sin problemas (minify off no rompe nada en este variant).
- [ ] `scripts/build_debug_apks.ps1` compila e instala vía ADB end-to-end en un Pixel conectado.

## Asset attribution

Trabajo y firma técnica: Floema (`floema@sprout.local`). Coordinación handoff: Cambium. Documentado en CREDITS.md y en la bitácora referenciada arriba.

🌿