### PR TITLE
docs+submission: PR A día 31 — tracks + license + APK naming + safety_rules EN

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -169,7 +169,7 @@ cd code/pollen
 ./gradlew testDemoDebugUnitTest
 ```
 
-El flavor demo usa inferencia mock determinista, así que funciona sin un archivo de modelo de 3 GB. Instala en cualquier Android 12+ (físico o emulador) con `adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk`.
+El flavor demo usa inferencia mock determinista, así que funciona sin un archivo de modelo de 3 GB. Instala en cualquier Android 12+ (físico o emulador) con `adb install app/build/outputs/apk/demo/debug/pollen-demo.apk`.
 
 ### Pollen flavor device con Gemma 4 E4B
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ cd code/pollen
 ./gradlew testDemoDebugUnitTest
 ```
 
-The demo flavor uses deterministic mock inference, so it runs without a 3 GB model file. Install on any Android 12+ device or emulator with `adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk`.
+The demo flavor uses deterministic mock inference, so it runs without a 3 GB model file. Install on any Android 12+ device or emulator with `adb install app/build/outputs/apk/demo/debug/pollen-demo.apk`.
 
 ### Pollen device flavor with Gemma 4 E4B
 

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -54,7 +54,7 @@ We want to be very explicit about this distinction. A hackathon project that ove
 - The **browser landing demo** at `landing-demo/` runs **deterministic mocks** (code in `landing-demo/js/api.js`, read it) so a judge can inspect the contracts without downloading models or using cloud APIs. The mocks are intentionally deterministic, not "fake" — they let you scrutinize the shape of every JSON object the real system produces.
 - **All ten JSON contracts** of the MVP (`RhizomeSnapshot`, `DecisionReceipt`, `AlertEvent`, `MissionPatch`, `ValidationStamp`, `WeatherDigest`, `VisitAmendment`, `FieldVisit`, `PolicyPacket`, `SyncBundle`) are documented in `docs/20_data_contracts.md` and exercised by tests in `code/shared/`.
 
-### Apuntado para extensión natural
+### Natural extensions noted
 
 - **`SAFETY_DOWNGRADE` rule** (capping a valid command to a safer envelope instead of rejecting it): defined in the contract; the firmware currently rejects with `EVENT_DURATION_OUT_OF_RANGE` when out of bounds. Modulation (e.g. *"AI asked 30s → final 12s"*) is the natural next step once the flow sensor closes the operational loop.
 - **GPU offload** on Jetson: 36/36 layers loaded successfully, but quality is not contractual under one test case (`RD04` derives semantically). The contractual path of the demo is `safe-cpu`.
@@ -89,7 +89,7 @@ Build the demo flavor and install it on any Android 12+ device or emulator:
 ```bash
 cd code/pollen
 ./gradlew assembleDemoDebug
-adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk
+adb install app/build/outputs/apk/demo/debug/pollen-demo.apk
 ```
 
 Mock LiteRT inference — walks through the UI without needing a 3 GB model on disk.
@@ -132,9 +132,9 @@ If you only have **5 minutes**:
 If you have **30 minutes**:
 
 4. Read [`docs/01_architecture.md`](docs/01_architecture.md) for the three-node design.
-5. Read [`docs/30_safety_rules.md`](docs/30_safety_rules.md) for the ESP32 hard limits.
+5. Read [`docs/30_safety_rules.en.md`](docs/30_safety_rules.en.md) for the ESP32 hard limits.
 6. Run `make test` in `code/meristem_node/` to see the deterministic evaluator + LLM smoke pass.
-7. Build and install the Pollen demo flavor: `cd code/pollen && ./gradlew assembleDemoDebug && adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk`.
+7. Build and install the Pollen demo flavor: `cd code/pollen && ./gradlew assembleDemoDebug && adb install app/build/outputs/apk/demo/debug/pollen-demo.apk`.
 
 If you have **2 hours and want to scrutinize**:
 
@@ -158,18 +158,51 @@ Three Gemma 4 instances, three jurisdictions, **no cloud roundtrip at any layer*
 
 ## Tracks
 
-We submit primarily to **Main Track** for vision + execution. The architecture is also a natural fit for:
+The Submission is entered in the three main Track categories:
 
-- **Global Resilience** — drought + dispersed agriculture + intermittent connectivity, with a working pattern that brings the decision to where the water lives.
-- **Safety & Trust** — auditable decisions, signed receipts, expiring contracts, physical veto. Every refusal is a product feature, not a failure.
+- **Main Track**
+- **Impact Track**
+- **Special Technology Track**
+
+Within those, the architecture maps to the following sub-tracks:
+
+### Main Track — overall vision + execution + impact
+
+> *Sprout is a safety-bounded decision network for irrigation under absence.*
+
+Sprout is not a single model, app or device. It is a reusable pattern for agriculture in low-connectivity terrain: three Gemma 4 jurisdictions with explicit boundaries, a physical safety floor, and signed receipts that survive the absence of the network.
+
+### Impact Track / Global Resilience
+
+> *Sprout targets the gap between field, human and network.*
+
+Sprout responds directly to drought, dispersed agriculture, intermittent connectivity, decisions that cannot wait for the cloud, and water management under human absence. The Rules describe this category as systems that anticipate, mitigate and respond to large challenges — from offline / edge response to long-term climate mitigation. Sprout brings local decision to places where the network arrives late or not at all.
+
+### Impact Track / Safety & Trust
+
+> *Every intelligence has jurisdiction. Every authority expires. The physical layer can say no.*
+
+Sprout implements a technical constitution that maps directly to this category: bounded authority, TTL / expiry on every instruction, signed `DecisionReceipt` objects, `MissionPatch` and `PolicyPacket` with explicit validity windows, `ShadowSkeptic` as a second local auditor with `affects_decision=false`, and an ESP32 safety coprocessor that owns the physical veto. The Rules describe Safety & Trust as frameworks of transparency, reliability, grounding and explainability. Sprout does not just claim those properties — it ships them as code.
+
+### Special Technology Track / LiteRT Prize
+
+> *Pollen makes the phone a field intelligence node, not a dashboard.*
+
+Pollen runs Gemma 4 E4B on Android via Google AI Edge LiteRT-LM, with native multimodal audio. It transforms a human visit into structured intelligence: voice input → validated `MissionPatch` → refusal / retry / hard refusal under the Mini Evaluator's four checks. The Rules describe the LiteRT Prize as the most compelling and effective use case built using LiteRT with Gemma 4. Pollen is exactly that — Gemma 4 local on the pocket, doing essential work inside the system, not decoration.
+
+### Special Technology Track / llama.cpp Prize
+
+> *Gemma 4 runs across field and home nodes without requiring cloud availability.*
+
+Rhizome runs Gemma 4 E2B on Jetson Orin Nano Super via `llama.cpp`. Meristem runs Gemma 4 E4B on a home laptop via `llama.cpp` with tool calling. The same runtime serves two distinct resource-constrained deployments. The Rules describe the llama.cpp Prize as the best innovative implementation of Gemma 4 on resource-constrained hardware — Sprout deploys it at both ends of the operational chain.
 
 ---
 
-## License and winner grant
+## License and attribution
 
 The Sprout repository is licensed under **Apache 2.0** (see [`LICENSE`](LICENSE)) — an OSI-approved permissive license. All third-party dependencies used to generate this Submission are OSI-approved open source (`llama.cpp`, LiteRT-LM, FastAPI, Pydantic, SQLite, ESP-IDF, Bosch `BME280_SensorAPI`).
 
-If the Submission is selected as a Prize winner, the team agrees to grant the Competition Sponsor the **CC-BY 4.0** license on the winning Submission and source code, in accordance with §1.6 and §2.5 of the Competition Rules. The repository will continue to be available to the public under Apache 2.0; the CC-BY 4.0 grant is in addition, not in replacement.
+Per §1.6 and §2.5 of the Competition Rules, the team accepts the obligation to grant the Competition Sponsor a **CC-BY 4.0** license on the Submission and source code under the conditions stated in those Rules. The repository remains publicly available under Apache 2.0; the CC-BY 4.0 grant is in addition, not in replacement.
 
 Sprout uses Gemma 4 models by Google. **Gemma is a trademark of Google LLC.** This project is not affiliated with or endorsed by Google. The Gemma 4 model naming and attribution guidelines (Google) are followed throughout the public surfaces (README, writeup, landing demo, video, node READMEs).
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -11,7 +11,7 @@ Esta carpeta esta reservada para builds finales del APK Android de Pollen. Duran
 ```bash
 cd code/pollen
 ./gradlew assembleDemoDebug
-adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk
+adb install app/build/outputs/apk/demo/debug/pollen-demo.apk
 ```
 
 Mock LiteRT determinista — no necesita el modelo de 3 GB. Sirve para recorrer la UI, el flujo de voz y los caminos de refusal/retry.
@@ -22,7 +22,7 @@ Mock LiteRT determinista — no necesita el modelo de 3 GB. Sirve para recorrer 
 cd code/pollen
 ./gradlew assembleDeviceRelease
 adb push gemma-4-E4B-it.litertlm /data/local/tmp/gemma-4-E4B-it.litertlm
-adb install app/build/outputs/apk/device/release/app-device-release.apk
+adb install app/build/outputs/apk/device/release/pollen-device.apk
 ```
 
 Requiere Android 12+ / API 31+, 12 GB RAM recomendado, 6 GB libres. Ver [`code/pollen/README.md`](../code/pollen/README.md) para los pasos completos de side-load del modelo y permisos.

--- a/docs/30_safety_rules.en.md
+++ b/docs/30_safety_rules.en.md
@@ -1,0 +1,90 @@
+# Safety rules — v2
+
+## 1. Governing principle
+
+The AI can propose.
+Only the physical layer can authorize execution.
+
+## 2. Non-negotiable rules
+
+### 2.1 Low tank
+
+If `tank_level_pct` falls below the minimum:
+
+- no irrigation cycle is started,
+- the rejection is logged,
+- the system transitions to a prudent mode or alert state depending on context.
+
+### 2.2 Missing heartbeat
+
+If the ESP32 does not receive a recent heartbeat from the Jetson:
+
+- it accepts no new irrigation commands,
+- it holds actuators closed.
+
+### 2.3 Maximum event duration
+
+Every irrigation command carries a hard upper bound in seconds.
+
+### 2.4 No flow detected
+
+If the pump or valve activates and no expected flow appears:
+
+- cut,
+- alert,
+- block any immediate retry.
+
+### 2.5 Safe startup
+
+After a reboot of either the ESP32 or the Jetson:
+
+- pump off,
+- valves closed,
+- no automatic resumption of irrigation.
+
+### 2.6 Explicit refusal
+
+Every invalid command must produce a legible reason. The five canonical codes are:
+
+- `TANK_LOW`
+- `JETSON_HEARTBEAT_LOST`
+- `EVENT_DURATION_OUT_OF_RANGE`
+- `NO_FLOW_DETECTED`
+- `ALERT_LATCHED`
+
+## 3. Rhizome's prudence rules
+
+Even when the ESP32 authorizes a command on physical grounds, Rhizome must degrade to a conservative mode if:
+
+- the active policy has expired,
+- critical sensor data is stale,
+- the most recent visit disputed the local state,
+- the remaining water budget is uncertain,
+- a weather digest changed the context and no confirmation has arrived yet.
+
+## 4. Authority priority
+
+When sources conflict, authority flows in this order (highest first):
+
+1. physical stop / alert latched
+2. ESP32 hard limits
+3. Rhizome's active policy
+4. Pollen `VisitAmendment`
+5. `MissionPatch`
+6. non-binding suggestions
+
+## 5. Video demonstration rule
+
+The submission video must show at least one case where:
+
+- the AI proposes,
+- the physical layer blocks,
+- and the block is explained clearly.
+
+That moment increases trust and credibility.
+
+---
+
+## Note on language
+
+This is the canonical English version. The Spanish original is preserved at [`30_safety_rules.md`](30_safety_rules.md) as evidence of the working language of the team. The five canonical refusal codes are identifiers in code and are not translated.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Documentacion del producto y la arquitectura. Orden de lectura sugerido por nume
 | 13 | [13_esp32_spec.md](13_esp32_spec.md) | Spec del coprocesador ESP32 |
 | 20 | 20_data_contracts.md | Schemas JSON: weather_packet, policy_delta, contradiction_alert (pendiente) |
 | 23 | [23_rhizome_prompt_mapping_v0.md](23_rhizome_prompt_mapping_v0.md) | Mapeo de prompts Rhizome v0/v0.5 |
-| 30 | 30_safety_rules.md | Reglas fisicas duras del ESP32 (pendiente) |
+| 30 | [30_safety_rules.en.md](30_safety_rules.en.md) · [ES](30_safety_rules.md) | ESP32 hard safety rules (EN canonical, ES preserved) |
 | 40 | 40_naming_guidelines.md | Cumplimiento naming Gemma (pendiente) |
 | 51 | [51_rhizome_gemma4_e2b_jetson_guide.md](51_rhizome_gemma4_e2b_jetson_guide.md) | Guia Gemma 4 E2B + llama.cpp en Jetson |
 | 52 | [52_endodermis_jetson_bringup_brief.md](52_endodermis_jetson_bringup_brief.md) | Briefing operativo para Endodermis |

--- a/landing-demo/try/pollen.html
+++ b/landing-demo/try/pollen.html
@@ -85,7 +85,7 @@
       <pre class="output-block"># Build and install the demo flavor
 cd code/pollen
 ./gradlew assembleDemoDebug
-adb install app/build/outputs/apk/demo/debug/app-demo-debug.apk</pre>
+adb install app/build/outputs/apk/demo/debug/pollen-demo.apk</pre>
       <p>
         <a class="btn btn-ghost" href="https://github.com/zigiella/sprout/blob/main/code/pollen/README.md" rel="noopener">
           Pollen build guide &rarr;

--- a/writeup/draft.es.md
+++ b/writeup/draft.es.md
@@ -1,6 +1,6 @@
 # Sprout: criterios locales para el agua cuando no hay nadie
 
-**Subtítulo:** IA abierta y local para decisiones sobre el agua bajo ausencia, con autoridad acotada, recibos firmados y un veto físico.
+**Subtítulo:** IA abierta y local para decisiones sobre el agua bajo ausencia, con autoridad acotada y caduca, recibos firmados y un veto físico.
 
 ## El problema
 
@@ -137,7 +137,7 @@ El idioma forma parte del roadmap. Sprout mantiene los contratos internos establ
 
 Sprout preserva el criterio de campo durante la ausencia. Convierte visitas en inteligencia operativa. Rechaza instrucciones caducadas. Registra lo que pasó. Le da a la IA local una segunda voz escéptica antes de darle a esa voz cualquier autoridad.
 
-**Sprout es IA abierta y local para decisiones sobre el agua bajo ausencia: autoridad acotada, recibos firmados, una segunda voz local que audita sin autoridad y una capa física que puede decir no.**
+**Sprout es IA abierta y local para decisiones sobre el agua bajo ausencia: autoridad acotada y caduca, recibos firmados, una segunda voz local que audita sin autoridad y una capa física que puede decir no.**
 
 ---
 

--- a/writeup/draft.md
+++ b/writeup/draft.md
@@ -1,6 +1,6 @@
 # Sprout: local criteria for water when nobody is there
 
-**Subtitle:** Open, local AI for water decisions under absence, with bounded authority, signed receipts and a physical veto.
+**Subtitle:** Open, local AI for water decisions under absence, with bounded, expiring authority, signed receipts and a physical veto.
 
 ## The problem
 
@@ -137,7 +137,7 @@ Language is part of the roadmap. Sprout keeps internal contracts stable, while P
 
 Sprout preserves field criteria during absence. It turns visits into operational intelligence. It rejects expired instructions. It records what happened. It gives local AI a second skeptical voice before giving that voice any authority.
 
-**Sprout is open, local AI for water decisions under absence: bounded authority, signed receipts, a second local voice that audits without authority, and a physical layer that can say no.**
+**Sprout is open, local AI for water decisions under absence: bounded, expiring authority, signed receipts, a second local voice that audits without authority, and a physical layer that can say no.**
 
 ---
 


### PR DESCRIPTION
## Summary

Cierre de cabos sueltos detectados por Bea revisando el writeup en Kaggle. Seis bloques en un commit:

1. **Writeup subtitle + conclusion** EN+ES: \`bounded authority\` → \`bounded, expiring authority\` (combina ambos adjetivos como Bea editó en Kaggle).
2. **SUBMISSION heading ES suelto:** \`Apuntado para extensión natural\` → \`Natural extensions noted\`.
3. **License section neutral:** rename \`License and winner grant\` → \`License and attribution\`. Drop \`If selected as a Prize winner\`. Nueva redacción: *"Per §1.6 and §2.5 of the Competition Rules, the team accepts the obligation to grant..."* — preserva la información legal sin presuponer victoria.
4. **Tracks section reescrita** con la estrategia real de Bea (3 main categories + 5 sub-tracks + frase de defensa por cada uno). Safety & Trust se posiciona como *technical constitution*, no como claim genérico.
5. **APK naming sweep** (7 sitios alineados con Gradle nativo de PR #192 de Floema): todas las refs ahora dicen \`pollen-demo.apk\` / \`pollen-device.apk\` consistente con scripts + Release attachments.
6. **\`docs/30_safety_rules.en.md\`** — traducción canónica EN. SUBMISSION + docs/README links actualizados. ES preservado como evidence-of-process.

## Pendiente

PR B siguiente: \`docs/01_architecture.md\` reescritura EN desde cero (scope mayor, sesión más larga, con review del equipo).

## Test plan

- [ ] Render landing tras merge: botones APK funcionan, copy actualizado en Pollen card
- [ ] writeup/draft.md subtitle muestra 'bounded, expiring authority' en main
- [ ] SUBMISSION.md Tracks section render bien con quotes + parrafos
- [ ] SUBMISSION.md link a \`docs/30_safety_rules.en.md\` resuelve
- [ ] \`docs/30_safety_rules.en.md\` renderiza en GitHub UI