### PR TITLE
build(pollen): Gradle nativo escribe pollen-demo.apk y pollen-device.apk (Opción B)

### DIFF
--- a/code/pollen/app/build.gradle.kts
+++ b/code/pollen/app/build.gradle.kts
@@ -56,6 +56,14 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    applicationVariants.all {
+        val variant = this
+        outputs.all {
+            val outputImpl = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+            outputImpl.outputFileName = "pollen-${variant.flavorName}.apk"
+        }
+    }
 }
 
 dependencies {

--- a/scripts/build_apks.ps1
+++ b/scripts/build_apks.ps1
@@ -2,8 +2,8 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
 $env:Path="$env:JAVA_HOME\bin;$env:Path"
 cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
 .\gradlew assembleDemoRelease
-Copy-Item "app\build\outputs\apk\demo\release\app-demo-release-unsigned.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+Copy-Item "app\build\outputs\apk\demo\release\pollen-demo.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
 .\gradlew assembleDeviceRelease
-Copy-Item "app\build\outputs\apk\device\release\app-device-release-unsigned.apk" -Destination "..\..\demo\pollen-venation-ui.apk" -Force
+Copy-Item "app\build\outputs\apk\device\release\pollen-device.apk" -Destination "..\..\demo\pollen-device.apk" -Force
 adb install -r "..\..\demo\pollen-demo.apk"
-adb install -r "..\..\demo\pollen-venation-ui.apk"
+adb install -r "..\..\demo\pollen-device.apk"

--- a/scripts/build_apks2.ps1
+++ b/scripts/build_apks2.ps1
@@ -2,6 +2,6 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
 $env:Path="$env:JAVA_HOME\bin;$env:Path"
 cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
 .\gradlew assembleDemoRelease
-Copy-Item "app\build\outputs\apk\demo\release\app-demo-release-unsigned.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+Copy-Item "app\build\outputs\apk\demo\release\pollen-demo.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
 .\gradlew assembleDeviceRelease
-Copy-Item "app\build\outputs\apk\device\release\app-device-release-unsigned.apk" -Destination "..\..\demo\pollen-venation-ui.apk" -Force
+Copy-Item "app\build\outputs\apk\device\release\pollen-device.apk" -Destination "..\..\demo\pollen-device.apk" -Force

--- a/scripts/build_debug_apks.ps1
+++ b/scripts/build_debug_apks.ps1
@@ -2,8 +2,8 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
 $env:Path="$env:JAVA_HOME\bin;$env:Path"
 cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
 .\gradlew assembleDemoDebug
-Copy-Item "app\build\outputs\apk\demo\debug\app-demo-debug.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+Copy-Item "app\build\outputs\apk\demo\debug\pollen-demo.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
 .\gradlew assembleDeviceDebug
-Copy-Item "app\build\outputs\apk\device\debug\app-device-debug.apk" -Destination "..\..\demo\pollen-venation-ui.apk" -Force
+Copy-Item "app\build\outputs\apk\device\debug\pollen-device.apk" -Destination "..\..\demo\pollen-device.apk" -Force
 adb install -r "..\..\demo\pollen-demo.apk"
-adb install -r "..\..\demo\pollen-venation-ui.apk"
+adb install -r "..\..\demo\pollen-device.apk"

--- a/scripts/build_demo_only.ps1
+++ b/scripts/build_demo_only.ps1
@@ -2,5 +2,5 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-17.0.19.10-hotspot"
 $env:Path="$env:JAVA_HOME\bin;$env:Path"
 cd C:\DATA\PETS\TEST\T6A2-POLLEN\sprout\code\pollen
 .\gradlew assembleDemoDebug
-Copy-Item "app\build\outputs\apk\demo\debug\app-demo-debug.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
+Copy-Item "app\build\outputs\apk\demo\debug\pollen-demo.apk" -Destination "..\..\demo\pollen-demo.apk" -Force
 adb install -r "..\..\demo\pollen-demo.apk"


### PR DESCRIPTION
## Summary

Trabajo de Floema (Opción B aceptada día 31): bloque \`applicationVariants.all\` en \`build.gradle.kts\` para que Gradle nativamente nombre los outputs como \`pollen-demo.apk\` y \`pollen-device.apk\`. Scripts PowerShell actualizados para apuntar a los nuevos paths nativos.

## Origen del commit

Trabajo original de Floema en commit \`1e76cc9\` sobre rama \`feat/floema/pollen-demo-signals\` (ya mergeada como PR #188 y borrada del remoto). Su clone local de esa rama seguía vivo, así que pusheó allí — pero la rama estaba colgada de \`main\` pre-PR-#188, mostrando ~600 líneas de "deleciones" de mi trabajo posterior (CREDITS.md, 2 bitácoras, traducciones EN, License section, etc.).

**Cherry-pick quirúrgico a rama limpia:** este PR aplica únicamente las 5 líneas de trabajo nuevo de Floema sobre \`main\` actual, omitiendo el rename del placeholder APK que ya no existe en main (eliminado en PR #186 día 30).

## Cambios

- \`code/pollen/app/build.gradle.kts\`: +8 líneas (\`applicationVariants.all\` block).
- 4 scripts PowerShell en \`scripts/\`: paths internos actualizados de \`app-{flavor}-{type}.apk\` → \`pollen-{flavor}.apk\`.

## Una sola fuente de verdad

| Capa | Antes | Ahora |
|---|---|---|
| Gradle nativo | \`app-demo-debug.apk\` / \`app-device-release.apk\` | \`pollen-demo.apk\` / \`pollen-device.apk\` ✓ |
| Script PowerShell output | \`pollen-demo.apk\` / \`pollen-venation-ui.apk\` ⚠️ | \`pollen-demo.apk\` / \`pollen-device.apk\` ✓ |
| GitHub Release v1.0 | \`pollen-demo.apk\` / \`pollen-device.apk\` ✓ | sin cambios ✓ |
| Docs en repo | \`app-demo-debug.apk\` (5 sitios) ⚠️ | follow-up en PR A (Cambium) |

## Follow-up

Cuando esta PR mergee, Cambium hace un commit en su PR A actualizando las 5 referencias en docs (README, README.es, SUBMISSION, demo/README, landing-demo/try/pollen.html) para que digan \`pollen-demo.apk\` / \`pollen-device.apk\` consistentemente.

## Test plan

- [ ] \`./gradlew assembleDemoDebug\` produce \`pollen-demo.apk\` (no \`app-demo-debug.apk\`)
- [ ] \`./gradlew assembleDeviceDebug\` produce \`pollen-device.apk\`
- [ ] \`./gradlew assembleDemoRelease\` produce \`pollen-demo.apk\` (unsigned)
- [ ] \`./gradlew assembleDeviceRelease\` produce \`pollen-device.apk\` (unsigned)
- [ ] \`scripts/build_debug_apks.ps1\` ejecuta end-to-end sin errores (Bea o Floema en Windows)

## Refs

- Coordination handoff día 30: \`bitacora/2026-05-15_handoff-rama-update-apks-stale_cambium-a-floema.md\`
- Conversación día 31 sobre Opción B